### PR TITLE
Display info about router on startup

### DIFF
--- a/router/galeb/router.go
+++ b/router/galeb/router.go
@@ -310,3 +310,15 @@ func (r *galebRouter) Routes(name string) ([]string, error) {
 	}
 	return hosts, nil
 }
+
+func (r galebRouter) StartupMessage() (string, error) {
+	domain, err := config.GetString(r.prefix + ":domain")
+	if err != nil {
+		return "", err
+	}
+	apiUrl, err := config.GetString(r.prefix + ":api-url")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Using galeb router %q with API URL %q.\n", domain, apiUrl), nil
+}

--- a/router/router.go
+++ b/router/router.go
@@ -66,6 +66,10 @@ type Router interface {
 	Routes(name string) ([]string, error)
 }
 
+type MessageRouter interface {
+	StartupMessage() (string, error)
+}
+
 func collection() (*storage.Collection, error) {
 	conn, err := db.Conn()
 	if err != nil {


### PR DESCRIPTION
Example output:

    [marca@marca-mac2 tsuru]$ make run-tsr-api
    build/tsr api
    Opening config file: /etc/tsuru/tsuru.conf
    Done reading config file: /etc/tsuru/tsuru.conf
    Using mongodb database "tsurudb" from the server "127.0.0.1:27017".
    Using hipache router "10.128.40.70.xip.io".  <--------------------- This is the new information
    Using "docker" provisioner.
    Using "native" auth scheme.
    tsuru HTTP server listening at 0.0.0.0:8080...

Mainly I am hoping that this helps people to understand the various pieces of tsuru better and what depends on what, because this is what I struggled with the most when I first started playing with it.
