### PR TITLE
Make user-create request end with newline

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -60,6 +60,9 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 		fmt.Fprintf(c.context.Stdout, string(requestDump))
+		if requestDump[len(requestDump)-1] != '\n' {
+			fmt.Fprintln(c.context.Stdout)
+		}
 		fmt.Fprintf(c.context.Stdout, "*************************** </Request uri=%q> **********************************\n", request.URL.RequestURI())
 	}
 	response, err := c.HTTPClient.Do(request)
@@ -74,6 +77,9 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 		fmt.Fprintf(c.context.Stdout, string(responseDump))
+		if responseDump[len(responseDump)-1] != '\n' {
+			fmt.Fprintln(c.context.Stdout)
+		}
 		fmt.Fprintf(c.context.Stdout, "*************************** </Response uri=%q> **********************************\n", request.URL.RequestURI())
 	}
 	supported := response.Header.Get(c.versionHeader)


### PR DESCRIPTION
Prevents stuff running together when using verbose mode. E.g.:

    $ tsuru-admin -v 2 user-create ${EMAIL}
    Password: ******
    Confirm: ******
    *************************** <Request uri="/users"> **********************************
    POST /users HTTP/1.1
    Host: 127.0.0.1:8080
    Connection: close
    Authorization: bearer d2f838d903e100b56beab35d76718924065d7a36

    {"email":"me@mycompany.com", "password":"secret"}*************************** </Request uri="/users"> **********************************
    *************************** <Response uri="/users"> **********************************
    HTTP/1.1 500 Internal Server Error
    ...