### PR TITLE
Remove "admin-listen" stuff from configs

### DIFF
--- a/etc/tsuru-docker-template.conf
+++ b/etc/tsuru-docker-template.conf
@@ -1,5 +1,4 @@
 listen: ":8080"
-admin-listen: ":8888"
 host: http://DOMAIN:8080
 database:
   url: 127.0.0.1:27017

--- a/etc/tsuru.conf
+++ b/etc/tsuru.conf
@@ -1,6 +1,5 @@
 listen: "0.0.0.0:8080"
 host: http://localhost:8080
-admin-listen: ":8888"
 host: http://127.0.0.1:8080
 use-tls: false
 tls-cert-file: /path/to/cert.pem


### PR DESCRIPTION
admin-listen (port 8888) is not used anymore in tsuru, according to @andrewsmedina 