### PR TITLE
App list filter by status

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -163,7 +163,7 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	owner := r.URL.Query().Get("owner")
 	pool := r.URL.Query().Get("pool")
 	description := r.URL.Query().Get("description")
-	status := r.URL.Query().Get("status")
+	status := strings.Split(r.URL.Query().Get("status"), ",")
 	locked, _ := strconv.ParseBool(r.URL.Query().Get("locked"))
 	extra := make([]interface{}, 0, 1)
 	filter := &app.Filter{}
@@ -208,8 +208,8 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
-	if status != "" {
-		apps, err = app.Provisioner.FilterAppsByUnitStatus(apps, []string{status})
+	if status[0] != "" || len(status) > 1 {
+		apps, err = app.Provisioner.FilterAppsByUnitStatus(apps, status)
 
 		if err != nil {
 			return err

--- a/api/app.go
+++ b/api/app.go
@@ -112,7 +112,7 @@ type miniApp struct {
 	Units []provision.Unit `json:"units"`
 	CName []string         `json:"cname"`
 	Ip    string           `json:"ip"`
-	Lock  app.AppLock      `json:"lock"`
+	Lock  json.Marshaler   `json:"lock"`
 }
 
 func minifyApp(app app.App) (miniApp, error) {
@@ -121,11 +121,11 @@ func minifyApp(app app.App) (miniApp, error) {
 		return miniApp{}, err
 	}
 	return miniApp{
-		Name:  app.Name,
+		Name:  app.GetName(),
 		Units: units,
-		CName: app.CName,
-		Ip:    app.Ip,
-		Lock:  app.Lock,
+		CName: app.GetCname(),
+		Ip:    app.GetIp(),
+		Lock:  app.GetLock(),
 	}, nil
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -110,11 +110,11 @@ func appDelete(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 // miniApp is a minimal representation of the app, created to make appList
 // faster and transmit less data.
 type miniApp struct {
-	Name  string           `json:"name"`
-	Units []provision.Unit `json:"units"`
-	CName []string         `json:"cname"`
-	Ip    string           `json:"ip"`
-	Lock  json.Marshaler   `json:"lock"`
+	Name  string            `json:"name"`
+	Units []provision.Unit  `json:"units"`
+	CName []string          `json:"cname"`
+	Ip    string            `json:"ip"`
+	Lock  provision.AppLock `json:"lock"`
 }
 
 func minifyApp(app app.App) (miniApp, error) {

--- a/api/app.go
+++ b/api/app.go
@@ -117,7 +117,7 @@ type miniApp struct {
 	Lock  provision.AppLock `json:"lock"`
 }
 
-func minifyApp(app app.App) (miniApp, error) {
+func minifyApp(app provision.App) (miniApp, error) {
 	units, err := app.Units()
 	if err != nil {
 		return miniApp{}, err
@@ -208,20 +208,8 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
-
 	if status != "" {
-		abc := make([]provision.App, len(apps))
-
-		for i, a := range apps {
-			abc[i] = &a
-		}
-
-		abc, err = app.Provisioner.FilterAppsByUnitStatus(abc, []string{status})
-
-
-		for i, a := range abc {
-			apps[i] = app.App(a)
-		}
+		apps, err = app.Provisioner.FilterAppsByUnitStatus(apps, []string{status})
 
 		if err != nil {
 			return err

--- a/api/app.go
+++ b/api/app.go
@@ -32,8 +32,6 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-var Provisioner provision.Provisioner
-
 func getAppFromContext(name string, r *http.Request) (app.App, error) {
 	var err error
 	a := context.GetApp(r)
@@ -210,12 +208,10 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	}
 	if status[0] != "" || len(status) > 1 {
 		apps, err = app.Provisioner.FilterAppsByUnitStatus(apps, status)
-
 		if err != nil {
 			return err
 		}
 	}
-
 	w.Header().Set("Content-Type", "application/json")
 	miniApps := make([]miniApp, len(apps))
 	for i, app := range apps {

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -300,46 +300,43 @@ func (s *S) TestAppListFilteringByPool(c *check.C) {
 }
 
 func (s *S) TestAppListFilteringByStatus(c *check.C) {
-
 	recorder := httptest.NewRecorder()
 	m := RunServer(true)
 
-	// create app1
 	app1 := app.App{Name: "app1", Platform: "zend", TeamOwner: s.team.Name}
 	err := app.CreateApp(&app1, s.user)
 	c.Assert(err, check.IsNil)
-	// add 2 units
 	requestBody := strings.NewReader("units=2&process=web")
 	request, err := http.NewRequest("PUT", "/apps/app1/units?:app=app1", requestBody)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Set("Authorization", "b " + s.token.GetValue())
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	m.ServeHTTP(recorder, request)
-	// stop
 	request, err = http.NewRequest("POST", fmt.Sprintf("/apps/%s/stop", app1.Name), nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", "b " + s.token.GetValue())
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 
-	// create app2
 	app2 := app.App{Name: "app2", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(&app2, s.user)
 	c.Assert(err, check.IsNil)
-	// add 1 unit
 	requestBody = strings.NewReader("units=1&process=web")
 	request, err = http.NewRequest("PUT", "/apps/app2/units?:app=app2", requestBody)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Set("Authorization", "b " + s.token.GetValue())
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	m.ServeHTTP(recorder, request)
 
-	// list apps with started units
-	request, err = http.NewRequest("GET", fmt.Sprintf("/apps?status=%s", "stopped"), nil)
+	app3 := app.App{Name: "app3", Platform: "zend", TeamOwner: s.team.Name}
+	err = app.CreateApp(&app3, s.user)
+	c.Assert(err, check.IsNil)
+
+	request, err = http.NewRequest("GET", "/apps?status=stopped,started", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", "b " + s.token.GetValue())
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	recorder = httptest.NewRecorder()
 	m = RunServer(true)
 	m.ServeHTTP(recorder, request)
@@ -349,7 +346,7 @@ func (s *S) TestAppListFilteringByStatus(c *check.C) {
 	apps := []app.App{}
 	err = json.Unmarshal(body, &apps)
 	c.Assert(err, check.IsNil)
-	expected := []app.App{app1}
+	expected := []app.App{app1, app2}
 	c.Assert(len(apps), check.Equals, len(expected))
 	for i, app := range apps {
 		c.Assert(app.Name, check.DeepEquals, expected[i].Name)

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -302,7 +302,6 @@ func (s *S) TestAppListFilteringByPool(c *check.C) {
 func (s *S) TestAppListFilteringByStatus(c *check.C) {
 	recorder := httptest.NewRecorder()
 	m := RunServer(true)
-
 	app1 := app.App{Name: "app1", Platform: "zend", TeamOwner: s.team.Name}
 	err := app.CreateApp(&app1, s.user)
 	c.Assert(err, check.IsNil)
@@ -318,7 +317,6 @@ func (s *S) TestAppListFilteringByStatus(c *check.C) {
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	m.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-
 	app2 := app.App{Name: "app2", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(&app2, s.user)
 	c.Assert(err, check.IsNil)
@@ -328,11 +326,9 @@ func (s *S) TestAppListFilteringByStatus(c *check.C) {
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	m.ServeHTTP(recorder, request)
-
 	app3 := app.App{Name: "app3", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(&app3, s.user)
 	c.Assert(err, check.IsNil)
-
 	request, err = http.NewRequest("GET", "/apps?status=stopped,started", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
@@ -356,7 +352,6 @@ func (s *S) TestAppListFilteringByStatus(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(units, check.DeepEquals, expectedUnits)
 	}
-
 }
 
 func (s *S) TestAppList(c *check.C) {

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -305,7 +305,12 @@ func (s *S) TestAppList(c *check.C) {
 		Context: permission.Context(permission.CtxTeam, s.team.Name),
 	})
 	u, _ := token.User()
-	app1 := app.App{Name: "app1", Platform: "zend", TeamOwner: s.team.Name, CName: []string{"cname.app1"}}
+	app1 := app.App{
+		Name:      "app1",
+		Platform:  "zend",
+		TeamOwner: s.team.Name,
+		CName:     []string{"cname.app1"},
+	}
 	err := app.CreateApp(&app1, u)
 	c.Assert(err, check.IsNil)
 	acquireDate := time.Date(2015, time.February, 12, 12, 3, 0, 0, time.Local)
@@ -334,18 +339,16 @@ func (s *S) TestAppList(c *check.C) {
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
 	body, err := ioutil.ReadAll(recorder.Body)
 	c.Assert(err, check.IsNil)
-	var apps []miniApp
+	var apps []app.App
 	err = json.Unmarshal(body, &apps)
 	c.Assert(err, check.IsNil)
 	c.Assert(apps, check.HasLen, 2)
-	miniApp1, err := minifyApp(app1)
-	c.Assert(err, check.IsNil)
-	miniApp1.Lock.AcquireDate = apps[0].Lock.AcquireDate
-	miniApp2, err := minifyApp(app2)
-	c.Assert(err, check.IsNil)
-	miniApp2.Lock.AcquireDate = apps[1].Lock.AcquireDate
-	expected := []miniApp{miniApp1, miniApp2}
-	c.Assert(apps, check.DeepEquals, expected)
+	c.Assert(apps[0].Name, check.Equals, app1.Name)
+	c.Assert(apps[0].CName, check.DeepEquals, app1.CName)
+	c.Assert(apps[0].Ip, check.Equals, app1.Ip)
+	c.Assert(apps[1].Name, check.Equals, app2.Name)
+	c.Assert(apps[1].CName, check.DeepEquals, app2.CName)
+	c.Assert(apps[1].Ip, check.Equals, app2.Ip)
 	action := rectest.Action{Action: "app-list", User: u.Email}
 	c.Assert(action, rectest.IsRecorded)
 }
@@ -375,7 +378,7 @@ func (s *S) TestAppListShouldListAllAppsOfAllTeamsThatTheUserHasPermission(c *ch
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
 	body, err := ioutil.ReadAll(recorder.Body)
 	c.Assert(err, check.IsNil)
-	var apps []miniApp
+	var apps []app.App
 	err = json.Unmarshal(body, &apps)
 	c.Assert(err, check.IsNil)
 	c.Assert(apps, check.HasLen, 1)

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -300,7 +300,7 @@ func (s *S) TestAppListFilteringByPool(c *check.C) {
 }
 
 func (s *S) TestAppListFilteringByStatus(c *check.C) {
-	//c.Skip("pending")
+	c.Skip("pending")
 
 	// stopped app
 	app1 := app.App{Name: "app1", Platform: "zend", TeamOwner: s.team.Name}

--- a/api/permission.go
+++ b/api/permission.go
@@ -116,7 +116,7 @@ func deployableApps(u *auth.User, rolesCache map[string]*permission.Role) ([]str
 	}
 	appNames := make([]string, len(apps))
 	for i := range apps {
-		appNames[i] = apps[i].Name
+		appNames[i] = apps[i].GetName()
 	}
 	return appNames, nil
 }

--- a/app/app.go
+++ b/app/app.go
@@ -955,6 +955,11 @@ func (app *App) SetQuotaInUse(inUse int) error {
 	return err
 }
 
+// GetCname returns the cnames of the app.
+func (app *App) GetCname() []string {
+	return app.CName
+}
+
 // GetPlatform returns the platform of the app.
 func (app *App) GetPlatform() string {
 	return app.Platform

--- a/app/app.go
+++ b/app/app.go
@@ -73,6 +73,20 @@ func (l *AppLock) String() string {
 	)
 }
 
+func (l *AppLock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Locked      bool   `json:"Locked"`
+		Reason      string `json:"Reason"`
+		Owner       string `json:"Owner"`
+		AcquireDate string `json:"AcquireDate"`
+	}{
+		Locked:      l.Locked,
+		Reason:      l.Reason,
+		Owner:       l.Owner,
+		AcquireDate: l.AcquireDate.Format(time.RFC3339),
+	})
+}
+
 // App is the main type in tsuru. An app represents a real world application.
 // This struct holds information about the app: its name, address, list of
 // teams that have access to it, used platform, etc.
@@ -958,6 +972,11 @@ func (app *App) SetQuotaInUse(inUse int) error {
 // GetCname returns the cnames of the app.
 func (app *App) GetCname() []string {
 	return app.CName
+}
+
+// GetLock returns the app lock information serialized in json.
+func (app *App) GetLock() json.Marshaler {
+	return &app.Lock
 }
 
 // GetPlatform returns the platform of the app.

--- a/app/app.go
+++ b/app/app.go
@@ -1443,7 +1443,7 @@ func (f *Filter) Query() bson.M {
 }
 
 // List returns the list of apps filtered through the filter parameter.
-func List(filter *Filter) ([]App, error) {
+func List(filter *Filter) ([]provision.App, error) {
 	var apps []App
 	conn, err := db.Conn()
 	if err != nil {
@@ -1452,9 +1452,13 @@ func List(filter *Filter) ([]App, error) {
 	defer conn.Close()
 	query := filter.Query()
 	if err := conn.Apps().Find(query).All(&apps); err != nil {
-		return []App{}, err
+		return []provision.App{}, err
 	}
-	return apps, nil
+	appList := make([]provision.App, len(apps))
+	for i := range apps {
+		appList[i] = &apps[i]
+	}
+	return appList, nil
 }
 
 // Swap calls the Provisioner.Swap.

--- a/app/app.go
+++ b/app/app.go
@@ -87,6 +87,22 @@ func (l *AppLock) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (l *AppLock) GetLocked() bool {
+	return l.Locked
+}
+
+func (l *AppLock) GetReason() string {
+	return l.Reason
+}
+
+func (l *AppLock) GetOwner() string {
+	return l.Owner
+}
+
+func (l *AppLock) GetAcquireDate() time.Time {
+	return l.AcquireDate
+}
+
 // App is the main type in tsuru. An app represents a real world application.
 // This struct holds information about the app: its name, address, list of
 // teams that have access to it, used platform, etc.
@@ -974,8 +990,8 @@ func (app *App) GetCname() []string {
 	return app.CName
 }
 
-// GetLock returns the app lock information serialized in json.
-func (app *App) GetLock() json.Marshaler {
+// GetLock returns the app lock information.
+func (app *App) GetLock() provision.AppLock {
 	return &app.Lock
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2942,6 +2942,20 @@ func (s *S) TestGetCname(c *check.C) {
 	c.Assert(a.GetCname(), check.DeepEquals, a.CName)
 }
 
+func (s *S) TestGetLock(c *check.C) {
+	a := App{
+		Lock: AppLock{
+			Locked: true,
+			Owner:  "someone",
+		},
+	}
+	data1, err := json.Marshal(a.Lock)
+	c.Assert(err, check.IsNil)
+	data2, err := json.Marshal(a.GetLock())
+	c.Assert(err, check.IsNil)
+	c.Assert(data1, check.DeepEquals, data2)
+}
+
 func (s *S) TestGetPlatform(c *check.C) {
 	a := App{Platform: "django"}
 	c.Assert(a.GetPlatform(), check.Equals, a.Platform)
@@ -3212,6 +3226,21 @@ func (s *S) TestAppLockStringLocked(c *check.C) {
 		AcquireDate: time.Date(2048, time.November, 10, 10, 0, 0, 0, time.UTC),
 	}
 	c.Assert(lock.String(), check.Matches, "App locked by someone, running /app/my-app/deploy. Acquired in 2048-11-10T.*")
+}
+
+func (s *S) TestAppLockMarshalJSON(c *check.C) {
+	lock := AppLock{
+		Locked:      true,
+		Reason:      "/app/my-app/deploy",
+		Owner:       "someone",
+		AcquireDate: time.Date(2048, time.November, 10, 10, 0, 0, 0, time.UTC),
+	}
+	data, err := lock.MarshalJSON()
+	c.Assert(err, check.IsNil)
+	var a AppLock
+	err = json.Unmarshal(data, &a)
+	c.Assert(err, check.IsNil)
+	c.Assert(a, check.DeepEquals, lock)
 }
 
 func (s *S) TestAppRegisterUnit(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2937,6 +2937,11 @@ func (s *S) TestSetQuotaInUseInvalid(c *check.C) {
 	c.Check(err.Error(), check.Equals, "invalid value, cannot be lesser than 0")
 }
 
+func (s *S) TestGetCname(c *check.C) {
+	a := App{CName: []string{"cname1", "cname2"}}
+	c.Assert(a.GetCname(), check.DeepEquals, a.CName)
+}
+
 func (s *S) TestGetPlatform(c *check.C) {
 	a := App{Platform: "django"}
 	c.Assert(a.GetPlatform(), check.Equals, a.Platform)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2945,15 +2945,16 @@ func (s *S) TestGetCname(c *check.C) {
 func (s *S) TestGetLock(c *check.C) {
 	a := App{
 		Lock: AppLock{
-			Locked: true,
-			Owner:  "someone",
+			Locked:      true,
+			Owner:       "someone",
+			Reason:      "/app/my-app/deploy",
+			AcquireDate: time.Date(2048, time.November, 10, 10, 0, 0, 0, time.UTC),
 		},
 	}
-	data1, err := json.Marshal(a.Lock)
-	c.Assert(err, check.IsNil)
-	data2, err := json.Marshal(a.GetLock())
-	c.Assert(err, check.IsNil)
-	c.Assert(data1, check.DeepEquals, data2)
+	c.Assert(a.GetLock().GetLocked(), check.Equals, a.Lock.Locked)
+	c.Assert(a.GetLock().GetOwner(), check.Equals, a.Lock.Owner)
+	c.Assert(a.GetLock().GetReason(), check.Equals, a.Lock.Reason)
+	c.Assert(a.GetLock().GetAcquireDate(), check.Equals, a.Lock.AcquireDate)
 }
 
 func (s *S) TestGetPlatform(c *check.C) {
@@ -3241,6 +3242,26 @@ func (s *S) TestAppLockMarshalJSON(c *check.C) {
 	err = json.Unmarshal(data, &a)
 	c.Assert(err, check.IsNil)
 	c.Assert(a, check.DeepEquals, lock)
+}
+
+func (s *S) TestAppLockGetLocked(c *check.C) {
+	lock := AppLock{Locked: true}
+	c.Assert(lock.GetLocked(), check.Equals, lock.Locked)
+}
+
+func (s *S) TestAppLockGetReason(c *check.C) {
+	lock := AppLock{Reason: "/app/my-app/deploy"}
+	c.Assert(lock.GetReason(), check.Equals, lock.Reason)
+}
+
+func (s *S) TestAppLockGetOwner(c *check.C) {
+	lock := AppLock{Owner: "someone"}
+	c.Assert(lock.GetOwner(), check.Equals, lock.Owner)
+}
+
+func (s *S) TestAppLockGetAcquireDate(c *check.C) {
+	lock := AppLock{AcquireDate: time.Date(2048, time.November, 10, 10, 0, 0, 0, time.UTC)}
+	c.Assert(lock.GetAcquireDate(), check.Equals, lock.AcquireDate)
 }
 
 func (s *S) TestAppRegisterUnit(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2658,7 +2658,7 @@ func (s *S) TestListReturnsAppsForAGivenUserFilteringByLockState(c *check.C) {
 	apps, err := List(&Filter{Locked: true})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(apps), check.Equals, 1)
-	c.Assert(apps[0].Name, check.Equals, "othertestapp")
+	c.Assert(apps[0].GetName(), check.Equals, "othertestapp")
 }
 
 func (s *S) TestListAll(c *check.C) {
@@ -2811,14 +2811,14 @@ func (s *S) TestListFilteringByPool(c *check.C) {
 	apps, err := List(&Filter{Pool: s.Pool})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(apps), check.Equals, 1)
-	c.Assert(apps[0].Name, check.Equals, a2.Name)
-	c.Assert(apps[0].Pool, check.Equals, a2.Pool)
+	c.Assert(apps[0].GetName(), check.Equals, a2.Name)
+	c.Assert(apps[0].GetPool(), check.Equals, a2.Pool)
 }
 
 func (s *S) TestListReturnsEmptyAppArrayWhenUserHasNoAccessToAnyApp(c *check.C) {
 	apps, err := List(nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(apps, check.DeepEquals, []App(nil))
+	c.Assert(apps, check.DeepEquals, []provision.App{})
 }
 
 func (s *S) TestListReturnsAllAppsWhenUsedWithNoFilters(c *check.C) {
@@ -2828,8 +2828,8 @@ func (s *S) TestListReturnsAllAppsWhenUsedWithNoFilters(c *check.C) {
 	defer s.conn.Apps().Remove(bson.M{"name": a.Name})
 	apps, err := List(nil)
 	c.Assert(len(apps), Greater, 0)
-	c.Assert(apps[0].Name, check.Equals, "testApp")
-	c.Assert(apps[0].Teams, check.DeepEquals, []string{"notAdmin", "noSuperUser"})
+	c.Assert(apps[0].GetName(), check.Equals, "testApp")
+	c.Assert(apps[0].GetTeamsName(), check.DeepEquals, []string{"notAdmin", "noSuperUser"})
 }
 
 func (s *S) TestListFilteringExtraWithOr(c *check.C) {
@@ -2872,7 +2872,7 @@ func (s *S) TestListFilteringExtraWithOr(c *check.C) {
 	c.Assert(err, check.IsNil)
 	var appNames []string
 	for _, a := range apps {
-		appNames = append(appNames, a.Name)
+		appNames = append(appNames, a.GetName())
 	}
 	sort.Strings(appNames)
 	c.Assert(appNames, check.DeepEquals, []string{a2.Name, a3.Name})

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -47,7 +47,7 @@ func ListDeploys(filter *Filter, skip, limit int) ([]DeployData, error) {
 	}
 	apps := make([]string, len(appsList))
 	for i, a := range appsList {
-		apps[i] = a.Name
+		apps[i] = a.GetName()
 	}
 	var list []DeployData
 	f := bson.M{"app": bson.M{"$in": apps}, "removedate": bson.M{"$exists": false}}

--- a/provision/docker/image.go
+++ b/provision/docker/image.go
@@ -48,9 +48,9 @@ func MigrateImages() error {
 	}
 	dcluster := mainDockerProvisioner.Cluster()
 	for _, app := range apps {
-		oldImage := registry + repoNamespace + "/" + app.Name
-		newImage := registry + repoNamespace + "/app-" + app.Name
-		containers, _ := mainDockerProvisioner.ListContainers(bson.M{"image": newImage, "appname": app.Name})
+		oldImage := registry + repoNamespace + "/" + app.GetName()
+		newImage := registry + repoNamespace + "/app-" + app.GetName()
+		containers, _ := mainDockerProvisioner.ListContainers(bson.M{"image": newImage, "appname": app.GetName()})
 		if len(containers) > 0 {
 			continue
 		}
@@ -73,7 +73,7 @@ func MigrateImages() error {
 				return err
 			}
 		}
-		err = mainDockerProvisioner.updateContainers(bson.M{"appname": app.Name}, bson.M{"$set": bson.M{"image": newImage}})
+		err = mainDockerProvisioner.updateContainers(bson.M{"appname": app.GetName()}, bson.M{"$set": bson.M{"image": newImage}})
 		if err != nil {
 			return err
 		}

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -1211,3 +1211,23 @@ func pluralize(str string, sz int) string {
 	}
 	return str
 }
+
+func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) []provision.App {
+	appNames := make([]string, len(apps))
+	for i, app := range apps {
+		appNames[i] = app.GetName()
+	}
+
+	containers, _ := p.listContainersByAppAndStatus(appNames, status)
+	result := make([]provision.App, 0)
+	for _, app := range apps {
+		for _, c := range containers {
+			if app.GetName() == c.AppName {
+				result = append(result, app)
+				break
+			}
+		}
+	}
+
+	return result
+}

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -1219,17 +1219,14 @@ func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status 
 	if status == nil {
 		return make([]provision.App, 0), nil
 	}
-
 	appNames := make([]string, len(apps))
 	for i, app := range apps {
 		appNames[i] = app.GetName()
 	}
-
 	containers, err := p.listContainersByAppAndStatus(appNames, status)
 	if err != nil {
 		return nil, err
 	}
-
 	result := make([]provision.App, 0)
 	for _, app := range apps {
 		for _, c := range containers {
@@ -1239,6 +1236,5 @@ func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status 
 			}
 		}
 	}
-
 	return result, nil
 }

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -1212,9 +1212,12 @@ func pluralize(str string, sz int) string {
 	return str
 }
 
-func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) []provision.App {
-	if apps == nil || status == nil {
-		return apps
+func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) ([]provision.App, error) {
+	if apps == nil {
+		return nil, fmt.Errorf("apps must be provided to FilterAppsByUnitStatus")
+	}
+	if status == nil {
+		return make([]provision.App, 0), nil
 	}
 
 	appNames := make([]string, len(apps))
@@ -1222,7 +1225,11 @@ func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status 
 		appNames[i] = app.GetName()
 	}
 
-	containers, _ := p.listContainersByAppAndStatus(appNames, status)
+	containers, err := p.listContainersByAppAndStatus(appNames, status)
+	if err != nil {
+		return nil, err
+	}
+
 	result := make([]provision.App, 0)
 	for _, app := range apps {
 		for _, c := range containers {
@@ -1233,5 +1240,5 @@ func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status 
 		}
 	}
 
-	return result
+	return result, nil
 }

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -1213,6 +1213,10 @@ func pluralize(str string, sz int) string {
 }
 
 func (p *dockerProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) []provision.App {
+	if apps == nil || status == nil {
+		return apps
+	}
+
 	appNames := make([]string, len(apps))
 	for i, app := range apps {
 		appNames[i] = app.GetName()

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -2767,15 +2767,26 @@ func (s *S) TestFilterAppsByUnitStatus(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer s.removeTestContainer(cont2)
 
-	apps := s.p.FilterAppsByUnitStatus([]provision.App{app1}, nil)
-	c.Assert(apps, check.DeepEquals, []provision.App{app1})
-
-	apps = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"started"})
-	c.Assert(apps, check.DeepEquals, []provision.App{app2})
-
-	apps = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"building"})
+	// Should return empty collection when status is nil
+	apps, err := s.p.FilterAppsByUnitStatus([]provision.App{app1}, nil)
 	c.Assert(apps, check.DeepEquals, []provision.App{})
+	c.Assert(err, check.IsNil)
 
-	apps = s.p.FilterAppsByUnitStatus(nil, []string{"building"})
+	// Should return error when apps are not specified
+	apps, err = s.p.FilterAppsByUnitStatus(nil, []string{"building"})
 	c.Assert(apps, check.IsNil)
+	c.Assert(err, check.Not(check.IsNil))
+
+	apps, err = s.p.FilterAppsByUnitStatus(nil, nil)
+	c.Assert(apps, check.IsNil)
+	c.Assert(err, check.Not(check.IsNil))
+
+	// Should return apps with units containing status
+	apps, err = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"started"})
+	c.Assert(apps, check.DeepEquals, []provision.App{app2})
+	c.Assert(err, check.IsNil)
+
+	apps, err = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"building"})
+	c.Assert(apps, check.DeepEquals, []provision.App{})
+	c.Assert(err, check.IsNil)
 }

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -2775,4 +2775,7 @@ func (s *S) TestFilterAppsByUnitStatus(c *check.C) {
 
 	apps = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"building"})
 	c.Assert(apps, check.DeepEquals, []provision.App{})
+
+	apps = s.p.FilterAppsByUnitStatus(nil, []string{"building"})
+	c.Assert(apps, check.IsNil)
 }

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -2752,40 +2752,30 @@ func (s *S) TestProvisionerRoutableUnits(c *check.C) {
 func (s *S) TestFilterAppsByUnitStatus(c *check.C) {
 	app1 := provisiontest.NewFakeApp("app1", "python", 0)
 	app2 := provisiontest.NewFakeApp("app2", "python", 0)
-
 	cont1, err := s.newContainer(&newContainerOpts{
 		AppName: app1.GetName(),
 		Status:  "stopped",
 	}, nil)
 	c.Assert(err, check.IsNil)
 	defer s.removeTestContainer(cont1)
-
 	cont2, err := s.newContainer(&newContainerOpts{
 		AppName: app2.GetName(),
 		Status:  "started",
 	}, nil)
 	c.Assert(err, check.IsNil)
 	defer s.removeTestContainer(cont2)
-
-	// Should return empty collection when status is nil
 	apps, err := s.p.FilterAppsByUnitStatus([]provision.App{app1}, nil)
 	c.Assert(apps, check.DeepEquals, []provision.App{})
 	c.Assert(err, check.IsNil)
-
-	// Should return error when apps are not specified
 	apps, err = s.p.FilterAppsByUnitStatus(nil, []string{"building"})
 	c.Assert(apps, check.IsNil)
 	c.Assert(err, check.Not(check.IsNil))
-
 	apps, err = s.p.FilterAppsByUnitStatus(nil, nil)
 	c.Assert(apps, check.IsNil)
 	c.Assert(err, check.Not(check.IsNil))
-
-	// Should return apps with units containing status
 	apps, err = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"started"})
 	c.Assert(apps, check.DeepEquals, []provision.App{app2})
 	c.Assert(err, check.IsNil)
-
 	apps, err = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"building"})
 	c.Assert(apps, check.DeepEquals, []provision.App{})
 	c.Assert(err, check.IsNil)

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -2748,3 +2748,31 @@ func (s *S) TestProvisionerRoutableUnits(c *check.C) {
 		conts[0].AsUnit(fakeApp),
 	})
 }
+
+func (s *S) TestFilterAppsByUnitStatus(c *check.C) {
+	app1 := provisiontest.NewFakeApp("app1", "python", 0)
+	app2 := provisiontest.NewFakeApp("app2", "python", 0)
+
+	cont1, err := s.newContainer(&newContainerOpts{
+		AppName: app1.GetName(),
+		Status:  "stopped",
+	}, nil)
+	c.Assert(err, check.IsNil)
+	defer s.removeTestContainer(cont1)
+
+	cont2, err := s.newContainer(&newContainerOpts{
+		AppName: app2.GetName(),
+		Status:  "started",
+	}, nil)
+	c.Assert(err, check.IsNil)
+	defer s.removeTestContainer(cont2)
+
+	apps := s.p.FilterAppsByUnitStatus([]provision.App{app1}, nil)
+	c.Assert(apps, check.DeepEquals, []provision.App{app1})
+
+	apps = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"started"})
+	c.Assert(apps, check.DeepEquals, []provision.App{app2})
+
+	apps = s.p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"building"})
+	c.Assert(apps, check.DeepEquals, []provision.App{})
+}

--- a/provision/docker/repository.go
+++ b/provision/docker/repository.go
@@ -107,6 +107,17 @@ func (p *dockerProvisioner) listRunnableContainersByApp(appName string) ([]conta
 	})
 }
 
+func (p *dockerProvisioner) listContainersByAppAndStatus(appNames []string, status []string) ([]container.Container, error) {
+	query := bson.M{}
+	if len(appNames) > 0 {
+		query["appname"] = bson.M{"$in": appNames}
+	}
+	if len(status) > 0 {
+		query["status"] = bson.M{"$in": status}
+	}
+	return p.ListContainers(query)
+}
+
 func (p *dockerProvisioner) listAllContainers() ([]container.Container, error) {
 	return p.ListContainers(nil)
 }

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -315,7 +315,7 @@ type Provisioner interface {
 	// Rollback a deploy
 	Rollback(App, string, io.Writer) (string, error)
 
-	FilterAppsByUnitStatus([]App, []string) []App
+	FilterAppsByUnitStatus([]App, []string) ([]App, error)
 }
 
 type MessageProvisioner interface {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -314,6 +314,8 @@ type Provisioner interface {
 
 	// Rollback a deploy
 	Rollback(App, string, io.Writer) (string, error)
+
+	FilterAppsByUnitStatus([]App, []string) []App
 }
 
 type MessageProvisioner interface {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -7,6 +7,7 @@
 package provision
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -200,6 +201,8 @@ type App interface {
 	GetCname() []string
 
 	GetIp() string
+
+	GetLock() json.Marshaler
 }
 
 // CNameManager represents a provisioner that supports cname on applications.

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -196,6 +196,10 @@ type App interface {
 
 	GetQuota() quota.Quota
 	SetQuotaInUse(int) error
+
+	GetCname() []string
+
+	GetIp() string
 }
 
 // CNameManager represents a provisioner that supports cname on applications.

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"time"
 
 	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/quota"
@@ -202,7 +203,19 @@ type App interface {
 
 	GetIp() string
 
-	GetLock() json.Marshaler
+	GetLock() AppLock
+}
+
+type AppLock interface {
+	json.Marshaler
+
+	GetLocked() bool
+
+	GetReason() string
+
+	GetOwner() string
+
+	GetAcquireDate() time.Time
 }
 
 // CNameManager represents a provisioner that supports cname on applications.

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -986,6 +986,10 @@ func (p *FakeProvisioner) ValidAppImages(appName string) ([]string, error) {
 	return []string{"app-image-old", "app-image"}, nil
 }
 
+func (p *FakeProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) []provision.App {
+	return apps
+}
+
 type PipelineFakeProvisioner struct {
 	*FakeProvisioner
 	executedPipeline bool

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -996,7 +996,27 @@ func (p *FakeProvisioner) ValidAppImages(appName string) ([]string, error) {
 }
 
 func (p *FakeProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) ([]provision.App, error) {
-	return apps, nil
+	filteredApps := []provision.App{}
+	for i := range apps {
+		units, _ := p.Units(apps[i])
+		for _, u := range units {
+			if stringInArray(u.Status.String(), status) {
+				filteredApps = append(filteredApps, apps[i])
+				break
+			}
+		}
+	}
+	return filteredApps, nil
+}
+
+func stringInArray(value string, array []string) bool {
+	for _, str := range array {
+		if str == value {
+			return true
+		}
+	}
+
+	return false
 }
 
 type PipelineFakeProvisioner struct {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -986,8 +986,8 @@ func (p *FakeProvisioner) ValidAppImages(appName string) ([]string, error) {
 	return []string{"app-image-old", "app-image"}, nil
 }
 
-func (p *FakeProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) []provision.App {
-	return apps
+func (p *FakeProvisioner) FilterAppsByUnitStatus(apps []provision.App, status []string) ([]provision.App, error) {
+	return apps, nil
 }
 
 type PipelineFakeProvisioner struct {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1015,7 +1015,6 @@ func stringInArray(value string, array []string) bool {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -5,6 +5,7 @@
 package provisiontest
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -268,6 +269,10 @@ func (a *FakeApp) UnsetEnvs(unsetEnvs bind.UnsetEnvApp, w io.Writer) error {
 
 func (a *FakeApp) GetIp() string {
 	return ""
+}
+
+func (a *FakeApp) GetLock() json.Marshaler {
+	return nil
 }
 
 func (a *FakeApp) GetUnits() ([]bind.Unit, error) {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -5,7 +5,6 @@
 package provisiontest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -271,7 +270,7 @@ func (a *FakeApp) GetIp() string {
 	return ""
 }
 
-func (a *FakeApp) GetLock() json.Marshaler {
+func (a *FakeApp) GetLock() provision.AppLock {
 	return nil
 }
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -31,6 +31,7 @@ func init() {
 // Fake implementation for provision.App.
 type FakeApp struct {
 	name           string
+	cname          []string
 	platform       string
 	units          []provision.Unit
 	logs           []string
@@ -139,6 +140,10 @@ func (a *FakeApp) SetQuotaInUse(inUse int) error {
 	}
 	a.Quota.InUse = inUse
 	return nil
+}
+
+func (a *FakeApp) GetCname() []string {
+	return a.cname
 }
 
 func (a *FakeApp) GetInstances(serviceName string) []bind.ServiceInstance {

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -1167,9 +1167,9 @@ func (s *S) TestFakeProvisionerFilterAppsByUnitStatus(c *check.C) {
 	err = p.Provision(app2)
 	c.Assert(err, check.IsNil)
 
-	unit := provision.Unit{AppName: "fairy-tale", ID: "unit/1", Status: provision.StatusStarting }
+	unit := provision.Unit{AppName: "fairy-tale", ID: "unit/1", Status: provision.StatusStarting}
 	p.AddUnit(app1, unit)
-	unit = provision.Unit{AppName: "unfairy-tale", ID: "unit/2", Status: provision.StatusStarting }
+	unit = provision.Unit{AppName: "unfairy-tale", ID: "unit/2", Status: provision.StatusStarting}
 	p.AddUnit(app2, unit)
 	err = p.SetUnitStatus(unit, provision.StatusError)
 	c.Assert(err, check.IsNil)

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -190,6 +190,12 @@ func (s *S) TestFakeAppSetQuotaInUse(c *check.C) {
 	c.Assert(e.Requested, check.Equals, uint(q.Limit+1))
 }
 
+func (s *S) TestFakeAppGetCname(c *check.C) {
+	app := NewFakeApp("sou", "otm", 0)
+	app.cname = []string{"cname1", "cname2"}
+	c.Assert(app.GetCname(), check.DeepEquals, []string{"cname1", "cname2"})
+}
+
 func (s *S) TestFakeAppGetInstances(c *check.C) {
 	instance1 := bind.ServiceInstance{Name: "inst1"}
 	instance2 := bind.ServiceInstance{Name: "inst2"}

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -1160,21 +1160,17 @@ func (s *S) TestFakeProvisionerMetricEnvs(c *check.C) {
 func (s *S) TestFakeProvisionerFilterAppsByUnitStatus(c *check.C) {
 	app1 := NewFakeApp("fairy-tale", "shaman", 1)
 	app2 := NewFakeApp("unfairy-tale", "shaman", 1)
-
 	p := NewFakeProvisioner()
 	err := p.Provision(app1)
 	c.Assert(err, check.IsNil)
 	err = p.Provision(app2)
 	c.Assert(err, check.IsNil)
-
 	unit := provision.Unit{AppName: "fairy-tale", ID: "unit/1", Status: provision.StatusStarting}
 	p.AddUnit(app1, unit)
 	unit = provision.Unit{AppName: "unfairy-tale", ID: "unit/2", Status: provision.StatusStarting}
 	p.AddUnit(app2, unit)
 	err = p.SetUnitStatus(unit, provision.StatusError)
 	c.Assert(err, check.IsNil)
-
-	// Should return apps with units containing status
 	apps, err := p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"starting"})
 	c.Assert(apps, check.DeepEquals, []provision.App{app1})
 	c.Assert(err, check.IsNil)

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -1156,3 +1156,26 @@ func (s *S) TestFakeProvisionerMetricEnvs(c *check.C) {
 	expected := map[string]string{"METRICS_BACKEND": "fake"}
 	c.Assert(envs, check.DeepEquals, expected)
 }
+
+func (s *S) TestFakeProvisionerFilterAppsByUnitStatus(c *check.C) {
+	app1 := NewFakeApp("fairy-tale", "shaman", 1)
+	app2 := NewFakeApp("unfairy-tale", "shaman", 1)
+
+	p := NewFakeProvisioner()
+	err := p.Provision(app1)
+	c.Assert(err, check.IsNil)
+	err = p.Provision(app2)
+	c.Assert(err, check.IsNil)
+
+	unit := provision.Unit{AppName: "fairy-tale", ID: "unit/1", Status: provision.StatusStarting }
+	p.AddUnit(app1, unit)
+	unit = provision.Unit{AppName: "unfairy-tale", ID: "unit/2", Status: provision.StatusStarting }
+	p.AddUnit(app2, unit)
+	err = p.SetUnitStatus(unit, provision.StatusError)
+	c.Assert(err, check.IsNil)
+
+	// Should return apps with units containing status
+	apps, err := p.FilterAppsByUnitStatus([]provision.App{app1, app2}, []string{"starting"})
+	c.Assert(apps, check.DeepEquals, []provision.App{app1})
+	c.Assert(err, check.IsNil)
+}

--- a/repository/gandalf/gandalf.go
+++ b/repository/gandalf/gandalf.go
@@ -90,13 +90,13 @@ func Sync(w io.Writer) error {
 			},
 			{
 				Scheme:  permission.PermAppDeploy,
-				Context: permission.Context(permission.CtxPool, app.Pool),
+				Context: permission.Context(permission.CtxPool, app.GetPool()),
 			},
 		}
-		for _, t := range app.GetTeams() {
+		for _, name := range app.GetTeamsName() {
 			allowedPerms = append(allowedPerms, permission.Permission{
 				Scheme:  permission.PermAppDeploy,
-				Context: permission.Context(permission.CtxTeam, t.Name),
+				Context: permission.Context(permission.CtxTeam, name),
 			})
 		}
 		users, err := auth.ListUsersWithPermissions(allowedPerms...)
@@ -107,8 +107,8 @@ func Sync(w io.Writer) error {
 		for i := range users {
 			userNames[i] = users[i].Email
 		}
-		fmt.Fprintf(w, "Syncing app %q... ", app.Name)
-		err = m.CreateRepository(app.Name, userNames)
+		fmt.Fprintf(w, "Syncing app %q... ", app.GetName())
+		err = m.CreateRepository(app.GetName(), userNames)
 		switch err {
 		case repository.ErrRepositoryAlreadExists:
 			fmt.Fprintln(w, "already present in Gandalf")
@@ -118,7 +118,7 @@ func Sync(w io.Writer) error {
 			return err
 		}
 		for _, user := range userNames {
-			m.GrantAccess(app.Name, user)
+			m.GrantAccess(app.GetName(), user)
 		}
 	}
 	return nil


### PR DESCRIPTION
Adds support to filter app list by unit status. You can pass more than one status, separated by `,`:

```
curl -H 'Authorization: b token'  "http://localhost:8080/apps?status=stopped,asleep"
```