### PR TITLE
healer: remove node status after healing a node

### DIFF
--- a/healer/healer_node.go
+++ b/healer/healer_node.go
@@ -153,6 +153,10 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 	if err != nil {
 		log.Errorf("Unable to move containers, skipping containers healing %q -> %q: %s: %s", failingHost, machine.Address, err, buf.String())
 	}
+	err = h.RemoveNode(node)
+	if err != nil {
+		log.Errorf("Unable to remove node %s status from healer: %s", node.Address(), err)
+	}
 	failingMachine, err := iaas.FindMachineByIdOrAddress(node.Metadata()["iaas-id"], failingHost)
 	if err != nil {
 		return &nodeSpec, errors.Wrapf(err, "Unable to find failing machine %s in IaaS", failingHost)

--- a/healer/healer_node_test.go
+++ b/healer/healer_node_test.go
@@ -51,6 +51,14 @@ func (s *S) TestHealerHealNode(c *check.C) {
 	c.Assert(nodes, check.HasLen, 1)
 	c.Assert(nodes[0].Address(), check.Equals, "http://addr1:1")
 
+	err = healer.UpdateNodeData(nodes[0], []provision.NodeCheckResult{
+		{
+			Name:       "whatever",
+			Successful: true,
+		},
+	})
+	c.Assert(err, check.IsNil)
+
 	machines, err := iaas.ListMachines()
 	c.Assert(err, check.IsNil)
 	c.Assert(machines, check.HasLen, 1)
@@ -68,6 +76,12 @@ func (s *S) TestHealerHealNode(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(machines, check.HasLen, 1)
 	c.Assert(machines[0].Address, check.Equals, "addr2")
+
+	coll, err := nodeDataCollection()
+	c.Assert(err, check.IsNil)
+	n, err := coll.FindId("http://addr1:1").Count()
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 0)
 }
 
 func (s *S) TestHealerHealNodeWithoutIaaS(c *check.C) {


### PR DESCRIPTION
Keeping this data might lead to misbehavior on the healer when the
underlying IaaS reuses an IP.

An actual healing I faced right after launching a node (like 1 min
after):

```
lastcheck:
  checks:
  - err: ''
    name: writableRoot
    successful: true
  - err: ''
    name: createContainer
    successful: true
  time: '2017-04-17T19:52:14.151000'
node:
  _id: https://1.2.3.4:2376
  metadata:
    amazonec2-iam-instance-profile: docker-nodes
    amazonec2-instance-type: m3.medium
    amazonec2-private-address-only: 'true'
    amazonec2-root-size: '60'
    amazonec2-security-group: docker-nodes
    amazonec2-subnet-id: subnet-0123456
    amazonec2-tags: Name,docker-node
    amazonec2-vpc-id: vpc-0123456
    driver: amazonec2
    iaas: dockermachine
    iaas-id: mypool-3ccdcb8302c6960f54a521680d44ca94
    insecure-registry: registry.example.com:5000
    memory: '4143964160'
    pool: mypool
  pool: mypool
  status: pending
reason: last update 71h19m22.75158458s ago, last success 71h19m22.75158478s ago
```

This happened because Amazon reused the private IP and the healer picked
information from the old node.
