### PR TITLE
Implements isolated flag to app-run command

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -748,7 +748,8 @@ func runCommand(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	onceBool, _ := strconv.ParseBool(once)
 	isolatedBool, _ := strconv.ParseBool(isolated)
-	return a.Run(command, writer, onceBool, isolatedBool)
+	args := provision.RunArgs{Once: onceBool, Isolated: isolatedBool}
+	return a.Run(command, writer, args)
 }
 
 // title: get envs

--- a/api/app.go
+++ b/api/app.go
@@ -720,6 +720,7 @@ func runCommand(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	}
 	appName := r.URL.Query().Get(":app")
 	once := r.FormValue("once")
+	isolated := r.FormValue("isolated")
 	a, err := getAppFromContext(appName, r)
 	if err != nil {
 		return err
@@ -746,7 +747,8 @@ func runCommand(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	onceBool, _ := strconv.ParseBool(once)
-	return a.Run(command, writer, onceBool)
+	isolatedBool, _ := strconv.ParseBool(isolated)
+	return a.Run(command, writer, onceBool, isolatedBool)
 }
 
 // title: get envs

--- a/app/app.go
+++ b/app/app.go
@@ -866,7 +866,7 @@ func (app *App) InstanceEnv(name string) map[string]bind.EnvVar {
 
 // Run executes the command in app units, sourcing apprc before running the
 // command.
-func (app *App) Run(cmd string, w io.Writer, once, isolated bool) error {
+func (app *App) Run(cmd string, w io.Writer, args provision.RunArgs) error {
 	if !app.available() {
 		return stderr.New("App must be available to run commands")
 	}
@@ -874,17 +874,17 @@ func (app *App) Run(cmd string, w io.Writer, once, isolated bool) error {
 	logWriter := LogWriter{App: app, Source: "app-run"}
 	logWriter.Async()
 	defer logWriter.Close()
-	return app.sourced(cmd, io.MultiWriter(w, &logWriter), once, isolated)
+	return app.sourced(cmd, io.MultiWriter(w, &logWriter), args)
 }
 
-func (app *App) sourced(cmd string, w io.Writer, once, isolated bool) error {
+func (app *App) sourced(cmd string, w io.Writer, args provision.RunArgs) error {
 	source := "[ -f /home/application/apprc ] && source /home/application/apprc"
 	cd := fmt.Sprintf("[ -d %s ] && cd %s", defaultAppDir, defaultAppDir)
 	cmd = fmt.Sprintf("%s; %s; %s", source, cd, cmd)
-	return app.run(cmd, w, once, isolated)
+	return app.run(cmd, w, args)
 }
 
-func (app *App) run(cmd string, w io.Writer, once, isolated bool) error {
+func (app *App) run(cmd string, w io.Writer, args provision.RunArgs) error {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return err
@@ -893,10 +893,10 @@ func (app *App) run(cmd string, w io.Writer, once, isolated bool) error {
 	if !ok {
 		return provision.ProvisionerNotSupported{Prov: prov, Action: "running commands"}
 	}
-	if isolated {
+	if args.Isolated {
 		return execProv.ExecuteCommandIsolated(w, w, app, cmd)
 	}
-	if once {
+	if args.Once {
 		return execProv.ExecuteCommandOnce(w, w, app, cmd)
 	}
 	return execProv.ExecuteCommand(w, w, app, cmd)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2515,7 +2515,8 @@ func (s *S) TestRun(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.Run("ls -lh", &buf, false, false)
+	args := provision.RunArgs{Once: false, Isolated: false}
+	err = app.Run("ls -lh", &buf, args)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
@@ -2554,7 +2555,8 @@ func (s *S) TestRunOnce(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.Run("ls -lh", &buf, true, false)
+	args := provision.RunArgs{Once: true, Isolated: false}
+	err = app.Run("ls -lh", &buf, args)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
@@ -2574,7 +2576,8 @@ func (s *S) TestRunIsolated(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.Run("ls -lh", &buf, false, true)
+	args := provision.RunArgs{Once: false, Isolated: true}
+	err = app.Run("ls -lh", &buf, args)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
@@ -2594,7 +2597,8 @@ func (s *S) TestRunWithoutEnv(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.run("ls -lh", &buf, false, false)
+	args := provision.RunArgs{Once: false, Isolated: false}
+	err = app.run("ls -lh", &buf, args)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	cmds := s.provisioner.GetCmds("ls -lh", &app)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2515,7 +2515,7 @@ func (s *S) TestRun(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.Run("ls -lh", &buf, false)
+	err = app.Run("ls -lh", &buf, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
@@ -2554,7 +2554,27 @@ func (s *S) TestRunOnce(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.Run("ls -lh", &buf, true)
+	err = app.Run("ls -lh", &buf, true, false)
+	c.Assert(err, check.IsNil)
+	c.Assert(buf.String(), check.Equals, "a lot of files")
+	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
+	expected += " [ -d /home/application/current ] && cd /home/application/current;"
+	expected += " ls -lh"
+	cmds := s.provisioner.GetCmds(expected, &app)
+	c.Assert(cmds, check.HasLen, 1)
+}
+
+func (s *S) TestRunIsolated(c *check.C) {
+	s.provisioner.PrepareOutput([]byte("a lot of files"))
+	app := App{
+		Name:      "myapp",
+		TeamOwner: s.team.Name,
+	}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	s.provisioner.AddUnits(&app, 1, "web", nil)
+	var buf bytes.Buffer
+	err = app.Run("ls -lh", &buf, false, true)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
@@ -2574,7 +2594,7 @@ func (s *S) TestRunWithoutEnv(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	var buf bytes.Buffer
-	err = app.run("ls -lh", &buf, false)
+	err = app.run("ls -lh", &buf, false, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "a lot of files")
 	cmds := s.provisioner.GetCmds("ls -lh", &app)

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -970,6 +970,19 @@ func (p *dockerProvisioner) ExecuteCommand(stdout, stderr io.Writer, app provisi
 	return nil
 }
 
+func (p *dockerProvisioner) ExecuteCommandIsolated(stdout, stderr io.Writer, app provision.App, cmd string, args ...string) error {
+	imageID, err := image.AppCurrentImageName(app.GetName())
+	if err != nil {
+		return err
+	}
+	output, err := p.runCommandInContainer(imageID, cmd, app)
+	if err != nil {
+		return err
+	}
+	stdout.Write(output.Bytes())
+	return nil
+}
+
 func (p *dockerProvisioner) AdminCommands() []cmd.Command {
 	return []cmd.Command{
 		&moveContainerCmd{},

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -211,7 +211,7 @@ type App interface {
 	// Run executes the command in app units. Commands executed with this
 	// method should have access to environment variables defined in the
 	// app.
-	Run(cmd string, w io.Writer, once bool) error
+	Run(cmd string, w io.Writer, once, isolated bool) error
 
 	Envs() map[string]bind.EnvVar
 
@@ -362,6 +362,9 @@ type ExecutableProvisioner interface {
 
 	// ExecuteCommandOnce runs a command in one unit of the app.
 	ExecuteCommandOnce(stdout, stderr io.Writer, app App, cmd string, args ...string) error
+
+	// ExecuteCommandIsolated runs a command in an new and ephemeral container.
+	ExecuteCommandIsolated(stdout, stderr io.Writer, app App, cmd string, args ...string) error
 }
 
 // SleepableProvisioner is a provisioner that allows putting applications to

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -187,6 +187,12 @@ type Named interface {
 	GetName() string
 }
 
+// RunArgs groups together the arguments to run an App.
+type RunArgs struct {
+	Once     bool
+	Isolated bool
+}
+
 // App represents a tsuru app.
 //
 // It contains only relevant information for provisioning.
@@ -211,7 +217,7 @@ type App interface {
 	// Run executes the command in app units. Commands executed with this
 	// method should have access to environment variables defined in the
 	// app.
-	Run(cmd string, w io.Writer, once, isolated bool) error
+	Run(cmd string, w io.Writer, args RunArgs) error
 
 	Envs() map[string]bind.EnvVar
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -325,7 +325,7 @@ func (a *FakeApp) SerializeEnvVars() error {
 	return nil
 }
 
-func (a *FakeApp) Run(cmd string, w io.Writer, once, isolated bool) error {
+func (a *FakeApp) Run(cmd string, w io.Writer, args provision.RunArgs) error {
 	a.commMut.Lock()
 	a.Commands = append(a.Commands, fmt.Sprintf("ran %s", cmd))
 	a.commMut.Unlock()

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -912,6 +912,20 @@ func (s *S) TestExecuteComandTimeout(c *check.C) {
 	c.Assert(err.Error(), check.Equals, "FakeProvisioner timed out waiting for output.")
 }
 
+func (s *S) TestExecuteCommandIsolated(c *check.C) {
+	var buf bytes.Buffer
+	output := []byte("myoutput!")
+	app := NewFakeApp("grand-designs", "rush", 1)
+	p := NewFakeProvisioner()
+	p.PrepareOutput(output)
+	err := p.ExecuteCommandIsolated(&buf, nil, app, "ls", "-l")
+	c.Assert(err, check.IsNil)
+	cmds := p.GetCmds("ls", app)
+	c.Assert(cmds, check.HasLen, 1)
+	expected := string(output)
+	c.Assert(buf.String(), check.Equals, expected)
+}
+
 func (s *S) TestAddr(c *check.C) {
 	app := NewFakeApp("quick", "who", 1)
 	p := NewFakeProvisioner()


### PR DESCRIPTION
This PR solves the issue #855 implementing the flag --isolated to app-run command.
If accepted user will can execute command in an ephemeral container.