### PR TITLE
router/vulcand: Add healthcheck

### DIFF
--- a/router/vulcand/router.go
+++ b/router/vulcand/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mailgun/vulcand/engine"
 	"github.com/mailgun/vulcand/plugin/registry"
 	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/hc"
 	"github.com/tsuru/tsuru/router"
 )
 
@@ -20,6 +21,7 @@ const routerName = "vulcand"
 
 func init() {
 	router.Register(routerName, createRouter)
+	hc.AddChecker("Router vulcand", router.BuildHealthCheck("vulcand"))
 }
 
 type vulcandRouter struct {
@@ -226,4 +228,8 @@ func (r *vulcandRouter) Routes(name string) ([]*url.URL, error) {
 func (r *vulcandRouter) StartupMessage() (string, error) {
 	message := fmt.Sprintf("vulcand router %q with API at %q", r.domain, r.client.Addr)
 	return message, nil
+}
+
+func (r *vulcandRouter) HealthCheck() error {
+	return r.client.GetStatus()
 }

--- a/router/vulcand/router_test.go
+++ b/router/vulcand/router_test.go
@@ -424,3 +424,20 @@ func (s *S) TestStartupMessage(c *check.C) {
 		fmt.Sprintf(`vulcand router "vulcand.example.com" with API at "%s"`, s.vulcandServer.URL),
 	)
 }
+
+func (s *S) TestHealthCheck(c *check.C) {
+	got, err := router.Get("vulcand")
+	c.Assert(err, check.IsNil)
+	hcRouter, ok := got.(router.HealthChecker)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(hcRouter.HealthCheck(), check.IsNil)
+}
+
+func (s *S) TestHealthCheckFailure(c *check.C) {
+	s.vulcandServer.Close()
+	got, err := router.Get("vulcand")
+	c.Assert(err, check.IsNil)
+	hcRouter, ok := got.(router.HealthChecker)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(hcRouter.HealthCheck(), check.ErrorMatches, ".* connection refused")
+}


### PR DESCRIPTION
Which ensures that it gets a successful response from the vulcand API.