### PR TITLE
.travis.yml: Allow go tip to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
   - tip
 env:
   - GOARCH=amd64
+matrix:
+  allow_failures:
+    - go: tip
 before_install:
   - sed -i "s|git://github.com/tsuru/tsuru.git|https://github.com/tsuru/tsuru|g" .git/config
   - sudo apt-get update -qq > apt-get.out 2>&1  || (cat apt-get.out && exit 1)


### PR DESCRIPTION
Because it might not always be stable.

See https://github.com/travis-ci/travis-ci/issues/2944:

> It's probably best to keep tip as an allowed_failures entry if you're
> concerned about this causing disruptions.