### PR TITLE
Set Content-Type: application/json

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -87,6 +87,7 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
+	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(apps)
 }
 
@@ -225,6 +226,7 @@ func addUnits(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
+	w.Header().Set("Content-Type", "application/json")
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(w)}
 	err = app.AddUnits(n, writer)
 	if err != nil {
@@ -498,6 +500,7 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	for k, v := range variables {
 		envs = append(envs, bind.EnvVar{Name: k, Value: v, Public: true})
 	}
+	w.Header().Set("Content-Type", "application/json")
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(w)}
 	err = app.SetEnvs(envs, true, writer)
 	if err != nil {
@@ -531,6 +534,7 @@ func unsetEnv(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
+	w.Header().Set("Content-Type", "application/json")
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(w)}
 	err = app.UnsetEnvs(variables, true, writer)
 	if err != nil {
@@ -805,6 +809,7 @@ func platformList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
+	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(platforms)
 }
 

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -103,6 +103,7 @@ func (s *S) TestAppList(c *gocheck.C) {
 	err = appList(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	body, err := ioutil.ReadAll(recorder.Body)
 	c.Assert(err, gocheck.IsNil)
 	apps := []app.App{}
@@ -146,6 +147,7 @@ func (s *S) TestAppListShouldListAllAppsOfAllTeamsThatTheUserIsAMember(c *gochec
 	err = appList(recorder, request, token)
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	body, err := ioutil.ReadAll(recorder.Body)
 	c.Assert(err, gocheck.IsNil)
 	var apps []app.App
@@ -558,6 +560,7 @@ func (s *S) TestAddUnits(c *gocheck.C) {
 	recorder := httptest.NewRecorder()
 	err = addUnits(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName(a.Name)
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(app.Units(), gocheck.HasLen, 3)
@@ -1587,6 +1590,7 @@ func (s *S) TestSetEnvHandlerShouldSetAPublicEnvironmentVariableInTheApp(c *goch
 	c.Assert(err, gocheck.IsNil)
 	err = setEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("black-dog")
 	c.Assert(err, gocheck.IsNil)
 	expected := bind.EnvVar{Name: "DATABASE_HOST", Value: "localhost", Public: true}
@@ -1624,6 +1628,7 @@ func (s *S) TestSetEnvHandlerShouldSetMultipleEnvironmentVariablesInTheApp(c *go
 	c.Assert(err, gocheck.IsNil)
 	err = setEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("vigil")
 	c.Assert(err, gocheck.IsNil)
 	expectedHost := bind.EnvVar{Name: "DATABASE_HOST", Value: "localhost", Public: true}
@@ -1668,6 +1673,7 @@ func (s *S) TestSetEnvHandlerShouldNotChangeValueOfPrivateVariables(c *gocheck.C
 	c.Assert(err, gocheck.IsNil)
 	err = setEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("losers")
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(app.Env, gocheck.DeepEquals, original)
@@ -1755,6 +1761,7 @@ func (s *S) TestUnsetEnvHandlerRemovesTheEnvironmentVariablesFromTheApp(c *goche
 	c.Assert(err, gocheck.IsNil)
 	err = unsetEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("swift")
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(app.Env, gocheck.DeepEquals, expected)
@@ -1791,6 +1798,7 @@ func (s *S) TestUnsetEnvHandlerRemovesAllGivenEnvironmentVariables(c *gocheck.C)
 	c.Assert(err, gocheck.IsNil)
 	err = unsetEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("let-it-be")
 	c.Assert(err, gocheck.IsNil)
 	expected := map[string]bind.EnvVar{
@@ -1832,6 +1840,7 @@ func (s *S) TestUnsetHandlerDoesNotRemovePrivateVariables(c *gocheck.C) {
 	c.Assert(err, gocheck.IsNil)
 	err = unsetEnv(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	app, err := app.GetByName("letitbe")
 	c.Assert(err, gocheck.IsNil)
 	expected := map[string]bind.EnvVar{
@@ -2575,6 +2584,7 @@ func (s *S) TestBindHandlerEndpointIsDown(c *gocheck.C) {
 	recorder := httptest.NewRecorder()
 	err = bindServiceInstance(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	c.Assert(recorder.Body.String(), gocheck.Equals, `{"Message":"","Error":"my-mysql api is down."}`+"\n")
 }
 
@@ -2614,6 +2624,7 @@ func (s *S) TestBindHandler(c *gocheck.C) {
 	s.provisioner.PrepareOutput([]byte("exported"))
 	err = bindServiceInstance(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	err = s.conn.ServiceInstances().Find(bson.M{"name": instance.Name}).One(&instance)
 	c.Assert(err, gocheck.IsNil)
 	c.Assert(instance.Apps, gocheck.DeepEquals, []string{a.Name})
@@ -3050,6 +3061,7 @@ func (s *S) TestPlatformList(c *gocheck.C) {
 	recorder := httptest.NewRecorder()
 	err := platformList(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	var got []app.Platform
 	err = json.NewDecoder(recorder.Body).Decode(&got)
 	c.Assert(err, gocheck.IsNil)
@@ -3327,6 +3339,7 @@ func (s *S) TestRegisterUnit(c *gocheck.C) {
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	expected := []map[string]interface{}{{
 		"name":   "MY_VAR_1",
 		"value":  "value1",

--- a/api/auth.go
+++ b/api/auth.go
@@ -225,6 +225,7 @@ func teamList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		for _, team := range teams {
 			result = append(result, map[string]string{"name": team.Name})
 		}
+		w.Header().Set("Content-Type", "application/json")
 		b, err := json.Marshal(result)
 		if err != nil {
 			return err

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -696,6 +696,7 @@ func (s *AuthSuite) TestListTeamsListsAllTeamsThatTheUserIsMember(c *gocheck.C) 
 	recorder := httptest.NewRecorder()
 	err = teamList(recorder, request, s.token)
 	c.Assert(err, gocheck.IsNil)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	b, err := ioutil.ReadAll(recorder.Body)
 	c.Assert(err, gocheck.IsNil)
 	var m []map[string]string

--- a/api/plan.go
+++ b/api/plan.go
@@ -46,6 +46,7 @@ func listPlans(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
+	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(plans)
 }
 

--- a/api/plan_test.go
+++ b/api/plan_test.go
@@ -116,6 +116,7 @@ func (s *S) TestPlanList(c *gocheck.C) {
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, gocheck.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), gocheck.Equals, "application/json")
 	var plans []app.Plan
 	err = json.Unmarshal(recorder.Body.Bytes(), &plans)
 	c.Assert(err, gocheck.IsNil)


### PR DESCRIPTION
for a bunch of endpoints that output JSON.

This makes output nicer when accessing via a tool, such as HTTPie