### PR TITLE
Allow the customization of the email template for reset-password message

### DIFF
--- a/auth/native/data.go
+++ b/auth/native/data.go
@@ -10,16 +10,12 @@ import (
 	"github.com/tsuru/config"
 )
 
-
 var passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_@#$%^&*()~[]{}?=-+,.<>:;`"
 
-func getEmailResetPasswordTemplate() (*template.Template) {
+func getEmailResetPasswordTemplate() (*template.Template, error) {
 	templateFile, _ := config.GetString("reset-password-template")
 	if templateFile != "" {
-		tmp, err := template.ParseFiles(templateFile)
-		if err == nil {
-			return tmp
-		}
+		return template.ParseFiles(templateFile)
 	}
 	return template.Must(template.New("reset").Parse(`Subject: [tsuru] Password reset process
 To: {{.UserEmail}}
@@ -29,16 +25,13 @@ need to use the following token to finish this process:
 
 {{.Token}}
 
-If you think this is email is wrong, just ignore it.`))
+If you think this is email is wrong, just ignore it.`)), nil
 }
 
-func getEmailResetPasswordSucessfullyTemplate() (*template.Template) {
+func getEmailResetPasswordSucessfullyTemplate() (*template.Template, error) {
 	templateFile, _ := config.GetString("reset-password-successfully-template")
 	if templateFile != "" {
-		tmp, err := template.ParseFiles(templateFile)
-		if err == nil {
-			return tmp
-		}
+		return template.ParseFiles(templateFile)
 	}
 	return template.Must(template.New("reset").Parse(`Subject: [tsuru] Password successfully reset
 To: {{.email}}
@@ -49,5 +42,5 @@ This message is the confirmation that your password has been reset. The new pass
 
 {{.password}}
 
-Use it to authenticate with tsuru server, and change it later.`))
+Use it to authenticate with tsuru server, and change it later.`)), nil
 }

--- a/auth/native/data.go
+++ b/auth/native/data.go
@@ -4,9 +4,24 @@
 
 package native
 
