### PR TITLE
api/node: disables the need for machine perms

### DIFF
--- a/api/node.go
+++ b/api/node.go
@@ -113,13 +113,6 @@ func addNodeHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 	if !permission.Check(t, permission.PermNodeCreate, permission.Context(permission.CtxPool, poolName)) {
 		return permission.ErrUnauthorized
 	}
-	if !params.Register {
-		canCreateMachine := permission.Check(t, permission.PermMachineCreate,
-			permission.Context(permission.CtxIaaS, params.Metadata["iaas"]))
-		if !canCreateMachine {
-			return permission.ErrUnauthorized
-		}
-	}
 	evt, err := event.New(&event.Opts{
 		Target:      event.Target{Type: event.TargetTypeNode},
 		Kind:        permission.PermNodeCreate,
@@ -191,14 +184,6 @@ func removeNodeHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 		return permission.ErrUnauthorized
 	}
 	removeIaaS, _ := strconv.ParseBool(r.URL.Query().Get("remove-iaas"))
-	if removeIaaS {
-		allowedIaasRemove := permission.Check(t, permission.PermMachineDelete,
-			permission.Context(permission.CtxIaaS, node.Metadata()["iaas"]),
-		)
-		if !allowedIaasRemove {
-			return permission.ErrUnauthorized
-		}
-	}
 	evt, err := event.New(&event.Opts{
 		Target:     event.Target{Type: event.TargetTypeNode, Value: node.Address()},
 		Kind:       permission.PermNodeDelete,

--- a/api/node.go
+++ b/api/node.go
@@ -183,7 +183,6 @@ func removeNodeHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 	if !allowedNodeRemove {
 		return permission.ErrUnauthorized
 	}
-	removeIaaS, _ := strconv.ParseBool(r.URL.Query().Get("remove-iaas"))
 	evt, err := event.New(&event.Opts{
 		Target:     event.Target{Type: event.TargetTypeNode, Value: node.Address()},
 		Kind:       permission.PermNodeDelete,
@@ -204,6 +203,7 @@ func removeNodeHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 	if err != nil {
 		return err
 	}
+	removeIaaS, _ := strconv.ParseBool(r.URL.Query().Get("remove-iaas"))
 	if removeIaaS {
 		var m iaas.Machine
 		m, err = iaas.FindMachineByIdOrAddress(node.Metadata()["iaas-id"], net.URLToHost(address))

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -82,7 +82,6 @@ var (
 	PermInstall                          = PermissionRegistry.get("install")                             // [global]
 	PermInstallManage                    = PermissionRegistry.get("install.manage")                      // [global]
 	PermMachine                          = PermissionRegistry.get("machine")                             // [global iaas]
-	PermMachineCreate                    = PermissionRegistry.get("machine.create")                      // [global iaas]
 	PermMachineDelete                    = PermissionRegistry.get("machine.delete")                      // [global iaas]
 	PermMachineRead                      = PermissionRegistry.get("machine.read")                        // [global iaas]
 	PermMachineReadEvents                = PermissionRegistry.get("machine.read.events")                 // [global iaas]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -77,7 +77,6 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 ).addWithCtx(
 	"machine", []contextType{CtxIaaS},
 ).add(
-	"machine.create",
 	"machine.delete",
 	"machine.read",
 	"machine.read.events",


### PR DESCRIPTION
This PR disables the need for `PermMachineCreate` and `PermMachineDelete` from adding and removing nodes. `PermMachineCreate` was removed since it wasn't used anywhere.