### PR TITLE
docs/installing/api.rst: Include example for docker.servers

### DIFF
--- a/docs/installing/api.rst
+++ b/docs/installing/api.rst
@@ -87,6 +87,8 @@ configuration is described below, please note that you should replace the values
         ssh:
             add-key-cmd: /var/lib/tsuru/add-key
             user: ubuntu
+        servers:
+            - http://<your-docker-server>:2375
     hipache:
         domain: <your-hipache-server-ip>.xip.io
         redis-server: <your-redis-server-with-port>


### PR DESCRIPTION
This shows folks how to configure at least one Docker server so that `tsr` doesn't fail with:

```
Error: You should configure the docker servers.
```

Cc: @cezarsa 