-import "text/template"
+import (
+	"text/template"
 
-var resetEmailData = template.Must(template.New("reset").Parse(`Subject: [tsuru] Password reset process
+	"github.com/tsuru/config"
+)
+
+
+var passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_@#$%^&*()~[]{}?=-+,.<>:;`"
+
+func getEmailResetPasswordTemplate() (*template.Template) {
+	templateFile, _ := config.GetString("email-reset-password-template-file")
+	if templateFile != "" {
+		tmp, err := template.ParseFiles(templateFile)
+		if err == nil {
+			return tmp
+		}
+	}
+	return template.Must(template.New("reset").Parse(`Subject: [tsuru] Password reset process
 To: {{.UserEmail}}
 
 Someone, hopefully you, requested to reset your password on tsuru. You will
@@ -15,8 +30,17 @@ need to use the following token to finish this process:
 {{.Token}}
 
 If you think this is email is wrong, just ignore it.`))
+}
 
-var passwordResetConfirm = template.Must(template.New("reset").Parse(`Subject: [tsuru] Password successfully reset
+func getEmailResetPasswordSucessfullyTemplate() (*template.Template) {
+	templateFile, _ := config.GetString("email-reset-password-successfully-template-file")
+	if templateFile != "" {
+		tmp, err := template.ParseFiles(templateFile)
+		if err == nil {
+			return tmp
+		}
+	}
+	return template.Must(template.New("reset").Parse(`Subject: [tsuru] Password successfully reset
 To: {{.email}}
 
 Greetings!
@@ -26,5 +50,4 @@ This message is the confirmation that your password has been reset. The new pass
 {{.password}}
 
 Use it to authenticate with tsuru server, and change it later.`))
-
-var passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_@#$%^&*()~[]{}?=-+,.<>:;`"
+}

--- a/auth/native/data.go
+++ b/auth/native/data.go
@@ -14,7 +14,7 @@ import (
 var passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_@#$%^&*()~[]{}?=-+,.<>:;`"
 
 func getEmailResetPasswordTemplate() (*template.Template) {
-	templateFile, _ := config.GetString("email-reset-password-template-file")
+	templateFile, _ := config.GetString("reset-password-template")
 	if templateFile != "" {
 		tmp, err := template.ParseFiles(templateFile)
 		if err == nil {
@@ -33,7 +33,7 @@ If you think this is email is wrong, just ignore it.`))
 }
 
 func getEmailResetPasswordSucessfullyTemplate() (*template.Template) {
-	templateFile, _ := config.GetString("email-reset-password-successfully-template-file")
+	templateFile, _ := config.GetString("reset-password-successfully-template")
 	if templateFile != "" {
 		tmp, err := template.ParseFiles(templateFile)
 		if err == nil {

--- a/auth/native/data_test.go
+++ b/auth/native/data_test.go
@@ -23,8 +23,8 @@ func (s *S) TestResetWithoutTemplate(c *check.C) {
 }
 
 func (s *S) TestResetWithTemplate(c *check.C) {
-	config.Set("email-reset-password-template-file", "testdata/email-reset-password.txt")
-	defer config.Unset("email-reset-password-template-file")
+	config.Set("reset-password-template", "testdata/email-reset-password.txt")
+	defer config.Unset("reset-password-template")
 	var email bytes.Buffer
 	tmp := getEmailResetPasswordTemplate()
 	err := tmp.Execute(&email, nil)
@@ -33,8 +33,8 @@ func (s *S) TestResetWithTemplate(c *check.C) {
 }
 
 func (s *S) TestResetWithNotFoundTemplate(c *check.C) {
-	config.Set("email-reset-password-template-file", "testdata/wrong-email-reset-password.txt")
-	defer config.Unset("email-reset-password-template-file")
+	config.Set("reset-password-template", "testdata/wrong-email-reset-password.txt")
+	defer config.Unset("reset-password-template")
 	var email bytes.Buffer
 	tmp := getEmailResetPasswordTemplate()
 	err := tmp.Execute(&email, nil)
@@ -51,8 +51,8 @@ func (s *S) TestResetSuccessWithoutTemplate(c *check.C) {
 }
 
 func (s *S) TestResetSuccessWithTemplate(c *check.C) {
-	config.Set("email-reset-password-successfully-template-file", "testdata/email-reset-success.txt")
-	defer config.Unset("email-reset-password-successfully-template-file")
+	config.Set("reset-password-successfully-template", "testdata/email-reset-success.txt")
+	defer config.Unset("reset-password-successfully-template")
 	var email bytes.Buffer
 	tmp := getEmailResetPasswordSucessfullyTemplate()
 	err := tmp.Execute(&email, nil)
@@ -61,8 +61,8 @@ func (s *S) TestResetSuccessWithTemplate(c *check.C) {
 }
 
 func (s *S) TestResetSuccessWithWrongTemplate(c *check.C) {
-	config.Set("email-reset-password-successfully-template-file", "testdata/wrong-email-reset-success.txt")
-	defer config.Unset("email-reset-password-successfully-template-file")
+	config.Set("reset-password-successfully-template", "testdata/wrong-email-reset-success.txt")
+	defer config.Unset("reset-password-successfully-template")
 	var email bytes.Buffer
 	tmp := getEmailResetPasswordSucessfullyTemplate()
 	err := tmp.Execute(&email, nil)

--- a/auth/native/data_test.go
+++ b/auth/native/data_test.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"strings"
 
-	"gopkg.in/check.v1"
-
 	"github.com/tsuru/config"
+	"gopkg.in/check.v1"
 )
 
 const resetDefaultContent = "Someone, hopefully you, requested to reset your password on tsuru"

--- a/auth/native/data_test.go
+++ b/auth/native/data_test.go
@@ -16,8 +16,9 @@ const successTemplateContent = "Congrats!"
 
 func (s *S) TestResetWithoutTemplate(c *check.C) {
 	var email bytes.Buffer
-	tmp := getEmailResetPasswordTemplate()
-	err := tmp.Execute(&email, nil)
+	tmp, err := getEmailResetPasswordTemplate()
+	c.Assert(err, check.IsNil)
+	err = tmp.Execute(&email, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.Contains(email.String(), resetDefaultContent), check.Equals, true)
 }
@@ -26,8 +27,9 @@ func (s *S) TestResetWithTemplate(c *check.C) {
 	config.Set("reset-password-template", "testdata/email-reset-password.txt")
 	defer config.Unset("reset-password-template")
 	var email bytes.Buffer
-	tmp := getEmailResetPasswordTemplate()
-	err := tmp.Execute(&email, nil)
+	tmp, err := getEmailResetPasswordTemplate()
+	c.Assert(err, check.IsNil)
+	err = tmp.Execute(&email, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.Contains(email.String(), resetTemplateContent), check.Equals, true)
 }
@@ -35,17 +37,16 @@ func (s *S) TestResetWithTemplate(c *check.C) {
 func (s *S) TestResetWithNotFoundTemplate(c *check.C) {
 	config.Set("reset-password-template", "testdata/wrong-email-reset-password.txt")
 	defer config.Unset("reset-password-template")
-	var email bytes.Buffer
-	tmp := getEmailResetPasswordTemplate()
-	err := tmp.Execute(&email, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(strings.Contains(email.String(), resetDefaultContent), check.Equals, true)
+	tmp, err := getEmailResetPasswordTemplate()
+	c.Assert(tmp, check.IsNil)
+	c.Assert(err, check.NotNil)
 }
 
 func (s *S) TestResetSuccessWithoutTemplate(c *check.C) {
 	var email bytes.Buffer
-	tmp := getEmailResetPasswordSucessfullyTemplate()
-	err := tmp.Execute(&email, nil)
+	tmp, err := getEmailResetPasswordSucessfullyTemplate()
+	c.Assert(err, check.IsNil)
+	err = tmp.Execute(&email, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.Contains(email.String(), successDefaultContent), check.Equals, true)
 }
@@ -54,8 +55,9 @@ func (s *S) TestResetSuccessWithTemplate(c *check.C) {
 	config.Set("reset-password-successfully-template", "testdata/email-reset-success.txt")
 	defer config.Unset("reset-password-successfully-template")
 	var email bytes.Buffer
-	tmp := getEmailResetPasswordSucessfullyTemplate()
-	err := tmp.Execute(&email, nil)
+	tmp, err := getEmailResetPasswordSucessfullyTemplate()
+	c.Assert(err, check.IsNil)
+	err = tmp.Execute(&email, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.Contains(email.String(), successTemplateContent), check.Equals, true)
 }
@@ -63,9 +65,7 @@ func (s *S) TestResetSuccessWithTemplate(c *check.C) {
 func (s *S) TestResetSuccessWithWrongTemplate(c *check.C) {
 	config.Set("reset-password-successfully-template", "testdata/wrong-email-reset-success.txt")
 	defer config.Unset("reset-password-successfully-template")
-	var email bytes.Buffer
-	tmp := getEmailResetPasswordSucessfullyTemplate()
-	err := tmp.Execute(&email, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(strings.Contains(email.String(), successDefaultContent), check.Equals, true)
+	tmp, err := getEmailResetPasswordSucessfullyTemplate()
+	c.Assert(tmp, check.IsNil)
+	c.Assert(err, check.NotNil)
 }

--- a/auth/native/data_test.go
+++ b/auth/native/data_test.go
@@ -1,0 +1,71 @@
+package native
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/check.v1"
+
+	"github.com/tsuru/config"
+)
+
+const resetDefaultContent = "Someone, hopefully you, requested to reset your password on tsuru"
+const resetTemplateContent = "It is an email template to reset password"
+const successDefaultContent = "Greetings!"
+const successTemplateContent = "Congrats!"
+
+func (s *S) TestResetWithoutTemplate(c *check.C) {
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), resetDefaultContent), check.Equals, true)
+}
+
+func (s *S) TestResetWithTemplate(c *check.C) {
+	config.Set("email-reset-password-template-file", "testdata/email-reset-password.txt")
+	defer config.Unset("email-reset-password-template-file")
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), resetTemplateContent), check.Equals, true)
+}
+
+func (s *S) TestResetWithNotFoundTemplate(c *check.C) {
+	config.Set("email-reset-password-template-file", "testdata/wrong-email-reset-password.txt")
+	defer config.Unset("email-reset-password-template-file")
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), resetDefaultContent), check.Equals, true)
+}
+
+func (s *S) TestResetSuccessWithoutTemplate(c *check.C) {
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordSucessfullyTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), successDefaultContent), check.Equals, true)
+}
+
+func (s *S) TestResetSuccessWithTemplate(c *check.C) {
+	config.Set("email-reset-password-successfully-template-file", "testdata/email-reset-success.txt")
+	defer config.Unset("email-reset-password-successfully-template-file")
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordSucessfullyTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), successTemplateContent), check.Equals, true)
+}
+
+func (s *S) TestResetSuccessWithWrongTemplate(c *check.C) {
+	config.Set("email-reset-password-successfully-template-file", "testdata/wrong-email-reset-success.txt")
+	defer config.Unset("email-reset-password-successfully-template-file")
+	var email bytes.Buffer
+	tmp := getEmailResetPasswordSucessfullyTemplate()
+	err := tmp.Execute(&email, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(email.String(), successDefaultContent), check.Equals, true)
+}

--- a/auth/native/native_test.go
+++ b/auth/native/native_test.go
@@ -160,7 +160,8 @@ func (s *S) TestStartPasswordReset(c *check.C) {
 	c.Assert(m.From, check.Equals, "root")
 	c.Assert(m.To, check.DeepEquals, []string{u.Email})
 	var buf bytes.Buffer
-	err = resetEmailData.Execute(&buf, token)
+	template := getEmailResetPasswordTemplate()
+	err = template.Execute(&buf, token)
 	c.Assert(err, check.IsNil)
 	expected := strings.Replace(buf.String(), "\n", "\r\n", -1) + "\r\n"
 	c.Assert(string(m.Data), check.Equals, expected)
@@ -202,7 +203,8 @@ func (s *S) TestResetPassword(c *check.C) {
 	c.Assert(m.From, check.Equals, "root")
 	c.Assert(m.To, check.DeepEquals, []string{u.Email})
 	var buf bytes.Buffer
-	err = passwordResetConfirm.Execute(&buf, map[string]string{"email": u.Email, "password": ""})
+	template := getEmailResetPasswordSucessfullyTemplate()
+	err = template.Execute(&buf, map[string]string{"email": u.Email, "password": ""})
 	c.Assert(err, check.IsNil)
 	expected := strings.Replace(buf.String(), "\n", "\r\n", -1) + "\r\n"
 	lines := strings.Split(string(m.Data), "\r\n")

--- a/auth/native/native_test.go
+++ b/auth/native/native_test.go
@@ -160,7 +160,8 @@ func (s *S) TestStartPasswordReset(c *check.C) {
 	c.Assert(m.From, check.Equals, "root")
 	c.Assert(m.To, check.DeepEquals, []string{u.Email})
 	var buf bytes.Buffer
-	template := getEmailResetPasswordTemplate()
+	template, err := getEmailResetPasswordTemplate()
+	c.Assert(err, check.IsNil)
 	err = template.Execute(&buf, token)
 	c.Assert(err, check.IsNil)
 	expected := strings.Replace(buf.String(), "\n", "\r\n", -1) + "\r\n"
@@ -203,7 +204,8 @@ func (s *S) TestResetPassword(c *check.C) {
 	c.Assert(m.From, check.Equals, "root")
 	c.Assert(m.To, check.DeepEquals, []string{u.Email})
 	var buf bytes.Buffer
-	template := getEmailResetPasswordSucessfullyTemplate()
+	template, err := getEmailResetPasswordSucessfullyTemplate()
+	c.Assert(err, check.IsNil)
 	err = template.Execute(&buf, map[string]string{"email": u.Email, "password": ""})
 	c.Assert(err, check.IsNil)
 	expected := strings.Replace(buf.String(), "\n", "\r\n", -1) + "\r\n"

--- a/auth/native/testdata/email-reset-password.txt
+++ b/auth/native/testdata/email-reset-password.txt
@@ -1,0 +1,6 @@
+Subject: [tsuru] Password reset process
+To: {{.UserEmail}}
+
+It is an email template to reset password, please write your message
+
+{{.Token}}

--- a/auth/native/testdata/email-reset-success.txt
+++ b/auth/native/testdata/email-reset-success.txt
@@ -1,0 +1,10 @@
+Subject: [tsuru] Password successfully reset
+To: {{.email}}
+
+Congrats!
+
+This message is the confirmation that your password has been reset. The new password is:
+
+{{.password}}
+
+Use it to authenticate with tsuru server, and change it later.

--- a/auth/native/user.go
+++ b/auth/native/user.go
@@ -18,9 +18,13 @@ import (
 )
 
 func sendResetPassword(u *auth.User, t *passwordToken) {
+	template, err := getEmailResetPasswordTemplate()
+	if err != nil {
+		log.Errorf("Failed to load email template: %s", err)
+		return
+	}
 	var body bytes.Buffer
-	template := getEmailResetPasswordTemplate()
-	err := template.Execute(&body, t)
+	err = template.Execute(&body, t)
 	if err != nil {
 		log.Errorf("Failed to send password token to user %q: %s", u.Email, err)
 		return
@@ -32,13 +36,17 @@ func sendResetPassword(u *auth.User, t *passwordToken) {
 }
 
 func sendNewPassword(u *auth.User, password string) {
+	template, err := getEmailResetPasswordSucessfullyTemplate()
+	if err != nil {
+		log.Errorf("Failed to load email template: %s", err)
+		return
+	}
 	m := map[string]string{
 		"password": password,
 		"email":    u.Email,
 	}
 	var body bytes.Buffer
-	template := getEmailResetPasswordSucessfullyTemplate()
-	err := template.Execute(&body, m)
+	err = template.Execute(&body, m)
 	if err != nil {
 		log.Errorf("Failed to send new password to user %q: %s", u.Email, err)
 		return

--- a/auth/native/user.go
+++ b/auth/native/user.go
@@ -19,7 +19,8 @@ import (
 
 func sendResetPassword(u *auth.User, t *passwordToken) {
 	var body bytes.Buffer
-	err := resetEmailData.Execute(&body, t)
+	template := getEmailResetPasswordTemplate()
+	err := template.Execute(&body, t)
 	if err != nil {
 		log.Errorf("Failed to send password token to user %q: %s", u.Email, err)
 		return
@@ -36,7 +37,8 @@ func sendNewPassword(u *auth.User, password string) {
 		"email":    u.Email,
 	}
 	var body bytes.Buffer
-	err := passwordResetConfirm.Execute(&body, m)
+	template := getEmailResetPasswordSucessfullyTemplate()
+	err := template.Execute(&body, m)
 	if err != nil {
 		log.Errorf("Failed to send new password to user %q: %s", u.Email, err)
 		return

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -132,6 +132,34 @@ This setting is optional. When ``index-page-template`` is not defined, tsuru
 will use the `default template
 <https://github.com/tsuru/tsuru/blob/master/api/index_templates.go>`_.
 
+reset-password-template
++++++++++++++++++++
+
+``reset-password-template`` is the template that will be used to "password reset" email.
+It must use the `Go template syntax <http://golang.org/pkg/text/template/>`_,
+and tsuru will provide the following variables in the context of the template:
+
+    - ``Token``: a string, the id of password reset request
+    - ``UserEmail``: a string, the user email
+    - ``Creation``: a time, when password reset was requested
+    - ``Used``: a boolean, reset-password was done or not
+
+This setting is optional. When ``reset-password-template`` is not defined, tsuru
+will use the `default template <https://github.com/tsuru/tsuru/blob/master/auth/native/data.go>`_.
+
+reset-password-successfully-template
++++++++++++++++++++
+
+``reset-password-successfully-template`` is the template that will be used to email with new password, after reset.
+It must use the `Go template syntax <http://golang.org/pkg/text/template/>`_,
+and tsuru will provide the following variables in the context of the template:
+
+    - ``password``: a string, the new password
+    - ``email``: a string, the user email
+
+This setting is optional. When ``reset-password-template`` is not defined, tsuru
+will use the `default template <https://github.com/tsuru/tsuru/blob/master/auth/native/data.go>`_.
+
 Database access
 ---------------
 


### PR DESCRIPTION
Hi @andrewsmedina, 

Could you please review this pull request.

Should I update the Tsuru **documentation**?
Now, we have two more configurations: 
1. `email-reset-password-template-file`: path/to/file/template.txt
2. `email-reset-password-successfully-template-file`: path/to/file/template.txt

Issue: #1164 