### PR TITLE
`tsr api` fail with error if config file not found

### DIFF
--- a/cmd/tsr/api.go
+++ b/cmd/tsr/api.go
@@ -5,6 +5,10 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"os"
+
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/api"
 	"github.com/tsuru/tsuru/cmd"
@@ -18,7 +22,17 @@ type apiCmd struct {
 }
 
 func (c *apiCmd) Run(context *cmd.Context, client *cmd.Client) error {
-	err := config.Check([]config.Checker{CheckProvisioner, CheckBeanstalkd, CheckBasicConfig})
+	log.Printf("Opening config file: %s\n", configPath)
+	err := config.ReadConfigFile(configPath)
+	if err != nil {
+		msg := `Could not open tsuru config file at %s (%s).
+  For an example, see: tsuru/etc/tsuru.conf
+  Note that you can specify a different config file with the --config option -- e.g.: --config=./etc/tsuru.conf`
+		log.Fatalf(msg, configPath, err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(context.Stdout, "Done reading config file: %s\n", configPath)
+	err = config.Check([]config.Checker{CheckProvisioner, CheckBeanstalkd, CheckBasicConfig})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make `tsr api` fail immediately with an error if the config file is not found. The error message will tell the user where tsuru looked for the config file that was not found.

Before:

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr api
    Error: Config Error: you should have "listen" key set in your config file

After:

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr api
    Reading config file: /etc/tsuru/tsuru.conf
    Failed to read config file: /etc/tsuru/tsuru.conf - open /etc/tsuru/tsuru.conf: no such file or directory

Note that this message tells the user the real problem - that the config file was not present, and it tells the user where it looked. Other commands are not affected:

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr help
    tsr version 0.9.1.

    Usage: tsr command [args]

    Available commands:
      api
      help
      token
      version

    Use tsr help <commandname> to get more information about a command.

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr token
    252eb6231376253f50c82074061ad169f463ffba