### PR TITLE
docker-setup: silence wget output and fix tar extracted filename

### DIFF
--- a/misc/docker-setup.bash
+++ b/misc/docker-setup.bash
@@ -17,8 +17,8 @@ function install_docker() {
     sudo apt-get install lxc wget bsdtar curl -y --force-yes
     # are you on AWS? if so, uncomment the line below
     # sudo apt-get install linux-image-extra-`uname -r`
-    wget http://get.docker.io/builds/Linux/x86_64/docker-latest.tgz
-    tar -xf docker-master.tgz
+    wget -q http://get.docker.io/builds/Linux/x86_64/docker-latest.tgz
+    tar -xf docker-latest.tgz
     cd docker-master
     sudo cp docker /usr/local/bin
     # runs docker daemon, it must be running in order to tsuru work


### PR DESCRIPTION
The wget command spits out junk during bootstrap, silence it.

The tar command has an incorrect filename for the downloaded docker install.
