### PR TITLE
Make `tsr token` include newline

### DIFF
--- a/cmd/tsr/token.go
+++ b/cmd/tsr/token.go
@@ -30,7 +30,7 @@ func (tokenCmd) Run(context *cmd.Context, client *cmd.Client) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(context.Stdout, t.GetValue())
+	fmt.Fprintln(context.Stdout, t.GetValue())
 	return nil
 }
 


### PR DESCRIPTION
Make sure output ends with a newline, as this is a UNIX convention to always have a newline at the end of text.