### PR TITLE
Typo in pre-commit hook apps/:name/available path

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -96,7 +96,7 @@ func RunServer(flags map[string]interface{}) {
 	// These handlers don't use :app on purpose. Using :app means that only
 	// the token generate for the given app is valid, but these handlers
 	// use a token generated for Gandalf.
-	m.Get("/apps/:appname/avaliable", authorizationRequiredHandler(appIsAvailable))
+	m.Get("/apps/:appname/available", authorizationRequiredHandler(appIsAvailable))
 	m.Get("/apps/:appname/repository/clone", authorizationRequiredHandler(cloneRepository))
 
 	if registrationEnabled, _ := config.GetBool("auth:user-registration"); registrationEnabled {

--- a/misc/git-hooks/pre-receive.py
+++ b/misc/git-hooks/pre-receive.py
@@ -12,7 +12,7 @@ timeout = 1800
 
 try:
     headers = {"Authorization": token}
-    url = "{0}/apps/{1}/avaliable".format(tsuru_host, app_name)
+    url = "{0}/apps/{1}/available".format(tsuru_host, app_name)
     request = urllib2.Request(url, headers=headers)
     f = urllib2.urlopen(request, timeout=timeout)
 except urllib2.HTTPError as e:


### PR DESCRIPTION
Is this intended or by mistake, since it's misspelled in both places. 
