### PR TITLE
db/storage.go: Add debug Printfs

### DIFF
--- a/.travis-kick
+++ b/.travis-kick
@@ -1,0 +1,1 @@
+Kick travis

--- a/db/storage.go
+++ b/db/storage.go
@@ -12,6 +12,8 @@
 package db
 
 import (
+	"fmt"
+
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/db/storage"
 	"gopkg.in/mgo.v2"
@@ -53,8 +55,11 @@ func Conn() (*Storage, error) {
 
 // Apps returns the apps collection from MongoDB.
 func (s *Storage) Apps() *storage.Collection {
+	fmt.Printf("db/storage.go: Apps(): s = %v\n", s)
 	nameIndex := mgo.Index{Key: []string{"name"}, Unique: true}
+	fmt.Printf("db/storage.go: Apps(): nameIndex = %v\n", nameIndex)
 	c := s.Collection("apps")
+	fmt.Printf("db/storage.go: Apps(): c = %v\n", c)
 	c.EnsureIndex(nameIndex)
 	return c
 }


### PR DESCRIPTION
to try to figure out what goes on in Travis CI when we get this error (note that [`db/storage.go:57`](https://github.com/tsuru/tsuru/blob/master/db/storage.go#L57) is mentioned):

```
----------------------------------------------------------------------
PANIC: actions_test.go:31: ActionsSuite.TearDownSuite
... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x43CA35)
/home/travis/.gvm/gos/go1.4/src/runtime/asm_amd64.s:401
  in call16
/home/travis/.gvm/gos/go1.4/src/runtime/panic.go:387
  in gopanic
/home/travis/.gvm/gos/go1.4/src/runtime/panic.go:42
  in panicmem
/home/travis/.gvm/gos/go1.4/src/runtime/sigpanic_unix.go:26
  in sigpanic
/home/travis/gopath/src/github.com/tsuru/tsuru/db/storage/storage.go:90
  in Storage.Close
/home/travis/.gvm/gos/go1.4/src/runtime/asm_amd64.s:401
  in call16
/home/travis/.gvm/gos/go1.4/src/runtime/panic.go:387
  in gopanic
/home/travis/.gvm/gos/go1.4/src/runtime/panic.go:42
  in panicmem
/home/travis/.gvm/gos/go1.4/src/runtime/sigpanic_unix.go:26
  in sigpanic
/home/travis/gopath/src/github.com/tsuru/tsuru/db/storage/storage.go:97
  in Storage.Collection
/home/travis/gopath/src/github.com/tsuru/tsuru/db/storage.go:57
  in Storage.Apps
actions_test.go:34
  in ActionsSuite.TearDownSuite
/home/travis/.gvm/gos/go1.4/src/runtime/asm_amd64.s:401
  in call16
```

Cc: @andrewsmedina 