### PR TITLE
Fix #724 - Returns app's public url in create-app command

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -160,6 +160,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t *auth.Token) error {
 	msg := map[string]string{
 		"status":         "success",
 		"repository_url": repository.ReadWriteURL(a.Name),
+		"ip":             a.Ip,
 	}
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -141,6 +141,12 @@ func CreateApp(app *App, user *auth.User) error {
 	if err != nil {
 		return &AppCreationError{app: app.Name, Err: err}
 	}
+	app.Ip, err = Provisioner.Addr(app)
+	if err != nil {
+		errMsg := "Failed to obtain app %s address: %s"
+		log.Errorf(errMsg, app.GetName(), err)
+		return fmt.Errorf(errMsg, app.GetName(), err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fix #724 - Returns app's public url in create-app command
