### PR TITLE
.travis.yml: ++memory info in after_failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ install:
   - echo http://localhost > $HOME/.tsuru_target
   - make get GO_EXTRAFLAGS=-x
 before_script:
+  # Check baseline memory usage; for compare with after_failure when OOM occurs
+  - free
+  - vmstat
+  - ps aux --sort -rss | head -n 10
+  - mongostat -n 1
+  # Make sure MongoDB and Redis are available
   - nc -zvv localhost 27017; out=$?; while [[ $out -ne 0 ]]; do echo "Retry hit port 27017..."; nc -zvv localhost 27017; out=$?; sleep 1; done
   - nc -zvv localhost 6379; out=$?; while [[ $out -ne 0 ]]; do echo "Retry hit port 6379..."; nc -zvv localhost 6379; out=$?; sleep 1; done
 script:
@@ -23,6 +29,18 @@ script:
 after_failure:
   # check for OOM; see https://github.com/travis-ci/travis-ci/issues/3075#issuecomment-68629130
   - sudo dmesg
+  - free
+  - vmstat
+  - ps aux --sort -rss | head -n 10
+  # mongostat might not work though if mongod was the process that was OOM-killed
+  - mongostat -n 1
+after_success:
+  # So we can see how much memory is used on success, it is probably borderline
+  # Here we can get useful output from mongostat since mongod wasn't OOM-killed
+  - free
+  - vmstat
+  - ps aux --sort -rss | head -n 10
+  - mongostat -n 1
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Add `free` and `top -b -n 1 -o RES | head -n 15` so we can try to see where all of the memory is going.

Refs: #1045