### PR TITLE
api: Fix intermittent SwapApp test failure

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -2875,20 +2875,16 @@ func (s *S) TestSwap(c *check.C) {
 }
 
 func (s *S) TestSwapApp1Locked(c *check.C) {
-	app1 := app.App{Name: "app1", Teams: []string{s.team.Name}, Lock: app.AppLock{
+	app1 := app.App{Name: "app1", Platform: "zend", Teams: []string{s.team.Name}, Lock: app.AppLock{
 		Locked: true, Reason: "/test", Owner: "x",
 	}}
-	err := s.conn.Apps().Insert(&app1)
+	err := app.CreateApp(&app1, s.user)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Apps().Remove(bson.M{"name": app1.Name})
-	app2 := app.App{Name: "app2", Teams: []string{s.team.Name}}
-	err = s.conn.Apps().Insert(&app2)
+	defer s.deleteApp(&app1)
+	app2 := app.App{Name: "app2", Platform: "zend", Teams: []string{s.team.Name}}
+	err = app.CreateApp(&app2, s.user)
 	c.Assert(err, check.IsNil)
-	app.Provisioner.Provision(&app1)
-	defer app.Provisioner.Destroy(&app1)
-	app.Provisioner.Provision(&app2)
-	defer app.Provisioner.Destroy(&app2)
-	defer s.conn.Apps().Remove(bson.M{"name": app2.Name})
+	defer s.deleteApp(&app2)
 	request, _ := http.NewRequest("PUT", "/swap?app1=app1&app2=app2", nil)
 	recorder := httptest.NewRecorder()
 	err = swap(recorder, request, s.token)
@@ -2896,16 +2892,16 @@ func (s *S) TestSwapApp1Locked(c *check.C) {
 }
 
 func (s *S) TestSwapApp2Locked(c *check.C) {
-	app1 := app.App{Name: "app1", Teams: []string{s.team.Name}}
-	err := s.conn.Apps().Insert(&app1)
+	app1 := app.App{Name: "app1", Platform: "zend", Teams: []string{s.team.Name}}
+	err := app.CreateApp(&app1, s.user)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Apps().Remove(bson.M{"name": app1.Name})
-	app2 := app.App{Name: "app2", Teams: []string{s.team.Name}, Lock: app.AppLock{
+	defer s.deleteApp(&app1)
+	app2 := app.App{Name: "app2", Platform: "zend", Teams: []string{s.team.Name}, Lock: app.AppLock{
 		Locked: true, Reason: "/test", Owner: "x",
 	}}
-	err = s.conn.Apps().Insert(&app2)
+	err = app.CreateApp(&app2, s.user)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Apps().Remove(bson.M{"name": app2.Name})
+	defer s.deleteApp(&app2)
 	request, _ := http.NewRequest("PUT", "/swap?app1=app1&app2=app2", nil)
 	recorder := httptest.NewRecorder()
 	err = swap(recorder, request, s.token)


### PR DESCRIPTION
`TestSwapApp1Locked` has been intermittently failing for me. I can't
reproduce it when running the test by itself, but can when run in
conjunction with `TestSwap`:

    ➜  tsuru git:(master) go test github.com/tsuru/tsuru/api -check.f TestSwap -check.v
    PASS: app_test.go:2853: S.TestSwap      0.486s

    ----------------------------------------------------------------------
    FAIL: app_test.go:2877: S.TestSwapApp1Locked

    app_test.go:2895:
        c.Assert(err, check.ErrorMatches, "app1: App locked by x, running /test. Acquired in .*")
    ... value = nil
    ... regex string = "app1: App locked by x, running /test. Acquired in .*"
    ... Error value is nil

    ----------------------------------------------------------------------
    PASS: app_test.go:2898: S.TestSwapApp2Locked    10.097s
    PASS: app_test.go:2962: S.TestSwapIncompatibleAppsForceSwap     0.034s
    PASS: app_test.go:2915: S.TestSwapIncompatiblePlatforms 0.041s
    PASS: app_test.go:2938: S.TestSwapIncompatibleUnits     0.032s
    OOPS: 5 passed, 1 FAILED
    --- FAIL: Test (10.98s)
    FAIL
    FAIL    github.com/tsuru/tsuru/api      10.989s

I'm thinking that this is a race condition to do with deleting the
(unlocked) app from the previous test and inserting the new (locked) app
directly into the database. Or `app.Provisioner.Provision()` introduced in
6fe0fc6 is unlocking the app afterwards?

Either way, this seems to be fixed by using `app.CreateApp()` and
`deleteApp()` instead of manipulating the database directly. Which matches
with what is done in `TestSwap`.