### PR TITLE
Log to stderr

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -39,7 +39,11 @@ func Init() {
 	} else {
 		logger = NewFileLogger(logFileName, debug)
 	}
-	SetLogger(logger)
+	stderrLogger := NewFileLogger("/dev/stderr", debug)
+	if logger != nil && stderrLogger != nil {
+		logger2 := NewMultiLogger(&logger, &stderrLogger)
+		SetLogger(logger2)
+	}
 }
 
 // Target is the current target for the log package.

--- a/log/multi_logger.go
+++ b/log/multi_logger.go
@@ -1,0 +1,56 @@
+// Copyright 2014 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package log
+
+import (
+	"log"
+)
+
+func NewMultiLogger(loggers ...*Logger) Logger {
+	return &multiLogger{loggers: loggers}
+}
+
+type multiLogger struct {
+	loggers []*Logger
+}
+
+func (m *multiLogger) Debug(format string) {
+	for _, logger := range m.loggers {
+		(*logger).Debug(format)
+	}
+}
+
+func (m *multiLogger) Error(format string) {
+	for _, logger := range m.loggers {
+		(*logger).Debug(format)
+	}
+}
+
+func (m *multiLogger) Fatal(format string) {
+	for _, logger := range m.loggers {
+		(*logger).Debug(format)
+	}
+}
+
+func (m *multiLogger) Debugf(format string, v ...interface{}) {
+	for _, logger := range m.loggers {
+		(*logger).Debugf(format, v...)
+	}
+}
+
+func (m *multiLogger) Errorf(format string, v ...interface{}) {
+	for _, logger := range m.loggers {
+		(*logger).Errorf(format, v...)
+	}
+}
+
+func (m *multiLogger) Fatalf(format string, v ...interface{}) {
+	for _, logger := range m.loggers {
+		(*logger).Fatalf(format, v...)
+	}
+}
+
+func (m *multiLogger) GetStdLogger() *log.Logger {
+	return (*m.loggers[0]).GetStdLogger()
+}


### PR DESCRIPTION
in addition to syslog or file

Some folks don't use syslog. They may want to run `tsr` using a process manager like supervisord that manages log files for output to stdout/stderr.

Also it is much easier to look at the console when running `tsr api` in the terminal when developing or debugging.

E.g.:

    $ ~/go/bin/tsr api
    ...
    2014-12-27T07:13:12.851705809-08:00 GET /auth/scheme 200 in 0.519067ms
    2014/12/27 07:13:16 DEBUG: Ignored invalid token for /users: Invalid token
    2014/12/27 07:13:16 DEBUG: Failed to create user in the git server: Failed to connect to Gandalf server, it's probably down.