### PR TITLE
Fix 665 ssh debug log

### DIFF
--- a/provision/docker/docker.go
+++ b/provision/docker/docker.go
@@ -351,7 +351,7 @@ func (c *container) ssh(stdout, stderr io.Writer, cmd string, args ...string) er
 	if err != nil {
 		return err
 	}
-    log.Debugf("Running SSH on %s:%d: %s %s", c.HostAddr, sshAgentPort(), cmd, args)
+	log.Debugf("Running SSH on %s:%d: %s %s", c.HostAddr, sshAgentPort(), cmd, args)
 	resp, err := http.Post(url, "application/json", &buf)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix #665 - provision/docker/ssh: add debug logs

Is not logging responses, but better than nothing:

```
2014/03/24 16:48:39 DEBUG: Running SSH on docker01.mycloud.tld:4545: [ -f /home/application/apprc ] && source /home/application/apprc; [ -d /home/application/current ] && cd /home/application/current; ps aux []
```
