### PR TITLE
provision/docker: unset memory limits for builder container

### DIFF
--- a/provision/docker/container/container_test.go
+++ b/provision/docker/container/container_test.go
@@ -329,7 +329,7 @@ func (s *S) TestContainerCreateForDeploy(c *check.C) {
 	c.Assert(dockerContainer.HostConfig.Memory, check.Equals, int64(0))
 	c.Assert(dockerContainer.HostConfig.MemorySwap, check.Equals, int64(0))
 	c.Assert(dockerContainer.HostConfig.CPUShares, check.Equals, int64(50))
-	c.Assert(dockerContainer.HostConfig.OomScoreAdj, check.Equals, int(1000))
+	c.Assert(dockerContainer.HostConfig.OomScoreAdj, check.Equals, 1000)
 }
 
 func (s *S) TestContainerCreateDoesNotSetEnvs(c *check.C) {

--- a/provision/docker/container/container_test.go
+++ b/provision/docker/container/container_test.go
@@ -149,7 +149,7 @@ func (s *S) TestContainerCreate(c *check.C) {
 	c.Assert(container.HostConfig.Memory, check.Equals, int64(15))
 	c.Assert(container.HostConfig.MemorySwap, check.Equals, int64(30))
 	c.Assert(container.HostConfig.CPUShares, check.Equals, int64(50))
-	c.Assert(container.HostConfig.OomScoreAdj, check.Equals, int(0))
+	c.Assert(container.HostConfig.OomScoreAdj, check.Equals, 0)
 	c.Assert(cont.Status, check.Equals, "created")
 }
 

--- a/provision/docker/container/container_test.go
+++ b/provision/docker/container/container_test.go
@@ -149,6 +149,7 @@ func (s *S) TestContainerCreate(c *check.C) {
 	c.Assert(container.HostConfig.Memory, check.Equals, int64(15))
 	c.Assert(container.HostConfig.MemorySwap, check.Equals, int64(30))
 	c.Assert(container.HostConfig.CPUShares, check.Equals, int64(50))
+	c.Assert(container.HostConfig.OomScoreAdj, check.Equals, int(0))
 	c.Assert(cont.Status, check.Equals, "created")
 }
 
@@ -325,9 +326,10 @@ func (s *S) TestContainerCreateForDeploy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(dockerContainer.HostConfig.RestartPolicy.Name, check.Equals, "")
 	c.Assert(dockerContainer.HostConfig.LogConfig.Type, check.Equals, "")
-	c.Assert(dockerContainer.HostConfig.Memory, check.Equals, int64(15))
-	c.Assert(dockerContainer.HostConfig.MemorySwap, check.Equals, int64(30))
+	c.Assert(dockerContainer.HostConfig.Memory, check.Equals, int64(0))
+	c.Assert(dockerContainer.HostConfig.MemorySwap, check.Equals, int64(0))
 	c.Assert(dockerContainer.HostConfig.CPUShares, check.Equals, int64(50))
+	c.Assert(dockerContainer.HostConfig.OomScoreAdj, check.Equals, int(1000))
 }
 
 func (s *S) TestContainerCreateDoesNotSetEnvs(c *check.C) {


### PR DESCRIPTION
Unset memory limits for builder container and give it a highest score possible on a container OOM kill event.