### PR TITLE
Kubernetes node cluster metadata

### DIFF
--- a/provision/kubernetes/node.go
+++ b/provision/kubernetes/node.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+const clusterMetadataName = "tsuru.io/cluster"
+
 type kubernetesNodeWrapper struct {
 	node    *v1.Node
 	prov    *kubernetesProvisioner
@@ -64,7 +66,11 @@ func (n *kubernetesNodeWrapper) Metadata() map[string]string {
 }
 
 func (n *kubernetesNodeWrapper) ExtraData() map[string]string {
-	return filterMap(n.allMetadata(), true)
+	filteredMap := filterMap(n.allMetadata(), true)
+	if n.cluster != nil {
+		filteredMap[clusterMetadataName] = n.cluster.Name
+	}
+	return filteredMap
 }
 
 func (n *kubernetesNodeWrapper) allMetadata() map[string]string {

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -116,6 +116,13 @@ func (s *S) TestNodeMetadata(c *check.C) {
 		"m2.m3": "v2",
 		"a2.a3": "v4",
 	})
+	node.cluster = s.client.clusterClient
+	node.cluster.Name = "fakecluster"
+	c.Assert(node.ExtraData(), check.DeepEquals, map[string]string{
+		"m2.m3":            "v2",
+		"a2.a3":            "v4",
+		"tsuru.io/cluster": "fakecluster",
+	})
 }
 
 func (s *S) TestNodeProvisioner(c *check.C) {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -146,6 +146,41 @@ func (s *S) TestAddNodeExisting(c *check.C) {
 	})
 }
 
+func (s *S) TestUpdateNode(c *check.C) {
+	err := s.p.AddNode(provision.AddNodeOptions{
+		Address: "my-node-addr",
+		Metadata: map[string]string{
+			"pool": "p1",
+			"m1":   "v1",
+		},
+	})
+	c.Assert(err, check.IsNil)
+	err = s.p.UpdateNode(provision.UpdateNodeOptions{
+		Address: "my-node-addr",
+		Metadata: map[string]string{
+			"pool": "p2",
+			"m1":   "",
+			"m2":   "v2",
+		},
+	})
+	c.Assert(err, check.IsNil)
+	nodes, err := s.p.ListNodes(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(nodes, check.HasLen, 1)
+	c.Assert(nodes[0].Address(), check.Equals, "my-node-addr")
+	c.Assert(nodes[0].Pool(), check.Equals, "p2")
+	c.Assert(nodes[0].Metadata(), check.DeepEquals, map[string]string{
+		"pool": "p2",
+		"m2":   "v2",
+	})
+	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Labels, check.DeepEquals, map[string]string{
+		"pool": "p2",
+	})
+	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Annotations, check.DeepEquals, map[string]string{
+		"m2": "v2",
+	})
+}
+
 func (s *S) TestUnits(c *check.C) {
 	a, wait, rollback := s.defaultReactions(c)
 	defer rollback()


### PR DESCRIPTION
Adds the cluster name as metadata in Kubernetes nodes. Fixes #1593