### PR TITLE
App tags

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -372,7 +372,7 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 			}
 		}()
 	}
-	if len(tags) > 0 {
+	if tags != nil {
 		app.Tags = tags
 	}
 	err = app.validate()

--- a/app/app.go
+++ b/app/app.go
@@ -126,6 +126,7 @@ type App struct {
 	Router         string
 	RouterOpts     map[string]string
 	Deploys        uint
+	Tags           []string
 
 	quota.Quota
 	provisioner provision.Provisioner
@@ -332,6 +333,7 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 	poolName := updateData.Pool
 	teamOwner := updateData.TeamOwner
 	routerName := updateData.Router
+	tags := updateData.Tags
 	if description != "" {
 		app.Description = description
 	}
@@ -369,6 +371,9 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 				app.Grant(team)
 			}
 		}()
+	}
+	if len(tags) > 0 {
+		app.Tags = tags
 	}
 	err = app.validate()
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -333,7 +333,18 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 	poolName := updateData.Pool
 	teamOwner := updateData.TeamOwner
 	routerName := updateData.Router
-	tags := updateData.Tags
+	var tags []string
+	if updateData.Tags != nil {
+		tags = []string{}
+	}
+	usedTags := make(map[string]bool)
+	for _, tag := range updateData.Tags {
+		tag := strings.Trim(tag, " ")
+		if len(tag) > 0 && !usedTags[tag] {
+			tags = append(tags, tag)
+			usedTags[tag] = true
+		}
+	}
 	if description != "" {
 		app.Description = description
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -407,7 +407,7 @@ func processTags(tags []string) []string {
 	processedTags := []string{}
 	usedTags := make(map[string]bool)
 	for _, tag := range tags {
-		tag = strings.Trim(tag, " ")
+		tag = strings.TrimSpace(tag)
 		if len(tag) > 0 && !usedTags[tag] {
 			processedTags = append(processedTags, tag)
 			usedTags[tag] = true

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4113,16 +4113,28 @@ func (s *S) TestUpdateTags(c *check.C) {
 	c.Assert(dbApp.Tags, check.DeepEquals, newTags)
 }
 
-func (s *S) TestUpdateWithoutNewTags(c *check.C) {
+func (s *S) TestUpdateWithEmptyTagsRemovesAllTags(c *check.C) {
 	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1"}}
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
-	updateData := App{Description: "ble"}
+	updateData := App{Description: "ble", Tags: []string{}}
 	err = app.Update(updateData, new(bytes.Buffer))
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(dbApp.Tags, check.DeepEquals, []string{"tag1"})
+	c.Assert(dbApp.Tags, check.DeepEquals, []string{})
+}
+
+func (s *S) TestUpdateWithoutTagsKeepsOriginalTags(c *check.C) {
+	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1", "tag2"}}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	updateData := App{Description: "ble", Tags: nil}
+	err = app.Update(updateData, new(bytes.Buffer))
+	c.Assert(err, check.IsNil)
+	dbApp, err := GetByName(app.Name)
+	c.Assert(err, check.IsNil)
+	c.Assert(dbApp.Tags, check.DeepEquals, []string{"tag1", "tag2"})
 }
 
 func (s *S) TestUpdateDescriptionPoolPlanAndRouter(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -179,6 +179,7 @@ func (s *S) TestCreateApp(c *check.C) {
 		Name:      "appname",
 		Platform:  "python",
 		TeamOwner: s.team.Name,
+		Tags:      []string{"test a", "test b"},
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
@@ -194,6 +195,7 @@ func (s *S) TestCreateApp(c *check.C) {
 	c.Assert(retrievedApp.Platform, check.Equals, a.Platform)
 	c.Assert(retrievedApp.Teams, check.DeepEquals, []string{s.team.Name})
 	c.Assert(retrievedApp.Owner, check.Equals, s.user.Email)
+	c.Assert(retrievedApp.Tags, check.DeepEquals, a.Tags)
 	env := retrievedApp.InstanceEnv("")
 	c.Assert(env["TSURU_APPNAME"].Value, check.Equals, a.Name)
 	c.Assert(env["TSURU_APPNAME"].Public, check.Equals, false)
@@ -4096,6 +4098,31 @@ func (s *S) TestUpdatePlanRestartFailure(c *check.C) {
 	sort.Strings(routesStr)
 	sort.Strings(expected)
 	c.Assert(routesStr, check.DeepEquals, expected)
+}
+
+func (s *S) TestUpdateTags(c *check.C) {
+	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1"}}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	newTags := []string{"tag2", "tag3"}
+	updateData := App{Tags: newTags}
+	err = app.Update(updateData, new(bytes.Buffer))
+	c.Assert(err, check.IsNil)
+	dbApp, err := GetByName(app.Name)
+	c.Assert(err, check.IsNil)
+	c.Assert(dbApp.Tags, check.DeepEquals, newTags)
+}
+
+func (s *S) TestUpdateWithoutNewTags(c *check.C) {
+	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1"}}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	updateData := App{Description: "ble"}
+	err = app.Update(updateData, new(bytes.Buffer))
+	c.Assert(err, check.IsNil)
+	dbApp, err := GetByName(app.Name)
+	c.Assert(err, check.IsNil)
+	c.Assert(dbApp.Tags, check.DeepEquals, []string{"tag1"})
 }
 
 func (s *S) TestUpdateDescriptionPoolPlanAndRouter(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4100,17 +4100,16 @@ func (s *S) TestUpdatePlanRestartFailure(c *check.C) {
 	c.Assert(routesStr, check.DeepEquals, expected)
 }
 
-func (s *S) TestUpdateTags(c *check.C) {
+func (s *S) TestUpdateIgnoresEmptyAndDuplicatedTags(c *check.C) {
 	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1"}}
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
-	newTags := []string{"tag2", "tag3"}
-	updateData := App{Tags: newTags}
+	updateData := App{Tags: []string{"tag2 ", "  tag3  ", "", " tag3"}}
 	err = app.Update(updateData, new(bytes.Buffer))
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(dbApp.Tags, check.DeepEquals, newTags)
+	c.Assert(dbApp.Tags, check.DeepEquals, []string{"tag2", "tag3"})
 }
 
 func (s *S) TestUpdateWithEmptyTagsRemovesAllTags(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -179,7 +179,7 @@ func (s *S) TestCreateApp(c *check.C) {
 		Name:      "appname",
 		Platform:  "python",
 		TeamOwner: s.team.Name,
-		Tags:      []string{"test a", "test b"},
+		Tags:      []string{"", " test a  ", "  ", "test b ", " test a "},
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
@@ -195,7 +195,7 @@ func (s *S) TestCreateApp(c *check.C) {
 	c.Assert(retrievedApp.Platform, check.Equals, a.Platform)
 	c.Assert(retrievedApp.Teams, check.DeepEquals, []string{s.team.Name})
 	c.Assert(retrievedApp.Owner, check.Equals, s.user.Email)
-	c.Assert(retrievedApp.Tags, check.DeepEquals, a.Tags)
+	c.Assert(retrievedApp.Tags, check.DeepEquals, []string{"test a", "test b"})
 	env := retrievedApp.InstanceEnv("")
 	c.Assert(env["TSURU_APPNAME"].Value, check.Equals, a.Name)
 	c.Assert(env["TSURU_APPNAME"].Public, check.Equals, false)
@@ -4104,7 +4104,7 @@ func (s *S) TestUpdateIgnoresEmptyAndDuplicatedTags(c *check.C) {
 	app := App{Name: "example", Platform: "python", TeamOwner: s.team.Name, Description: "blabla", Tags: []string{"tag1"}}
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
-	updateData := App{Tags: []string{"tag2 ", "  tag3  ", "", " tag3"}}
+	updateData := App{Tags: []string{"tag2 ", "  tag3  ", "", " tag3", "  "}}
 	err = app.Update(updateData, new(bytes.Buffer))
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -41,6 +41,7 @@ var (
 	PermAppUpdateCnameAdd                = PermissionRegistry.get("app.update.cname.add")                // [global app team pool]
 	PermAppUpdateCnameRemove             = PermissionRegistry.get("app.update.cname.remove")             // [global app team pool]
 	PermAppUpdateDescription             = PermissionRegistry.get("app.update.description")              // [global app team pool]
+	PermAppUpdateTags                    = PermissionRegistry.get("app.update.tags")                     // [global app team pool]
 	PermAppUpdateEnv                     = PermissionRegistry.get("app.update.env")                      // [global app team pool]
 	PermAppUpdateEnvSet                  = PermissionRegistry.get("app.update.env.set")                  // [global app team pool]
 	PermAppUpdateEnvUnset                = PermissionRegistry.get("app.update.env.unset")                // [global app team pool]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -12,6 +12,7 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"app.create", []contextType{CtxTeam},
 ).add(
 	"app.update.description",
+	"app.update.tags",
 	"app.update.log",
 	"app.update.pool",
 	"app.update.unit.add",


### PR DESCRIPTION
Adds support to tags in apps (#1550). Tags can be set in app creation, or edited in update. When the tags param is set, it replaces all current tags. When it's omitted, the original tags are kept.