### PR TITLE
Give reason why tsuru couldn't guess name of app

### DIFF
--- a/cmd/guess.go
+++ b/cmd/guess.go
@@ -71,9 +71,11 @@ func (cmd *GuessingCommand) Guess() (string, error) {
 	}
 	name, err := cmd.guesser().GuessName(path)
 	if err != nil {
-		return "", errors.New(`tsuru wasn't able to guess the name of the app.
+		return "", fmt.Errorf(`tsuru wasn't able to guess the name of the app.
 
-Use the --app flag to specify it.`)
+Use the --app flag to specify it.
+
+%s`, err)
 	}
 	return name, nil
 }

--- a/cmd/guess_test.go
+++ b/cmd/guess_test.go
@@ -158,14 +158,16 @@ func (s *S) TestGuessingCommandWithoutFlagDefined(c *gocheck.C) {
 }
 
 func (s *S) TestGuessingCommandFailToGuess(c *gocheck.C) {
-	fake := &testing.FailingFakeGuesser{}
+	fake := &testing.FailingFakeGuesser{ErrorMessage: "Something's always wrong"}
 	g := GuessingCommand{G: fake}
 	name, err := g.Guess()
 	c.Assert(name, gocheck.Equals, "")
 	c.Assert(err, gocheck.NotNil)
 	c.Assert(err.Error(), gocheck.Equals, `tsuru wasn't able to guess the name of the app.
 
-Use the --app flag to specify it.`)
+Use the --app flag to specify it.
+
+Something's always wrong`)
 	pwd, err := os.Getwd()
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(fake.HasGuess(pwd), gocheck.Equals, true)


### PR DESCRIPTION
```
$ tsuru app-info
Error: tsuru wasn't able to guess the name of the app.

Use the --app flag to specify it.

tsuru remote not declared.
```
