### PR TITLE
Make help print command list in columns

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"code.google.com/p/go-columnize"
 	"github.com/sajari/fuzzy"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/fs"
@@ -328,9 +329,9 @@ func (c *help) Run(context *Context, client *Client) error {
 			}
 		}
 		sort.Strings(commands)
-		for _, command := range commands {
-			output += fmt.Sprintf("  %s\n", command)
-		}
+		opts := columnize.DefaultOptions()
+		opts.ArrangeVertical = false
+		output += fmt.Sprintf(columnize.Columnize(commands, opts))
 		output += fmt.Sprintf("\nUse %s help <commandname> to get more information about a command.\n", c.manager.name)
 		if len(c.manager.topics) > 0 {
 			output += fmt.Sprintln("\nAvailable topics:")


### PR DESCRIPTION
Nice thing about displaying in column is all comands can fit on a screen and you don't have to scroll to look through all of them.

```
$ tsuru
tsuru version 0.14.0.

Usage: tsuru command [args]

Available commands:
app-create        app-deploy        app-grant           app-info
app-list          app-log           app-remove          app-restart
app-revoke        app-run           app-set-team-owner  app-start
app-stop          app-swap          autoscale-config    autoscale-disable
autoscale-enable  change-password   cname-add           cname-remove
env-get           env-set           env-unset           help
key-add           key-list          key-remove          login
logout            plan-list         platform-list       plugin-install
plugin-list       plugin-remove     reset-password      service-add
service-bind      service-doc       service-info        service-list
service-remove    service-status    service-unbind      target-add
target-list       target-remove     target-set          team-create
team-list         team-remove       team-user-add       team-user-list
team-user-remove  token-regenerate  token-show          unit-add
unit-remove       user-create       user-remove         version

Use tsuru help <commandname> to get more information about a command.

Available topics:
  target

Use tsuru help <topicname> to get more information about a topic.
```