### PR TITLE
User-list bug fix

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -749,6 +749,21 @@ func listUsers(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			}
 		}
 	}
+	if len(apiUsers) == 0 {
+		user, err := t.User()
+		if err != nil {
+			return err
+		}
+		perm, err := user.Permissions()
+		if err != nil {
+			return err
+		}
+		userData, err := createAPIUser(perm, user, nil, true)
+		if err != nil {
+			return err
+		}
+		apiUsers = append(apiUsers, *userData)
+	}
 	w.Header().Add("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(apiUsers)
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -729,9 +729,6 @@ func (s *AuthSuite) TestAddKeyToUserReturnsBadRequestIfTheKeyIsEmpty(c *check.C)
 func (s *AuthSuite) TestAddKeyToUserKeyManagerDisabled(c *check.C) {
 	config.Set("repo-manager", "none")
 	defer config.Set("repo-manager", "fake")
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	b := strings.NewReader("name=the-key&key=my-key")
 	request, err := http.NewRequest("POST", "/users/keys", b)
 	c.Assert(err, check.IsNil)
@@ -792,11 +789,8 @@ func (s *AuthSuite) TestAddKeyForcingUpdate(c *check.C) {
 }
 
 func (s *AuthSuite) TestAddKeyToUserFailure(c *check.C) {
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	u := &auth.User{Email: "me@gmail.com", Password: "123456"}
-	_, err = nativeScheme.Create(u)
+	_, err := nativeScheme.Create(u)
 	c.Assert(err, check.IsNil)
 	t, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
@@ -856,9 +850,6 @@ func (s *AuthSuite) TestRemoveKeyNotFound(c *check.C) {
 func (s *AuthSuite) TestRemoveKeyFromUserKeyManagerDisabled(c *check.C) {
 	config.Set("repo-manager", "none")
 	defer config.Set("repo-manager", "fake")
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	request, err := http.NewRequest("DELETE", "/users/keys/the-key", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -897,8 +888,6 @@ func (s *AuthSuite) TestListKeysHandler(c *check.C) {
 func (s *AuthSuite) TestListKeysKeyManagerDisabled(c *check.C) {
 	config.Set("repo-manager", "none")
 	defer config.Set("repo-manager", "fake")
-	conn, _ := db.Conn()
-	defer conn.Close()
 	request, err := http.NewRequest("GET", "/users/keys", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -1624,8 +1613,6 @@ func (s *AuthSuite) TestUserInfo(c *check.C) {
 }
 
 func (s *AuthSuite) TestUserInfoWithoutRoles(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	token := userWithPermission(c)
 	u, err := token.User()
 	c.Assert(err, check.IsNil)
@@ -1658,8 +1645,6 @@ func (l rolePermList) Less(i, j int) bool {
 }
 
 func (s *AuthSuite) TestUserInfoWithRoles(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	token := userWithPermission(c)
 	r, err := permission.NewRole("myrole", "team", "")
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
Fixes bug on Issue #1430 where in a situation that a user has only basic permissions and is not assigned to any teams, using `tsuru user-list` command would not show anything other than the headers.