### PR TITLE
router/vulcand: Test against memng instead of etcd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ before_install:
   - echo "smallfiles = true" | sudo tee -a /etc/mongodb.conf
   - cat /etc/mongodb.conf
   - sudo /etc/init.d/mongodb start
-  - curl -L https://github.com/coreos/etcd/releases/download/v2.0.12/etcd-v2.0.12-linux-amd64.tar.gz -o /tmp/etcd.tar.gz
-  - tar xzvf /tmp/etcd.tar.gz -C /tmp
-  - /tmp/etcd-v2.0.12-linux-amd64/etcd &
 install:
   - export PATH="$HOME/gopath/bin:$PATH"
   - echo http://localhost > $HOME/.tsuru_target

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -205,11 +205,6 @@
 			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
-			"ImportPath": "github.com/mailgun/vulcand/secret",
-			"Comment": "v0.8.0-beta.3-15-g22a71f6",
-			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
-		},
-		{
 			"ImportPath": "github.com/mailgun/vulcand/stapler",
 			"Comment": "v0.8.0-beta.3-15-g22a71f6",
 			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
@@ -269,19 +264,7 @@
 			"Rev": "1fbbd62cfec66bd39d91e97749579579d4d3037e"
 		},
 		{
-			"ImportPath": "golang.org/x/crypto/nacl/secretbox",
-			"Rev": "1fbbd62cfec66bd39d91e97749579579d4d3037e"
-		},
-		{
 			"ImportPath": "golang.org/x/crypto/ocsp",
-			"Rev": "1fbbd62cfec66bd39d91e97749579579d4d3037e"
-		},
-		{
-			"ImportPath": "golang.org/x/crypto/poly1305",
-			"Rev": "1fbbd62cfec66bd39d91e97749579579d4d3037e"
-		},
-		{
-			"ImportPath": "golang.org/x/crypto/salsa20/salsa",
 			"Rev": "1fbbd62cfec66bd39d91e97749579579d4d3037e"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -181,36 +181,43 @@
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/anomaly",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/api",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/engine",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/plugin",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/proxy",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/secret",
-			"Comment": "v0.8.0-beta.3",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/stapler",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/mailgun/vulcand/supervisor",
-			"Rev": "f0d929bd61791580828a957389d998fc6f22db58"
+			"Comment": "v0.8.0-beta.3-15-g22a71f6",
+			"Rev": "22a71f6b1f6eb0b2be35aaaeadabf2a8ed8c4bc2"
 		},
 		{
 			"ImportPath": "github.com/sajari/fuzzy",


### PR DESCRIPTION
Now that the fix for `UpsertServer()` has been merged and we've bumped our
dependency. This makes running the tests easier, because you don't need to
have etcd installed and we don't need to cleanup the datastore before each
test.