### PR TITLE
.travis.yml: Use travis_retry for `make test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - echo http://localhost > $HOME/.tsuru_target
   - make get GO_EXTRAFLAGS=-x
 script:
-  - make test GO_EXTRAFLAGS=-x
+  - travis_retry make test GO_EXTRAFLAGS=-x
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Hoping that this might help Travis CI tests to pass even when there are sporadic failures relating to MongoDB (e.g.: #1048, #1049)