### PR TITLE
Set WWW-Authenticate response header

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -34,6 +34,7 @@ type authorizationRequiredHandler func(http.ResponseWriter, *http.Request, auth.
 func (fn authorizationRequiredHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t := context.GetAuthToken(r)
 	if t == nil {
+		w.Header().Set("WWW-Authenticate", "Bearer realm=\"tsuru\" scope=\"tsuru\"")
 		context.AddRequestError(r, tokenRequiredErr)
 	} else {
 		context.AddRequestError(r, fn(w, r, t))

--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -178,6 +178,7 @@ func (s *HandlerSuite) TestAuthorizationRequiredHandlerShouldReturnUnauthorizedI
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusUnauthorized)
+	c.Assert(recorder.Header().Get("WWW-Authenticate"), gocheck.Equals, "Bearer realm=\"tsuru\" scope=\"tsuru\"")
 	c.Assert(recorder.Body.String(), gocheck.Equals, "You must provide a valid Authorization header\n")
 }
 
@@ -191,6 +192,7 @@ func (s *HandlerSuite) TestAuthorizationRequiredHandlerShouldReturnUnauthorizedI
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusUnauthorized)
+	c.Assert(recorder.Header().Get("WWW-Authenticate"), gocheck.Equals, "Bearer realm=\"tsuru\" scope=\"tsuru\"")
 	c.Assert(recorder.Body.String(), gocheck.Equals, "You must provide a valid Authorization header\n")
 }
 
@@ -281,6 +283,7 @@ func (s *HandlerSuite) TestAdminRequiredHandlerShouldReturnUnauthorizedIfTheAuth
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusUnauthorized)
+	c.Assert(recorder.Header().Get("WWW-Authenticate"), gocheck.Equals, "Bearer realm=\"tsuru\" scope=\"tsuru\"")
 	c.Assert(recorder.Body.String(), gocheck.Equals, "You must provide a valid Authorization header\n")
 }
 
@@ -294,6 +297,7 @@ func (s *HandlerSuite) TestAdminRequiredHandlerShouldReturnUnauthorizedIfTheToke
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusUnauthorized)
+	c.Assert(recorder.Header().Get("WWW-Authenticate"), gocheck.Equals, "Bearer realm=\"tsuru\" scope=\"tsuru\"")
 	c.Assert(recorder.Body.String(), gocheck.Equals, "You must provide a valid Authorization header\n")
 }
 


### PR DESCRIPTION
when no authorization token is provided by client

as specified in OAuth 2.0 spec at
http://self-issued.info/docs/draft-ietf-oauth-v2-bearer.html#authn-header
