### PR TITLE
Update gandalf.rst

### DIFF
--- a/docs/installing/gandalf.rst
+++ b/docs/installing/gandalf.rst
@@ -76,11 +76,15 @@ address:
     EOF
 
 In the ``/etc/gandalf.conf`` file, remove the comment from the line "template:
-/home/git/bare-template", so it looks like that:
+/home/git/bare-template" and from the line "database", so it looks like that:
 
 .. highlight:: yaml
 
 ::
+
+    database:
+      url: <your-mongodb-server>:27017
+      name: gandalf
 
     git:
       bare:


### PR DESCRIPTION
Adding the information about mongodb server. Most people have problem at this steps because they receive the message "No reachable servers" on tsuru-api and have no idea that the problem is with the communication between gandalf and mongodb.