### PR TITLE
.travis.yml: Stop postgresql and mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - sed -i "s|git://github.com/tsuru/tsuru.git|https://github.com/tsuru/tsuru|g" .git/config
   - sudo apt-get update -qq > apt-get.out 2>&1  || (cat apt-get.out && exit 1)
   - sudo apt-get install bzr mercurial git -qq > apt-get.out 2>&1 || (cat apt-get.out && exit 1)
+  - sudo /etc/init.d/postgresql stop
+  - sudo /etc/init.d/mysql stop
 install:
   - export PATH="$HOME/gopath/bin:$PATH"
   - echo http://localhost > $HOME/.tsuru_target


### PR DESCRIPTION
to save some memory and maybe lessen chance of OOMs on Travis

(although I think MongoDB is using a lot more memory than these two are).