### PR TITLE
Improve `team-user-list` usage instruction

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -366,7 +366,7 @@ func (teamUserList) Run(context *Context, client *Client) error {
 func (teamUserList) Info() *Info {
 	return &Info{
 		Name:    "team-user-list",
-		Usage:   "team-user-list",
+		Usage:   "team-user-list <teamname>",
 		Desc:    "List members of a team.",
 		MinArgs: 1,
 	}

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -318,7 +318,7 @@ func (s *S) TestTeamUserListError(c *gocheck.C) {
 func (s *S) TestTeamUserListInfo(c *gocheck.C) {
 	expected := &Info{
 		Name:    "team-user-list",
-		Usage:   "team-user-list",
+		Usage:   "team-user-list <teamname>",
 		Desc:    "List members of a team.",
 		MinArgs: 1,
 	}


### PR DESCRIPTION
Tell the user she needs to supply the name of the team to list its users
