### PR TITLE
Make /install/client.html redirect to /using/install-client.html

### DIFF
--- a/docs/install/client.rst
+++ b/docs/install/client.rst
@@ -1,0 +1,15 @@
+.. Copyright 2014 tsuru authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the LICENSE file.
+
+:orphan:
+
+.. raw:: html
+
+  <meta http-equiv="refresh" content="0; url=../using/install-client.html" />
+
+++++++++++++++++++++++++++++++++
+Deprecated `install/client` page
+++++++++++++++++++++++++++++++++
+
+:doc:`New page that documents installing clients </using/install-client>`


### PR DESCRIPTION
Because old clients (e.g.: 0.10.1 which is what gets installed if one does `sudo apt-get install tsuru` [sic]; see https://github.com/tsuru/tsuru/issues/923) reference the former page, which is now a [broken link on ReadTheDocs](http://docs.tsuru.io/en/latest/install/client.html).

Fixes: GH-921

```
make doc
```

and now `file:///Users/marca/go/src/github.com/tsuru/tsuru/docs/_build/html/install/client.html` redirects to `file:///Users/marca/go/src/github.com/tsuru/tsuru/docs/_build/html/using/install-client.html`
