### PR TITLE
cmd: increase the chance of a command being suggested

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -154,7 +154,7 @@ func (m *Manager) Run(args []string) {
 					sort.Strings(keys)
 					for _, key := range keys {
 						levenshtein := fuzzy.Levenshtein(&key, &args[0])
-						if levenshtein < 3 || strings.HasPrefix(key, args[0]) {
+						if levenshtein < 3 || strings.Contains(key, args[0]) {
 							msg += fmt.Sprintf("\t%s\n", key)
 						}
 					}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -659,6 +659,28 @@ Did you mean?
 	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
 }
 
+func (s *S) TestInvalidCommandFuzzyMatch03(c *check.C) {
+	lookup := func(ctx *Context) error {
+		return os.ErrNotExist
+	}
+	manager := BuildBaseManager("tsuru", "1.0", "", lookup)
+	var stdout, stderr bytes.Buffer
+	var exiter recordingExiter
+	manager.e = &exiter
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"list"})
+	expectedOutput := `.*: "list" is not a tsuru command. See "tsuru help".
+
+Did you mean?
+	target-list
+`
+	expectedOutput = strings.Replace(expectedOutput, "\n", "\\W", -1)
+	expectedOutput = strings.Replace(expectedOutput, "\t", "\\W+", -1)
+	c.Assert(stderr.String(), check.Matches, expectedOutput)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
 func (s *S) TestFileSystem(c *check.C) {
 	fsystem = &fstest.RecordingFs{}
 	c.Assert(filesystem(), check.DeepEquals, fsystem)


### PR DESCRIPTION
What do you think of, instead of just the prefix, consider any occurrence of the argument in the command name when deciding to suggest the command or not. Here is a brief example:

* Before this change:
```
► tsuru log
tsuru: "log" is not a tsuru command. See "tsuru help".

Did you mean?
    login
    logout
```

* After this change:
```
► tsuru log
tsuru: "log" is not a tsuru command. See "tsuru help".

Did you mean?
    app-log
    login
    logout
```

As far as I could test, [tsuru/tsuru-client](http://github.com/tsuru/tsuru-client) wasn't affected by this change. Please advise me if any other project is, though.
