### PR TITLE
"Unknown scheme" => "Unknown auth scheme"

### DIFF
--- a/auth/scheme.go
+++ b/auth/scheme.go
@@ -50,7 +50,7 @@ func UnregisterScheme(name string) {
 func GetScheme(name string) (Scheme, error) {
 	scheme, ok := schemes[name]
 	if !ok {
-		return nil, fmt.Errorf("Unknown scheme: %q.", name)
+		return nil, fmt.Errorf("Unknown auth scheme: %q.", name)
 	}
 	return scheme, nil
 }

--- a/auth/scheme_test.go
+++ b/auth/scheme_test.go
@@ -61,5 +61,5 @@ func (s *S) TestGetScheme(c *gocheck.C) {
 func (s *S) TestGetSchemeInvalidScheme(c *gocheck.C) {
 	_, err := GetScheme("x")
 	c.Assert(err, gocheck.NotNil)
-	c.Assert(err.Error(), gocheck.Equals, `Unknown scheme: "x".`)
+	c.Assert(err.Error(), gocheck.Equals, `Unknown auth scheme: "x".`)
 }


### PR DESCRIPTION
Slightly clearer since "scheme" to a lot of people implies a URL.