### PR TITLE
provision/docker/bs: fix panic index auth of range

### DIFF
--- a/provision/docker/bs/cmd.go
+++ b/provision/docker/bs/cmd.go
@@ -38,6 +38,13 @@ func (c *EnvSetCmd) Run(context *cmd.Context, client *cmd.Client) error {
 	var envList []Env
 	for _, arg := range context.Args {
 		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf("cannot set variable")
+		}
+
+		if parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("cannot set variable")
+		}
 		envList = append(envList, Env{Name: parts[0], Value: parts[1]})
 	}
 	conf := Config{}


### PR DESCRIPTION
# What
Quick fix to validate user input for setting env variables.
For instance executing: 
* ```tsuru-admin bs-env-set BS_DEBUG```
* ```tsuru-admin bs-env-set =true```
* ```tsuru-admin bs-env-set =```

results in panic.
```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/tsuru/tsuru/provision/docker/bs.(*EnvSetCmd).Run(0xc8200db3e0, 0xc8200971d0, 0xc820097220, 0x0, 0x0)
        /private/tmp/tsuru-admin20151027-27582-1peo0xl/src/github.com/tsuru/tsuru/provision/docker/bs/cmd.go:41 +0x8ed
github.com/tsuru/tsuru/cmd.(*Manager).Run(0xc820102480, 0xc820107740, 0x1, 0x1)
        /private/tmp/tsuru-admin20151027-27582-1peo0xl/src/github.com/tsuru/tsuru/cmd/cmd.go:192 +0x18ca
main.main()
        /private/tmp/tsuru-admin20151027-27582-1peo0xl/src/github.com/tsuru/tsuru-admin/main.go:70 +0xba

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/Cellar/go/1.5.1/libexec/src/runtime/asm_amd64.s:1696 +0x1

goroutine 20 [syscall]:
os/signal.loop()
        /usr/local/Cellar/go/1.5.1/libexec/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
        /usr/local/Cellar/go/1.5.1/libexec/src/os/signal/signal_unix.go:28 +0x37
```
# How to review
Compile and execute one of the above listed examples