### PR TITLE
List commands with short description

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -329,7 +329,13 @@ func (c *help) Run(context *Context, client *Client) error {
 		}
 		sort.Strings(commands)
 		for _, command := range commands {
-			output += fmt.Sprintf("  %s\n", command)
+			description := c.manager.Commands[command].Info().Desc
+			description = strings.Split(description, "\n")[0]
+			description = strings.Split(description, ".")[0]
+			if len(description) > 2 {
+				description = strings.ToUpper(description[0:1]) + description[1:]
+			}
+			output += fmt.Sprintf("  %-20s %s\n", command, description)
 		}
 		output += fmt.Sprintf("\nUse %s help <commandname> to get more information about a command.\n", c.manager.name)
 		if len(c.manager.topics) > 0 {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -307,9 +307,9 @@ func (s *S) TestHelp(c *gocheck.C) {
 Usage: glb command [args]
 
 Available commands:
-  help
-  user-create
-  version
+  help                 
+  user-create          Creates a user
+  version              Display the current version
 
 Use glb help <commandname> to get more information about a command.
 `
@@ -327,9 +327,9 @@ func (s *S) TestHelpWithTopics(c *gocheck.C) {
 Usage: glb command [args]
 
 Available commands:
-  help
-  user-create
-  version
+  help                 
+  user-create          Creates a user
+  version              Display the current version
 
 Use glb help <commandname> to get more information about a command.
 
@@ -383,8 +383,8 @@ func (s *S) TestRunWithoutArgsShouldRunHelp(c *gocheck.C) {
 Usage: glb command [args]
 
 Available commands:
-  help
-  version
+  help                 
+  version              Display the current version
 
 Use glb help <commandname> to get more information about a command.
 `


### PR DESCRIPTION
This is an alternative (and sort of opposite to) https://github.com/tsuru/tsuru/pull/1069

Instead of displaying commands in columns to cram more in the space, this uses the space to display a bit of info about each command, and is probably more typical of command-line tools, as this is seen in git, hg, pip, go, etc.

```
$ tsuru
tsuru version 0.14.0.

Usage: tsuru command [args]

Available commands:
  app-create           Create a new app
  app-deploy           Deploys set of files and/or directories to tsuru server
  app-grant            Grants access to an app to a team
  app-info             Show information about your app
  app-list             List all your apps
  app-log              Show logs for an app
  app-remove           Removes an app
  app-restart          Restarts an app
  app-revoke           Revokes access to an app from a team
  app-run              Run a command in all instances of the app, and prints the output
  app-set-team-owner   Set app's owner team
  app-start            Starts an app
  app-stop             Stops an app
  app-swap             Swap routes between two apps
  autoscale-config     Config app autoscale
  autoscale-disable    Disable the app autoscale
  autoscale-enable     Enable the app autoscale
  change-password      Change your password
  cname-add            Adds a cname for your app
  cname-remove         Removes cnames of your app
  env-get              Retrieve environment variables for an app
  env-set              Set environment variables for an app
  env-unset            Unset environment variables for an app
  help
  key-add              Adds a public key to your account
  key-list             Lists public keys registered in your account
  key-remove           Removes the given public key from your account
  login                Log in with your credentials
  logout               Clear local authentication credentials
  plan-list            List available plans that can be used when creating an app
  platform-list        Display the list of available platforms
  plugin-install       Install tsuru plugins
  plugin-list          List installed tsuru plugins
  plugin-remove        Remove tsuru plugins
  reset-password       Redefines the user password
  service-add          Create a service instance to one or more apps make use of
  service-bind         Bind a service instance to an app
  service-doc          Show documentation of a service
  service-info         List all instances of a service
  service-list         Get all available services, and user's instances for this services
  service-remove       Removes a service instance
  service-status       Check status of a given service instance
  service-unbind       Unbind a service instance from an app
  target-add           Adds a new entry to the list of available targets
  target-list          Displays the list of targets, marking the current
  target-remove        Remove a target from target-list (tsuru server)
  target-set           Change current target (tsuru server)
  team-create          Creates a new team
  team-list            List all teams that you are member
  team-remove          Removes a team from tsuru server
  team-user-add        Adds a user to a team
  team-user-list       List members of a team
  team-user-remove     Removes a user from a team
  token-regenerate     Generates a new API key
  token-show           Show API token user
  unit-add             Add new units to an app
  unit-remove          Remove units from an app
  user-create          Creates a user
  user-remove          Removes your user from tsuru server
  version              Display the current version

Use tsuru help <commandname> to get more information about a command.

Available topics:
  target

Use tsuru help <topicname> to get more information about a topic.
```