### PR TITLE
Update returns a 404 when platform is not found

### DIFF
--- a/api/platform.go
+++ b/api/platform.go
@@ -68,6 +68,7 @@ func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 // responses:
 //   200: Platform updated
 //   401: Unauthorized
+//   404: Not found
 func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	defer r.Body.Close()
 	name := r.URL.Query().Get(":name")
@@ -94,6 +95,9 @@ func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error 
 		Output: writer,
 	})
 	if err != nil {
+		if err == app.ErrPlatformNotFound {
+			return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
+		}
 		writer.Encode(io.SimpleJsonMessage{Error: err.Error()})
 		writer.Write([]byte("Failed to update platform!\n"))
 		return nil

--- a/api/platform.go
+++ b/api/platform.go
@@ -94,10 +94,10 @@ func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error 
 		Input:  file,
 		Output: writer,
 	})
+	if err == app.ErrPlatformNotFound {
+		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
+	}
 	if err != nil {
-		if err == app.ErrPlatformNotFound {
-			return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
-		}
 		writer.Encode(io.SimpleJsonMessage{Error: err.Error()})
 		writer.Write([]byte("Failed to update platform!\n"))
 		return nil

--- a/api/platform_test.go
+++ b/api/platform_test.go
@@ -250,8 +250,6 @@ func (*PlatformSuite) TestPlatformUpdateNotFound(c *check.C) {
 	recorder := httptest.NewRecorder()
 	m := RunServer(true)
 	m.ServeHTTP(recorder, request)
-	var msg io.SimpleJsonMessage
-	json.Unmarshal(recorder.Body.Bytes(), &msg)
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
 }
 


### PR DESCRIPTION
Make update on platform behaves like delete when resource is not found