### PR TITLE
Tweak password reset messages

### DIFF
--- a/auth/native/data.go
+++ b/auth/native/data.go
@@ -16,12 +16,12 @@ need to use the following token to finish this process:
 
 If you think this is email is wrong, just ignore it.`))
 
-var passwordResetConfirm = template.Must(template.New("reset").Parse(`Subject: [tsuru] Password successfuly redefined
+var passwordResetConfirm = template.Must(template.New("reset").Parse(`Subject: [tsuru] Password successfully reset
 To: {{.email}}
 
 Greetings!
 
-This message is the confirmation that your password has been redefined. The new password is:
+This message is the confirmation that your password has been reset. The new password is:
 
 {{.password}}
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -477,9 +477,9 @@ func (c *resetPassword) Info() *Info {
 	return &Info{
 		Name:  "reset-password",
 		Usage: "reset-password <email> [--token|-t <token>]",
-		Desc: `Redefines the user password.
+		Desc: `Resets the user password.
 
-This process is composed by two steps:
+This process is composed of two steps:
 
 1. Generate a new token
 2. Reset the password using the token
@@ -499,7 +499,7 @@ func (c *resetPassword) msg() string {
 
 Please check your email.`
 	}
-	return `Your password has been redefined and mailed to you.
+	return `Your password has been reset and mailed to you.
 
 Please check your email.`
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -659,7 +659,7 @@ func (s *S) TestResetPasswordStepTwo(c *gocheck.C) {
 	client := NewClient(&http.Client{Transport: &trans}, nil, manager)
 	err := command.Run(&context, client)
 	c.Assert(err, gocheck.IsNil)
-	expected := `Your password has been redefined and mailed to you.
+	expected := `Your password has been reset and mailed to you.
 
 Please check your email.` + "\n"
 	c.Assert(buf.String(), gocheck.Equals, expected)
@@ -670,9 +670,9 @@ func (s *S) TestResetPasswordInfo(c *gocheck.C) {
 	expected := &Info{
 		Name:  "reset-password",
 		Usage: "reset-password <email> [--token|-t <token>]",
-		Desc: `Redefines the user password.
+		Desc: `Resets the user password.
 
-This process is composed by two steps:
+This process is composed of two steps:
 
 1. Generate a new token
 2. Reset the password using the token


### PR DESCRIPTION
Mostly using "reset" in place of "redefine", which looks better to this
native English speaker's eyes. Also "successfully" was misspelled before
with only one "l".