### PR TITLE
Allow healthcheck failures

### DIFF
--- a/docs/using/tsuru.yaml.rst
+++ b/docs/using/tsuru.yaml.rst
@@ -80,6 +80,7 @@ Here is how you can configure a health check in your yaml file:
       method: GET
       status: 200
       match: .*OKAY.*
+      allowed_failures: 0
 
 * ``healthcheck:path``: Which path to call in your application. This path will be
   called for each unit. It is the only mandatory field, if it's not set your
@@ -93,3 +94,5 @@ Here is how you can configure a health check in your yaml file:
   checked. This regular expression uses `go syntax
   <https://code.google.com/p/re2/wiki/Syntax>`_ and runs with ``.`` matching
   ``\n`` (``s`` flag).
+* ``healthcheck:allowed_failures``: The number of allowed failures before that the 
+  health check consider the application as unhealthy. Defaults to 0.


### PR DESCRIPTION
This PR introduce an `allowed_failures` parameter for applications' healthcheck. This is the number of allowed failures before that the health check consider the application as unhealthy (the default value is for sure 0)

This is especially interesting when sometimes there's some need of asynchronous process to be started before the application can have its normal behavior.