### PR TITLE
docker-setup: don't change CWD to avoid confusing later setup pieces.

### DIFF
--- a/misc/docker-setup.bash
+++ b/misc/docker-setup.bash
@@ -27,8 +27,7 @@ function install_docker() {
     sudo apt-get install linux-image-extra-`uname -r` -y --force-yes
     wget -q http://get.docker.io/builds/Linux/x86_64/docker-master.tgz
     tar -xf docker-master.tgz
-    cd docker-master
-    sudo cp docker /usr/local/bin
+    sudo cp docker-master/docker /usr/local/bin
     # runs docker daemon, it must be running in order to tsuru work
     sudo -E docker -d &
 }


### PR DESCRIPTION
This way the other steps don't need to worry about preserving/changing their own CWD.  For example, the platforms-setup.js script gets downloaded into docker-master/ .
