### PR TITLE
Better error when docker can't open mongodb

### DIFF
--- a/provision/docker/docker.go
+++ b/provision/docker/docker.go
@@ -60,7 +60,8 @@ func buildClusterStorage() (cluster.Storage, error) {
 	}
 	storage, err := mongodb.Mongodb(mongoUrl, mongoDatabase)
 	if err != nil {
-		return nil, fmt.Errorf("Cluster Storage: Unable to connnect to mongodb: %s", err.Error())
+		return nil, fmt.Errorf("Cluster Storage: Unable to connect to mongodb: %s (docker:cluster:mongo-url = %q; docker:cluster:mongo-database = %q)",
+			err.Error(), mongoUrl, mongoDatabase)
 	}
 	return storage, nil
 }


### PR DESCRIPTION
Two changes:

1. Fix spelling of "connect". It had an extra "n" before.
2. Add info about mongo-url and mongo-database.

Before:

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr api
    Using the database "tsurudb" from the server "127.0.0.1:27017".
    Using "docker" provisioner.
    Cluster Storage: Unable to connnect to mongodb: no reachable servers

After:

    [marca@marca-mac2 tsuru]$ ~/go/bin/tsr api
    Using the database "tsurudb" from the server "127.0.0.1:27017".
    Using "docker" provisioner.
    Cluster Storage: Unable to connect to mongodb: no reachable servers (docker:cluster:mongo-url = "127.0.0.1:27017"; docker:cluster:mongo-database = "cluster")