### PR TITLE
Error when used the suffix domain

### DIFF
--- a/router/hipache/router.go
+++ b/router/hipache/router.go
@@ -235,7 +235,7 @@ func (r *hipacheRouter) validCName(cname string) bool {
 	if err != nil {
 		return false
 	}
-	return !strings.Contains(cname, domain)
+	return cname != domain
 }
 
 func (r *hipacheRouter) SetCName(cname, name string) error {


### PR DESCRIPTION
This error occurs when you try to use the suffix domain like cname.domain.com to create cname.domain.com.br

another example:
cname.domain.com
cnamenew.domain.com