### PR TITLE
Supports for '512M' as value for memory and swap

### DIFF
--- a/api/plan.go
+++ b/api/plan.go
@@ -20,7 +20,6 @@ func addPlan(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	cpuShare, _ := strconv.Atoi(r.FormValue("cpushare"))
 	isDefault, _ := strconv.ParseBool(r.FormValue("default"))
 	memory := getSize(r.FormValue("memory"))
-
 	swap := getSize(r.FormValue("swap"))
 	plan := app.Plan{
 		Name:     r.FormValue("name"),

--- a/api/plan.go
+++ b/api/plan.go
@@ -112,7 +112,6 @@ func getSize(formValue string) int64 {
 		default:
 			return 0
 		}
-	} else {
-		return value
 	}
+	return value
 }

--- a/api/plan.go
+++ b/api/plan.go
@@ -19,8 +19,9 @@ import (
 func addPlan(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	cpuShare, _ := strconv.Atoi(r.FormValue("cpushare"))
 	isDefault, _ := strconv.ParseBool(r.FormValue("default"))
-	memory, _ := strconv.ParseInt(r.FormValue("memory"), 10, 64)
-	swap, _ := strconv.ParseInt(r.FormValue("swap"), 10, 64)
+	memory := getSize(r.FormValue("memory"))
+
+	swap := getSize(r.FormValue("swap"))
 	plan := app.Plan{
 		Name:     r.FormValue("name"),
 		Memory:   memory,
@@ -94,4 +95,25 @@ func listRouters(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(routers)
+}
+
+func getSize(formValue string) int64 {
+	const OneKbInBytes = 1024
+	value, err := strconv.ParseInt(formValue, 10, 64)
+	if err != nil {
+		unit := formValue[len(formValue)-1:]
+		size, _ := strconv.ParseInt(formValue[0:len(formValue)-1], 10, 64)
+		switch unit {
+		case "K":
+			return size * OneKbInBytes
+		case "M":
+			return size * OneKbInBytes * OneKbInBytes
+		case "G":
+			return size * OneKbInBytes * OneKbInBytes * OneKbInBytes
+		default:
+			return 0
+		}
+	} else {
+		return value
+	}
 }

--- a/api/plan_test.go
+++ b/api/plan_test.go
@@ -36,6 +36,63 @@ func (s *S) TestPlanAdd(c *check.C) {
 	})
 }
 
+func (s *S) TestPlanAddWithMegabyteAsMemoryUnit(c *check.C) {
+	recorder := httptest.NewRecorder()
+	body := strings.NewReader("name=xyz&memory=512M&swap=1024&cpushare=100&router=fake")
+	request, err := http.NewRequest("POST", "/plans", body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	m := RunServer(true)
+	m.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
+	defer s.conn.Plans().RemoveAll(nil)
+	var plans []app.Plan
+	err = s.conn.Plans().Find(nil).All(&plans)
+	c.Assert(err, check.IsNil)
+	c.Assert(plans, check.DeepEquals, []app.Plan{
+		{Name: "xyz", Memory: 536870912, Swap: 1024, CpuShare: 100, Router: "fake"},
+	})
+}
+
+func (s *S) TestPlanAddWithMegabyteAsSwapUnit(c *check.C) {
+	recorder := httptest.NewRecorder()
+	body := strings.NewReader("name=xyz&memory=512M&swap=1024&cpushare=100&router=fake")
+	request, err := http.NewRequest("POST", "/plans", body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	m := RunServer(true)
+	m.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
+	defer s.conn.Plans().RemoveAll(nil)
+	var plans []app.Plan
+	err = s.conn.Plans().Find(nil).All(&plans)
+	c.Assert(err, check.IsNil)
+	c.Assert(plans, check.DeepEquals, []app.Plan{
+		{Name: "xyz", Memory: 536870912, Swap: 1024, CpuShare: 100, Router: "fake"},
+	})
+}
+
+func (s *S) TestPlanAddWithGigabyteAsMemoryUnit(c *check.C) {
+	recorder := httptest.NewRecorder()
+	body := strings.NewReader("name=xyz&memory=9223372036854775807&swap=512M&cpushare=100&router=fake")
+	request, err := http.NewRequest("POST", "/plans", body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	m := RunServer(true)
+	m.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
+	defer s.conn.Plans().RemoveAll(nil)
+	var plans []app.Plan
+	err = s.conn.Plans().Find(nil).All(&plans)
+	c.Assert(err, check.IsNil)
+	c.Assert(plans, check.DeepEquals, []app.Plan{
+		{Name: "xyz", Memory: 9223372036854775807, Swap: 536870912, CpuShare: 100, Router: "fake"},
+	})
+}
+
 func (s *S) TestPlanAddWithNoPermission(c *check.C) {
 	token := userWithPermission(c)
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
This is related to #1394.

With this change, It should be possible to user to use the following notation in order to create a plan:

`$ tsuru-admin plan-create basics -c 2 -m 1G -s 1G -r hipache -d`

The following options are available:
- K for kilobytes
- M for megabytes
- G for gigabytes

This is my first PR for a Golang project, so I'm not so sure about where the function `getSize ` should be placed, but some feedback is welcome :)

