### PR TITLE
Add note to install docs about setting auth.user-registration

### DIFF
--- a/docs/installing/api.rst
+++ b/docs/installing/api.rst
@@ -92,6 +92,19 @@ configuration is described below, please note that you should replace the values
         redis-server: <your-redis-server-with-port>
 
 
+In particular, take note that you must set ``auth.user-registration`` to ``true``:
+
+.. highlight:: yaml
+
+::
+
+    auth:
+        user-registration: true
+        scheme: native
+
+
+Otherwise, tsuru will fail to create an admin user in the next section.
+
 Now you only need to start your tsuru API server:
 
 


### PR DESCRIPTION
Because I missed this and then tsuru was failing to create an admin user
and I puzzled over this for a while before I figured it out.
