### PR TITLE
For failed connect to server, suggest target-add

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -43,7 +43,10 @@ func (c *Client) detectClientError(err error) error {
 		return fmt.Errorf("Failed to connect to tsuru server (%s): %s", target, urlErr.Err)
 	}
 	target, _ := ReadTarget()
-	return fmt.Errorf("Failed to connect to tsuru server (%s), it's probably down.", target)
+	return fmt.Errorf(
+		"Failed to connect to tsuru server (%s), it's probably down.\n"+
+			"Did you forget to run `tsuru target-add <label> <target> --set-current` ?",
+		target)
 }
 
 func (c *Client) Do(request *http.Request) (*http.Response, error) {


### PR DESCRIPTION
When user gets `"Failed to connect to tsuru server (%s), it's probably down."`, suggest that maybe they forgot to run `tsuru target-add ...`, because a common case of getting this error is that the user just installed the tsuru client and they have not pointed it at the right server yet.

Output looks like this:

```
$ tsuru app-list
Error: Failed to connect to tsuru server (http://127.0.0.1:62018), it's probably down.
Did you forget to run `tsuru target-add <label> <target> --set-current` ?
```
