### PR TITLE
docker-setup: git hooks require config in environment

### DIFF
--- a/misc/docker-setup.bash
+++ b/misc/docker-setup.bash
@@ -90,7 +90,6 @@ function main() {
     source hipache-setup.bash
     install_docker
     configure_tsuru
-    remove_git_hooks
     configure_git_hooks
     use_https_in_git
     #start_tsuru


### PR DESCRIPTION
This solves the problem of gandalf not starting a deploy on a push -- it doesn't have a host name or auth token to talk to tsuru.
