### PR TITLE
cmd: Error with HTTP status when body is empty

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -105,12 +105,17 @@ and download the last version.
 		return response, errUnauthorized
 	}
 	if response.StatusCode > 399 {
-		defer response.Body.Close()
-		result, _ := ioutil.ReadAll(response.Body)
 		err := &errors.HTTP{
 			Code:    response.StatusCode,
-			Message: string(result),
+			Message: response.Status,
 		}
+
+		defer response.Body.Close()
+		body, _ := ioutil.ReadAll(response.Body)
+		if len(body) > 0 {
+			err.Message = string(body)
+		}
+
 		return response, err
 	}
 	return response, nil

--- a/cmd/cmdtest/transport.go
+++ b/cmd/cmdtest/transport.go
@@ -7,6 +7,7 @@ package cmdtest
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -18,8 +19,15 @@ type Transport struct {
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	var statusText string
+	if text := http.StatusText(t.Status); text != "" {
+		statusText = fmt.Sprintf("%d %s", t.Status, text)
+	} else {
+		statusText = fmt.Sprintf("%d status code %d", t.Status, t.Status)
+	}
 	resp = &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBufferString(t.Message)),
+		Status:     statusText,
 		StatusCode: t.Status,
 		Header:     http.Header(t.Headers),
 	}


### PR DESCRIPTION
When the API is behind an AWS ELB and all instances are unhealthy, the ELB
will respond to client requests with a 503 status code and reason but no body
text. As demonstrated by:

    ➜  ~  curl -v http://tsuru.redacted:8080/info
    * Hostname was NOT found in DNS cache
    *   Trying xx.xx.xx.xx...
    * Connected to tsuru.redacted (xx.xx.xx.xx) port 8080 (#0)
    > GET /info HTTP/1.1
    > User-Agent: curl/7.37.1
    > Host: tsuru.redacted:8080
    > Accept: */*
    >
    < HTTP/1.1 503 Service Unavailable: Back-end server is at capacity
    < Content-Length: 0
    < Connection: keep-alive
    <
    * Connection #0 to host tsuru.redacted left intact

This lack of body causes tsuru-client not to print any error message to
indicate what has gone wrong. Instead you get:

    ➜  ~  tsuru app-list
    Error:

Make this clearer by using `http.Response.Status`, which contains the status
code and textual reason, if the response body is empty. Afterwards it looks
like this:

    ➜  tsuru git:(master) ./tsuru app-list
    Error: 503 Service Unavailable: Back-end server is at capacity

I've had to modify `cmdtest.Transport` slightly in order to mimic what
`http.Response.Write()` does because we aren't setting all of the fields on our
dummy response.