### PR TITLE
Platform Add / Update Heartbeat

### DIFF
--- a/api/platform.go
+++ b/api/platform.go
@@ -7,9 +7,11 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/io"
 )
 
 func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) error {
@@ -19,7 +21,8 @@ func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		args[key] = values[0]
 	}
 	w.Header().Set("Content-Type", "text")
-	err := app.PlatformAdd(name, args, w)
+	writer := io.NewKeepAliveWriter(w, 30*time.Second, "please wait...")
+	err := app.PlatformAdd(name, args, writer)
 	if err != nil {
 		return err
 	}
@@ -38,7 +41,8 @@ func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error 
 		args[key] = values[0]
 	}
 	w.Header().Set("Content-Type", "text")
-	err = app.PlatformUpdate(name, args, w)
+	writer := io.NewKeepAliveWriter(w, 30*time.Second, "please wait...")
+	err = app.PlatformUpdate(name, args, writer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Installing a platform can take a long time and we
had issues with platform-add/update timing out
after 60 seconds (default Nginx proxy timeout).

We have implemented a simple workaround similar how
deployment endpoint works - using a keep alive writer
and a 30s "please wait" heartbeat.

See also this issue for more thoughts: https://github.com/tsuru/tsuru/issues/1239