### PR TITLE
Fix when adding cname using the suffix domain

### DIFF
--- a/router/hipache/router.go
+++ b/router/hipache/router.go
@@ -235,7 +235,7 @@ func (r *hipacheRouter) validCName(cname string) bool {
 	if err != nil {
 		return false
 	}
-	return !strings.Contains(cname, domain)
+	return !strings.HasSuffix(cname, domain)
 }
 
 func (r *hipacheRouter) SetCName(cname, name string) error {

--- a/router/hipache/router_test.go
+++ b/router/hipache/router_test.go
@@ -391,6 +391,14 @@ func (s *S) TestSetCNameValidatesCNameAccordingToDomainConfig(c *check.C) {
 	c.Assert(err.Error(), check.Equals, expected)
 }
 
+func (s *S) TestSetCNameDoesNotBlockSuffixDomain(c *check.C) {
+	reply := map[string]interface{}{"GET": "", "SET": "", "LRANGE": []interface{}{[]byte{}}, "RPUSH": []interface{}{[]byte{}}}
+	conn = &ResultCommandRedisConn{Reply: reply, FakeRedisConn: s.fake}
+	router := hipacheRouter{prefix: "hipache"}
+	err := router.SetCName("mycname.golang.org.br", "myapp")
+	c.Assert(err, check.IsNil)
+}
+
 func (s *S) TestUnsetCName(c *check.C) {
 	router := hipacheRouter{prefix: "hipache"}
 	err := router.SetCName("myapp.com", "myapp")


### PR DESCRIPTION
This error occurs when you try to use the suffix domain like cname.domain.com to create cname.domain.com.br

another example:
cname.domain.com
cnamenew.domain.com