### PR TITLE
[docs] Fix root-user-create call

### DIFF
--- a/docs/installing/api.rst
+++ b/docs/installing/api.rst
@@ -136,7 +136,7 @@ For a description
 
 ::
 
-    $ tsurud [--config <path to tsuru.conf>] root-user-create myemail@somewhere.com
+    $ tsurud root-user-create [--config <path to tsuru.conf>] myemail@somewhere.com
     # type a password and confirmation (only if using native auth scheme)
 
     $ sudo apt-get install tsuru-client


### PR DESCRIPTION
This fixes:

```
flag provided but not defined: --config
Usage of tsuru flags:
-h, --help  (= false)
    Display help and exit
-v, --verbosity  (= 0)
    Verbosity level: 1 => print HTTP requests; 2 => print HTTP requests/responses
--version  (= false)
    Print version and exit
```