### PR TITLE
Fixed scope parsing.

### DIFF
--- a/auth/oauth/token.go
+++ b/auth/oauth/token.go
@@ -18,6 +18,7 @@ import (
 type Token struct {
 	oauth2.Token
 	UserEmail string `json:"email"`
+	Scope     string `json:"scope"`
 }
 
 func (t *Token) GetValue() string {


### PR DESCRIPTION
I assume the scope in config would look something like this:

```yaml
auth:
  oauth2:
    scope: user-create team-user-add
```

Since config.GetString("auth:oauth:scope") is a string, when passing it to oauth2.Config.Scopes, it should be split by spaces rather then passed as the only slice element.

See the Oauth2 spec: https://tools.ietf.org/html/rfc6749#page-23

Scope is a space delimited string describing permissions.

What do you think? Does this make sense?

Later down the road, I believe Oauth2's scope could be used for giving users more granular permissions.