### PR TITLE
Properly save and display origin for git-based deployments

### DIFF
--- a/api/deploy.go
+++ b/api/deploy.go
@@ -108,6 +108,9 @@ func deploy(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 			message = messages[0]
 		}
 	}
+	if origin == "" && commit != "" {
+		origin = "git"
+	}
 	opts := app.DeployOptions{
 		App:        instance,
 		Commit:     commit,

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -373,7 +373,7 @@ func (s *DeploySuite) TestDeployWithCommit(c *check.C) {
 			"archiveurl": "http://something.tar.gz",
 			"user":       "fulano",
 			"image":      "",
-			"origin":     "",
+			"origin":     "git",
 			"build":      false,
 			"rollback":   false,
 			"message":    "msg1",

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -839,6 +839,7 @@ func (s *DeploySuite) TestDeployInfoByAdminUser(c *check.C) {
 		{App: "g1", Timestamp: timestamp, Commit: "e82nn93nd93mm12o2ueh83dhbd3iu112", Error: ""},
 	}
 	lastDeploy := depData[1]
+	lastDeploy.Origin = "git"
 	evts := insertDeploysAsEvents(depData, c)
 	url := fmt.Sprintf("/deploys/%s", evts[1].UniqueID.Hex())
 	request, err := http.NewRequest("GET", url, nil)

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -131,7 +131,7 @@ func eventToDeployData(evt *event.Event, validImages set, full bool) *DeployData
 	err := evt.StartData(&startOpts)
 	if err == nil {
 		data.Commit = startOpts.Commit
-		data.Origin = startOpts.Origin
+		data.Origin = startOpts.GetOrigin()
 	}
 	if full {
 		data.Log = evt.Log
@@ -171,6 +171,16 @@ type DeployOptions struct {
 	Event        *event.Event `bson:"-"`
 	Kind         DeployKind
 	Message      string
+}
+
+func (o *DeployOptions) GetOrigin() string {
+	if o.Origin != "" {
+		return o.Origin
+	}
+	if o.Commit != "" {
+		return "git"
+	}
+	return ""
 }
 
 func (o *DeployOptions) GetKind() (kind DeployKind) {


### PR DESCRIPTION
This PR includes two fixes to #1454:

1. When displaying deployment information, set origin to "git" whenever origin is not defined and commit is defined
1. When saving a new deployment, set origin to "git" whenever origin is not defined and commit is defined, like tsuru used to do before the release of 1.1

The first fix can be replaced with a migration that make all deployments compatible with the logic implemented by the second fix. I wanted to open the pull request and let anyone jump in with thoughts/suggestions.

Fix #1454.