### PR TITLE
Show Docker nodes at startup

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -230,6 +230,12 @@ func RunServer(dry bool) http.Handler {
 				fatal(err)
 			}
 		}
+		if messageProvisioner, ok := app.Provisioner.(provision.MessageProvisioner); ok {
+			startupMessage, err := messageProvisioner.StartupMessage()
+			if err == nil && startupMessage != "" {
+				fmt.Print(startupMessage)
+			}
+		}
 		scheme, err := getAuthScheme()
 		if err != nil {
 			fmt.Printf("Warning: configuration didn't declare a auth:scheme, using default scheme.\n")

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -40,7 +40,19 @@ func getRouterForApp(app provision.App) (router.Router, error) {
 	return router.Get(routerName)
 }
 
-type dockerProvisioner struct{}
+type dockerProvisioner struct {}
+
+func (p *dockerProvisioner) StartupMessage() (string, error) {
+	nodeList, err := dockerCluster().UnfilteredNodes()
+	if err != nil {
+		return "", err
+	}
+	out := "Docker provisioner reports the following nodes:\n"
+	for _, node := range nodeList {
+		out += fmt.Sprintf("    Docker node: %s\n", node.Address)
+	}
+	return out, nil
+}
 
 func (p *dockerProvisioner) Initialize() error {
 	err := initDockerCluster()

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -240,6 +240,10 @@ type Provisioner interface {
 	RegisterUnit(Unit) error
 }
 
+type MessageProvisioner interface {
+	StartupMessage() (string, error)
+}
+
 // InitializableProvisioner is a provisioner that provides an initialization
 // method that should be called when the app is started
 type InitializableProvisioner interface {


### PR DESCRIPTION
This is my stab at making tsuru display the list of nodes in the Docker cluster when tsuru starts up.

It seems useful to know what your Docker nodes are, especially since I've seen at least a few times on gitter/IRC, people were puzzled when they got an error about having a node in the config file that was already registered.

```
vagrant@vagrant-ubuntu-trusty-64:~/go/src/github.com/tsuru/tsuru$ rm -rf build; make run-tsr-api
godep go build -o build/tsr cmd/tsr/*.go
build/tsr api
Opening config file: /etc/tsuru/tsuru.conf
Done reading config file: /etc/tsuru/tsuru.conf
Using mongodb database "tsurudb" from the server "127.0.0.1:27017".
Using "docker" provisioner.
nodeList = [{http://127.0.0.1:2375 {0001-01-01 00:00:00 +0000 UTC false} map[LastSuccess:2015-01-04T18:22:22Z pool:theonepool]}]
Using "native" auth scheme.
tsuru HTTP server listening at 0.0.0.0:8080...
```