### PR TITLE
Add `install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,6 @@ release:
 
 install:
 	go install $(GO_EXTRAFLAGS) ./... ../tsuru-client/...
+
+serve:
+	$(HOME)/go/bin/tsr api


### PR DESCRIPTION
to make it easier to update `tsr` and `tsuru-client` (`tsuru`) when developing

Maybe I'm just not proficient enough with golang, but I still struggle to figure out how to build a new `~/go/bin/tsuru` for testing my changes while developing.
