### PR TITLE
cmd: implicit topics help and allow space as separator

### DIFF
--- a/cmd/topics.go
+++ b/cmd/topics.go
@@ -4,19 +4,8 @@
 
 package cmd
 
-const targetTopic = `In tsuru, a target is the address of the remote tsuru server.
+const targetTopic = `Target is used to manage the address of the remote tsuru server.
 
 Each target is identified by a label and a HTTP/HTTPS address. The client
 requires at least one target to connect to, there's no default target. A user
-may have multiple targets, but he/she will be able to use only per session.
-
-The following commands are used to manage targets in the client:
-
-  * target-add: adds a new target to the list os available targets
-  * target-list: list available targets, marking the current
-  * target-remove: removes a target by its label
-  * target-set: defines the current target, to which the CLI will send next
-    commands
-
-See each command usage by running %s help <commandname>
-`
+may have multiple targets, but only one will be used at a time.`


### PR DESCRIPTION
Creating a pull-request for discussion related to #1527.

With these changes, the first part of any dash separated command will create an implicit topic on tsuru. Which we can review and add proper descriptions latter.

Building tsuru-client with these changes result in the following behavior:

```
$ tsuru help
tsuru version 1.2.0-dev.

Usage: tsuru command [args]

Available commands:
  app-create                   Creates a new app using the given name and platform
  ... ALL STILL COMMANDS LISTED .. 

Use tsuru help <commandname> to get more information about a command.

Available topics:
  app                  
  bs                   
  certificate          
  cname                
  containers           
  docker               
  env                  
  event                
  install              
  key                  
  machine              
  node                 
  plan                 
  platform             
  plugin               
  pool                 
  role                 
  service              
  target               Target is used to manage the address of the remote tsuru server
  team                 
  token                
  unit                 
  user                 

Use tsuru help <topicname> to get more information about a topic.
```

```
$ tsuru app
The following commands are available in the "app" topic:

  app-create           Creates a new app using the given name and platform
  ... ALL `app-` COMMANDS...

Use tsuru help <commandname> to get more information about a command.
```

```
$ tsuru app list
# WORKS
$ tsuru app-list
# ALSO WORKS
```

