### PR TITLE
app/deploy: reject images that are not valid for rollback

### DIFF
--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -1115,30 +1115,12 @@ func (s *DeploySuite) TestDeployRollbackHandlerWithInexistVersion(c *check.C) {
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	server := RunServer(true)
 	server.ServeHTTP(recorder, request)
-	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/x-json-stream")
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	c.Assert(recorder.Body.String(), check.Equals, "{\"Message\":\"Rollback deploy called\"}\n")
-	c.Assert(eventtest.EventDesc{
-		Target: appTarget(a.Name),
-		Owner:  s.token.GetUserName(),
-		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
-			"app.name":   a.Name,
-			"commit":     "",
-			"filesize":   0,
-			"kind":       "rollback",
-			"archiveurl": "",
-			"user":       s.token.GetUserName(),
-			"image":      "v3",
-			"origin":     "rollback",
-			"build":      false,
-			"rollback":   true,
-		},
-		EndCustomData: map[string]interface{}{
-			"image": "v3",
-		},
-	}, eventtest.HasEvent)
+	var body map[string]string
+	err = json.Unmarshal(recorder.Body.Bytes(), &body)
+	c.Assert(err, check.IsNil)
+	c.Assert(body, check.DeepEquals, map[string]string{"Message": "", "Error": `invalid version: "v3"`})
 }
 
 func (s *DeploySuite) TestDiffDeploy(c *check.C) {

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -199,11 +199,15 @@ func Deploy(opts DeployOptions) (string, error) {
 	if opts.Rollback && !regexp.MustCompile(":v[0-9]+$").MatchString(opts.Image) {
 		validImages, err := findValidImages(opts.App.Name)
 		if err == nil {
+			inputImage := opts.Image
 			for img := range validImages {
 				if strings.HasSuffix(img, opts.Image) {
 					opts.Image = img
 					break
 				}
+			}
+			if opts.Image == inputImage {
+				return "", fmt.Errorf("invalid version: %q", inputImage)
 			}
 		}
 	}

--- a/app/deploy_test.go
+++ b/app/deploy_test.go
@@ -717,8 +717,9 @@ func (s *S) TestRollbackWithWrongVersionImage(c *check.C) {
 		Rollback:     true,
 		Event:        evt,
 	})
-	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "v20")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `^invalid version: "v20"$`)
+	c.Assert(imgID, check.Equals, "")
 }
 
 func (s *S) TestDeployKind(c *check.C) {


### PR DESCRIPTION
Tsuru accepts any value as a parameter to app-deploy-rollback, and you won't believe what happens next:

```
% tsuru app-deploy-rollback app-deploy-rollback --app test-chico
Are you sure you want to rollback app "test-chico" to image "app-deploy-rollback"? (y/n) y

---- Starting 0 new units  ----

---- Binding and checking 0 new units ----

---- Setting router healthcheck (Path: /) ----

---- Removing routes from old units ----
 ---> Removed route from unit b7df34b7b8 [web]

---- Removing 1 old unit ----
 ---> Removed old unit b7df34b7b8 [web]

---- Unbinding 1 old unit ----
 ---> Removed bind for old unit b7df34b7b8 [web]
% tsuru app-deploy-list -a test-chico
+-------------------------+----------+--------+-------------------------+-------+
| Image (Rollback)        | Origin   | User   | Date (Duration)         | Error |
+-------------------------+----------+--------+-------------------------+-------+
| app-deploy-rollback (*) | rollback | fsouza | Aug 16 10:48:32 (00:02) |       |
+-------------------------+----------+--------+-------------------------+-------+
| v40 (*)                 | rollback | fsouza | Aug 16 10:42:55 (00:04) |       |
+-------------------------+----------+--------+-------------------------+-------+
| v41 (*)                 |          | fsouza | Aug 16 10:28:33 (00:34) |       |
+-------------------------+----------+--------+-------------------------+-------+
% tsuru app-restart -a test-chico
---- Restarting the app "test-chico" ----

---- Starting 0 new units  ----

---- Binding and checking 0 new units ----

---- Setting router healthcheck (Path: /) ----

---- Removing 0 old units ----

---- Unbinding 0 old units ----
% tsuru unit-add -a test-chico 1

---- Starting 1 new unit [: 1] ----

**** ROLLING BACK AFTER FAILURE ****
 ---> CreateContainer: maximum number of tries exceeded, last error: error in docker node "http://server1:2375" running command "createContainer": no such image <---
Error: CreateContainer: maximum number of tries exceeded, last error: error in docker node "http://server2:2375" running command "createContainer": no such image
```

The change in this PR fixes this issue.