### PR TITLE
Make --help and --version work

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -131,6 +131,15 @@ func (m *Manager) Run(args []string) {
 	if len(args) == 0 {
 		args = append(args, "help")
 	}
+	for i, j := range args {
+		if j == "--help" {
+			args = append(args[0:i], args[i+1:]...)
+			args = append([]string{"help"}, args...)
+		}
+	}
+	if args[0] == "--version" {
+		args[0] = "version"
+	}
 	flagset := gnuflag.NewFlagSet("tsuru flags", gnuflag.ExitOnError)
 	verbosity := flagset.Int("verbosity", 0, "Verbosity: 1 => print HTTP requests; 2 => print HTTP requests/responses")
 	flagset.IntVar(verbosity, "v", 0, "Verbosity: 1 => print HTTP requests; 2 => print HTTP requests/responses")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -392,6 +392,21 @@ Use glb help <commandname> to get more information about a command.
 	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, expected)
 }
 
+func (s *S) TestDashDashHelp(c *gocheck.C) {
+	expected := `glb version 1.0.
+
+Usage: glb command [args]
+
+Available commands:
+  help
+  version
+
+Use glb help <commandname> to get more information about a command.
+`
+	manager.Run([]string{"--help"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, expected)
+}
+
 func (s *S) TestHelpShouldReturnHelpForACmd(c *gocheck.C) {
 	expected := `glb version 1.0.
 
@@ -402,6 +417,19 @@ Foo do anything or nothing.
 `
 	manager.Register(&TestCommand{})
 	manager.Run([]string{"help", "foo"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, expected)
+}
+
+func (s *S) TestDashDashHelpShouldReturnHelpForACmd(c *gocheck.C) {
+	expected := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"--help", "foo"})
 	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, expected)
 }
 
@@ -454,6 +482,12 @@ func (s *S) TestVersion(c *gocheck.C) {
 	err := command.Run(&context, nil)
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, "tsuru version 5.0.\n")
+}
+
+func (s *S) TestDashDashVersion(c *gocheck.C) {
+	expected := "glb version 1.0.\n"
+	manager.Run([]string{"--version"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), gocheck.Equals, expected)
 }
 
 func (s *S) TestVersionInfo(c *gocheck.C) {


### PR DESCRIPTION
because a lot of other Linux commands support these (E.g.: `git`), so why not?

This is much friendlier than the current behavior:

```
$ tsuru --help
Error: command "--help" does not exist

$ tsuru --version
Error: command "--version" does not exist
```