### PR TITLE
Changed the return code on delete a user to 404 if not found

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -482,7 +482,7 @@ func removeUser(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if email != "" && u.IsAdmin() {
 		u, err = auth.GetUserByEmail(email)
 		if err != nil {
-			return err
+			return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 		}
 	} else if u.IsAdmin() {
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: "please specify the user you want to remove"}


### PR DESCRIPTION
When querying the user database, if a user is not found the api currently
returns a server error (5XX) which is inconsistent with the other api
calls. This commit updates this behaviour.

I couldn't see any test implications but am happy to update if this is the case.

[#1242]