### PR TITLE
Fix #770 - Return memory and swap (real) size in JSON

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -75,6 +75,11 @@ func (app *App) MarshalJSON() ([]byte, error) {
 	result["ready"] = app.State == "ready"
 	result["owner"] = app.Owner
 	result["deploys"] = app.Deploys
+	result["memory"] = app.Memory
+	result["swap"] = 0
+	if app.Swap > 0 {
+		result["swap"] = app.Swap - app.Memory
+	}
 	return json.Marshal(&result)
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1640,6 +1640,8 @@ func (s *S) TestAppMarshalJSON(c *gocheck.C) {
 		CName:    "name.mycompany.com",
 		Owner:    "appOwner",
 		Deploys:  7,
+		Memory:   64,
+		Swap:     128,
 	}
 	expected := make(map[string]interface{})
 	expected["name"] = "name"
@@ -1651,6 +1653,9 @@ func (s *S) TestAppMarshalJSON(c *gocheck.C) {
 	expected["cname"] = "name.mycompany.com"
 	expected["owner"] = "appOwner"
 	expected["deploys"] = float64(7)
+	expected["memory"] = float64(64)
+	// Expected swap is the "real" swap size. App object has the sum of memory + swap but in json we return it as real size (swap - memory)
+	expected["swap"] = float64(64)
 	expected["ready"] = false
 	data, err := app.MarshalJSON()
 	c.Assert(err, gocheck.IsNil)
@@ -1670,6 +1675,8 @@ func (s *S) TestAppMarshalJSONReady(c *gocheck.C) {
 		State:    "ready",
 		Owner:    "appOwner",
 		Deploys:  7,
+		Memory:   64,
+		Swap:     128,
 	}
 	expected := make(map[string]interface{})
 	expected["name"] = "name"
@@ -1681,6 +1688,9 @@ func (s *S) TestAppMarshalJSONReady(c *gocheck.C) {
 	expected["cname"] = "name.mycompany.com"
 	expected["owner"] = "appOwner"
 	expected["deploys"] = float64(7)
+	expected["memory"] = float64(64)
+	// Expected swap is the "real" swap size. App object has the sum of memory + swap but in json we return it as real size (swap - memory)
+	expected["swap"] = float64(64)
 	expected["ready"] = true
 	data, err := app.MarshalJSON()
 	c.Assert(err, gocheck.IsNil)
@@ -1879,6 +1889,16 @@ func (s *S) TestGetPlatform(c *gocheck.C) {
 func (s *S) TestGetDeploys(c *gocheck.C) {
 	a := App{Deploys: 3}
 	c.Assert(a.GetDeploys(), gocheck.Equals, a.Deploys)
+}
+
+func (s *S) TestGetMemory(c *gocheck.C) {
+	a := App{Memory: 64}
+	c.Assert(a.GetMemory(), gocheck.Equals, a.Memory)
+}
+
+func (s *S) TestGetSwap(c *gocheck.C) {
+	a := App{Swap: 64}
+	c.Assert(a.GetSwap(), gocheck.Equals, a.Swap)
 }
 
 func (s *S) TestListAppDeploys(c *gocheck.C) {


### PR DESCRIPTION
Fix #770 - Return memory and swap (real) size in JSON

`App` object is made with the sum between requested swap and requested memory (due to docker that needs swap including memory). The returned json has the real swap size (swap - memory) so tests take care of this and check for the real swap size and not the size wrote on App object.

Probably this could be done better in a next release
