### PR TITLE
tsuru env-set: Fix parse of environment variables containing values with = sign

### DIFF
--- a/cmd/tsuru-base/env.go
+++ b/cmd/tsuru-base/env.go
@@ -82,7 +82,7 @@ func (c *EnvSet) Run(context *cmd.Context, client *cmd.Client) error {
 		return err
 	}
 	raw := strings.Join(context.Args, " ")
-	regex := regexp.MustCompile(`(\w+=[^=]+)(\s|$)`)
+	regex := regexp.MustCompile(`(\w+=[^\s]+[^=]+)(\s|$)`)
 	decls := regex.FindAllStringSubmatch(raw, -1)
 	if len(decls) < 1 {
 		return errors.New(envSetValidationMessage)
@@ -90,7 +90,7 @@ func (c *EnvSet) Run(context *cmd.Context, client *cmd.Client) error {
 	variables := make(map[string]string, len(decls))
 	for _, v := range decls {
 		parts := strings.Split(v[1], "=")
-		variables[parts[0]] = parts[1]
+		variables[parts[0]] = strings.Join(parts[1:], "=")
 	}
 	var buf bytes.Buffer
 	json.NewEncoder(&buf).Encode(variables)

--- a/cmd/tsuru-base/env_test.go
+++ b/cmd/tsuru-base/env_test.go
@@ -190,8 +190,10 @@ func (s *S) TestEnvSetValues(c *gocheck.C) {
 	context := cmd.Context{
 		Args: []string{
 			"DATABASE_HOST=some", "host",
-			"DATABASE_USER=root", "DATABASE_PASSWORD=.1234..abc",
+			"DATABASE_USER=root",
+			"DATABASE_PASSWORD=.1234..abc",
 			"http_proxy=http://myproxy.com:3128/",
+			"VALUE_WITH_EQUAL_SIGN=http://wholikesquerystrings.me/?tsuru=awesome",
 		},
 		Stdout: &stdout,
 		Stderr: &stderr,
@@ -200,10 +202,11 @@ func (s *S) TestEnvSetValues(c *gocheck.C) {
 		Transport: testing.Transport{Message: result, Status: http.StatusOK},
 		CondFunc: func(req *http.Request) bool {
 			want := map[string]string{
-				"DATABASE_HOST":     "some host",
-				"DATABASE_USER":     "root",
-				"DATABASE_PASSWORD": ".1234..abc",
-				"http_proxy":        "http://myproxy.com:3128/",
+				"DATABASE_HOST":         "some host",
+				"DATABASE_USER":         "root",
+				"DATABASE_PASSWORD":     ".1234..abc",
+				"http_proxy":            "http://myproxy.com:3128/",
+				"VALUE_WITH_EQUAL_SIGN": "http://wholikesquerystrings.me/?tsuru=awesome",
 			}
 			defer req.Body.Close()
 			var got map[string]string


### PR DESCRIPTION
This should fix #738.
