### PR TITLE
docs/reference/config: Fix router links

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -536,7 +536,8 @@ routers:<router name>:type (type: hipache, galeb, vulcand)
 
 Indicates the type of this router configuration. The standard router
 supported by tsuru is ``hipache``. There is also experimental support for
-```galeb`` <http://galeb.io/>`_ and ```vulcand`` <https://docs.vulcand.io/>`_
+``galeb`` (`ref <http://galeb.io/>`_) and ``vulcand`` (`ref
+<https://docs.vulcand.io/>`_).
 
 Depending on the type, there are some specific configuration options available.
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -535,8 +535,9 @@ routers:<router name>:type (type: hipache, galeb, vulcand)
 +++++++++++++++++++++++++++++++++++++++++++++++++
 
 Indicates the type of this router configuration. The standard router
-supported by tsuru is ``hipache``. There is also experimental support for
-``galeb`` (`ref <http://galeb.io/>`_) and ``vulcand`` (`ref
+supported by tsuru is ``hipache`` (`ref
+<https://github.com/hipache/hipache>`_). There is also experimental support
+for ``galeb`` (`ref <http://galeb.io/>`_) and ``vulcand`` (`ref
 <https://docs.vulcand.io/>`_).
 
 Depending on the type, there are some specific configuration options available.


### PR DESCRIPTION
#### docs/reference/config: Fix galeb/vulcand links

RsT doesn't support code formatting inside hyperlinks:

http://docutils.sourceforge.net/FAQ.html#is-nested-inline-markup-possible

Fix the rendering by making the link a separate reference. Keeping the
formatting means that it's easy to see the possible values.

#### docs/reference/config: Add link for Hipache

To match the other routers.