### PR TITLE
Correct small typo in Gandalf set-up documentation

### DIFF
--- a/docs/installing/gandalf.rst
+++ b/docs/installing/gandalf.rst
@@ -100,8 +100,7 @@ Then start gandalf and archive-server:
 Configuring tsuru to use Gandalf
 ================================
 
-In order to use Gandalf, you need to change tsuru.conf accordingly, it's a
-two steps setup:
+In order to use Gandalf, you need to change tsuru.conf accordingly:
 
 #. Define "repo-manager" to use "gandalf";
 #. Define "git:api-server" to point to the API of the Gandalf server


### PR DESCRIPTION
There are three steps not two.