### PR TITLE
docker-setup: tsr should run as 'ubuntu', not as whomever is running the...

### DIFF
--- a/misc/docker-setup.bash
+++ b/misc/docker-setup.bash
@@ -35,9 +35,9 @@ function install_docker() {
 
 function start_tsuru() {
     echo "starting tsuru-collector"
-    tsr collector &
+    sudo -u ubuntu tsr collector &
     echo "starting tsuru-api"
-    tsr api &
+    sudo -u ubuntu tsr api &
 }
 
 function configure_git_hooks() {


### PR DESCRIPTION
... bootstrap script.

Deploys still fail, but that's another bug (or two, or three, ...)
