### PR TITLE
Adding Concept Of Team Leads

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -81,7 +81,11 @@ func (s *AuthSuite) createUserAndTeam(c *check.C) {
 	s.user = &auth.User{Email: "whydidifall@thewho.com", Password: "123456"}
 	_, err := nativeScheme.Create(s.user)
 	c.Assert(err, check.IsNil)
-	s.team = &auth.Team{Name: "tsuruteam", Users: []string{s.user.Email}}
+	s.team = &auth.Team{
+		Name:      "tsuruteam",
+		Users:     []string{s.user.Email},
+		TeamLeads: []string{s.user.Email},
+	}
 	conn, _ := db.Conn()
 	defer conn.Close()
 	err = conn.Teams().Insert(s.team)

--- a/api/server.go
+++ b/api/server.go
@@ -190,6 +190,8 @@ func RunServer(dry bool) http.Handler {
 
 	m.Add("Get", "/teams", authorizationRequiredHandler(teamList))
 	m.Add("Post", "/teams", authorizationRequiredHandler(createTeam))
+	m.Add("Put", "/teams/{team}/leads/{user}", authorizationRequiredHandler(addLeadToTeam))
+	m.Add("Delete", "/teams/{team}/leads/{user}", authorizationRequiredHandler(removeLeadFromTeam))
 	m.Add("Get", "/teams/{name}", authorizationRequiredHandler(getTeam))
 	m.Add("Delete", "/teams/{name}", authorizationRequiredHandler(removeTeam))
 	m.Add("Put", "/teams/{team}/{user}", authorizationRequiredHandler(addUserToTeam))

--- a/auth/team.go
+++ b/auth/team.go
@@ -85,11 +85,49 @@ func (t *Team) RemoveUser(u *User) error {
 	if index < 0 {
 		return fmt.Errorf("User %s is not in the team %s.", u.Email, t.Name)
 	}
+
+	// If the user is a team lead,
+	// let's try removing him from TeamLeads slice first
+	if t.ContainsTeamLead(u) {
+		if err := t.RemoveTeamLead(u); err != nil {
+			return err
+		}
+	}
+
 	last := len(t.Users) - 1
 	if index < last {
 		t.Users[index] = t.Users[last]
 	}
 	t.Users = t.Users[:last]
+	return nil
+}
+
+// RemoveTeamLead removes user from team leads.
+func (t *Team) RemoveTeamLead(u *User) error {
+	index := -1
+	for i, user := range t.TeamLeads {
+		if u.Email == user {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return fmt.Errorf("User %s is not lead of the team %s.", u.Email, t.Name)
+	}
+
+	if len(t.TeamLeads) < 2 {
+		return fmt.Errorf(
+			"Cannot remove lead %s as he/she is the only lead of the team %s.",
+			u.Email,
+			t.Name,
+		)
+	}
+
+	last := len(t.TeamLeads) - 1
+	if index < last {
+		t.TeamLeads[index] = t.TeamLeads[last]
+	}
+	t.TeamLeads = t.TeamLeads[:last]
 	return nil
 }
 

--- a/auth/team.go
+++ b/auth/team.go
@@ -114,15 +114,6 @@ func (t *Team) RemoveTeamLead(u *User) error {
 	if index < 0 {
 		return fmt.Errorf("User %s is not lead of the team %s.", u.Email, t.Name)
 	}
-
-	if len(t.TeamLeads) < 2 {
-		return fmt.Errorf(
-			"Cannot remove lead %s as he/she is the only lead of the team %s.",
-			u.Email,
-			t.Name,
-		)
-	}
-
 	last := len(t.TeamLeads) - 1
 	if index < last {
 		t.TeamLeads[index] = t.TeamLeads[last]

--- a/auth/team.go
+++ b/auth/team.go
@@ -27,13 +27,24 @@ var (
 // Team represents a real world team, a team has team members (users) and
 // a name.
 type Team struct {
-	Name  string   `bson:"_id" json:"name"`
-	Users []string `json:"users"`
+	Name      string   `bson:"_id" json:"name"`
+	Users     []string `json:"users"`
+	TeamLeads []string `json:"team_leads"`
 }
 
 // ContainsUser checks if the team contains the user.
 func (t *Team) ContainsUser(u *User) bool {
 	for _, user := range t.Users {
+		if u.Email == user {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsTeamLead checks if the team contains the team lead.
+func (t *Team) ContainsTeamLead(u *User) bool {
+	for _, user := range t.TeamLeads {
 		if u.Email == user {
 			return true
 		}
@@ -47,6 +58,18 @@ func (t *Team) AddUser(u *User) error {
 		return fmt.Errorf("User %s is already in the team %s.", u.Email, t.Name)
 	}
 	t.Users = append(t.Users, u.Email)
+	return nil
+}
+
+// AddTeamLead adds a team lead to the team.
+func (t *Team) AddTeamLead(u *User) error {
+	if !t.ContainsUser(u) {
+		return fmt.Errorf("User %s must be member of the team %s before he/she can become team lead.", u.Email, t.Name)
+	}
+	if t.ContainsTeamLead(u) {
+		return fmt.Errorf("User %s is already lead of the team %s.", u.Email, t.Name)
+	}
+	t.TeamLeads = append(t.TeamLeads, u.Email)
 	return nil
 }
 

--- a/auth/team_test.go
+++ b/auth/team_test.go
@@ -75,7 +75,7 @@ func (s *S) TestShouldReturnErrorWhenAddingTeamLeadWhoIsNotMemberOfTeam(c *check
 	c.Assert(err, check.ErrorMatches, "^User nobody@globo.com must be member of the team  before he/she can become team lead.$")
 }
 
-func (s *S) TestShouldBeAbleToAddTeamLeadToTeam(c *check.C) {
+func (s *S) TestShouldBeAbleToAddLeadToTeam(c *check.C) {
 	u := &User{Email: "nobody@globo.com"}
 	t := new(Team)
 	t.AddUser(u)
@@ -124,6 +124,37 @@ func (s *S) TestShouldReturnErrorWhenTryingToRemoveAUserThatIsNotInTheTeam(c *ch
 	err := t.RemoveUser(u)
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, "^User nobody@globo.com is not in the team timeredbull.$")
+}
+
+func (s *S) TestShouldReturnErrorWhenTryingToRemoveTeamLeadThatIsNotInTheTeam(c *check.C) {
+	u := &User{Email: "nobody@globo.com"}
+	t := &Team{Name: "timeredbull"}
+	err := t.RemoveTeamLead(u)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "^User nobody@globo.com is not lead of the team timeredbull.$")
+}
+
+func (s *S) TestShouldReturnErrorWhenTryingToRemoveLastTeamLead(c *check.C) {
+	u := &User{Email: "nobody@globo.com"}
+	t := &Team{Name: "timeredbull"}
+	t.AddUser(u)
+	t.AddTeamLead(u)
+	err := t.RemoveTeamLead(u)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "^Cannot remove lead nobody@globo.com as he/she is the only lead of the team timeredbull.$")
+}
+
+func (s *S) TestLeadFromTeam(c *check.C) {
+	u := &User{Email: "nobody@globo.com"}
+	u2 := &User{Email: "nobody2@globo.com"}
+	t := &Team{Name: "timeredbull"}
+	t.AddUser(u)
+	t.AddUser(u2)
+	t.AddTeamLead(u)
+	t.AddTeamLead(u2)
+	err := t.RemoveTeamLead(u)
+	c.Assert(err, check.IsNil)
+	c.Assert(t.TeamLeads, check.DeepEquals, []string{"nobody2@globo.com"})
 }
 
 func (s *S) TestTeamAllowedApps(c *check.C) {

--- a/auth/team_test.go
+++ b/auth/team_test.go
@@ -134,16 +134,6 @@ func (s *S) TestShouldReturnErrorWhenTryingToRemoveTeamLeadThatIsNotInTheTeam(c 
 	c.Assert(err, check.ErrorMatches, "^User nobody@globo.com is not lead of the team timeredbull.$")
 }
 
-func (s *S) TestShouldReturnErrorWhenTryingToRemoveLastTeamLead(c *check.C) {
-	u := &User{Email: "nobody@globo.com"}
-	t := &Team{Name: "timeredbull"}
-	t.AddUser(u)
-	t.AddTeamLead(u)
-	err := t.RemoveTeamLead(u)
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, "^Cannot remove lead nobody@globo.com as he/she is the only lead of the team timeredbull.$")
-}
-
 func (s *S) TestLeadFromTeam(c *check.C) {
 	u := &User{Email: "nobody@globo.com"}
 	u2 := &User{Email: "nobody2@globo.com"}


### PR DESCRIPTION
See this issue: https://github.com/tsuru/tsuru/issues/1220

This pull request adds a new slice on Team struct which can contain list of team leads. A new API endpoint has been introduced to add and remove team leads from a team.

- each team can have multiple team leads.
- team leads can be added or removed by admin or another team lead from the same team
- removing last team lead will return error
- removing a user now also removes the user from team leads

This is a first step towards more granular team permissions.

Tell us what you think and if you have any objections.

In the future, we would follow up with more PRs to continue developing the team lead functionality.

If you accept this PR, we would then add new commands to tsuru client to add and remove team leads as well as improve team-user-list command to indicate which users are team leads.