### PR TITLE
Print fatal errors to stdout

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -35,6 +35,7 @@ type TsuruHandler struct {
 }
 
 func fatal(err error) {
+	fmt.Println(err.Error())
 	log.Fatal(err.Error())
 }
 


### PR DESCRIPTION
When starting `tsr` from the console, which is something folks probably want to do when developing, it is nice to see errors right away on the console.
##### Before

```
[marca@marca-mac2 tsr]$ ~/go/bin/tsr api
Using the database "tsuru" from the server "127.0.0.1:27017".

Warning: configuration didn't declare a provisioner, using default provisioner.
Using "docker" provisioner.
```
##### After

```
[marca@marca-mac2 tsr]$ ~/go/bin/tsr api
Using the database "tsuru" from the server "127.0.0.1:27017".

Warning: configuration didn't declare a provisioner, using default provisioner.
Using "docker" provisioner.

Cluster Storage: docker:cluster:{mongo-url,mongo-database} must be set.
```

Fixes: #1019
