### PR TITLE
Nicer error when fail to create user in gandalf

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -81,6 +81,8 @@ func createUser(w http.ResponseWriter, r *http.Request) error {
 		if rollbackErr != nil {
 			log.Errorf("error trying to rollback user creation: %s", rollbackErr.Error())
 		}
+		gURL := repository.ServerURL()
+		log.Errorf("error trying to create user %q in gandalf (%s): %s", u.Email, gURL, err.Error())
 		return err
 	}
 	rec.Log(u.Email, "create-user")


### PR DESCRIPTION
Shows user email and the gandalf server address

```
2014/12/27 07:30:28 ERROR: error trying to create user "user@example.com" in gandalf (http://127.0.0.1:8000): Failed to create user in the git server: Failed to connect to Gandalf server, it's probably down.
```
