### PR TITLE
Fix for #1589

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -983,7 +983,7 @@ func unsetEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) 
 	return a.UnsetEnvs(
 		bind.UnsetEnvApp{
 			VariableNames: variables,
-			PublicOnly:    true,
+			PublicOnly:    false,
 			ShouldRestart: !noRestart,
 		}, writer,
 	)

--- a/api/app.go
+++ b/api/app.go
@@ -983,7 +983,6 @@ func unsetEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) 
 	return a.UnsetEnvs(
 		bind.UnsetEnvApp{
 			VariableNames: variables,
-			PublicOnly:    false,
 			ShouldRestart: !noRestart,
 		}, writer,
 	)

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -3434,7 +3434,7 @@ func (s *S) TestUnsetEnvHandlerRemovesAllGivenEnvironmentVariables(c *check.C) {
 	}, eventtest.HasEvent)
 }
 
-func (s *S) TestUnsetHandlerDoesNotRemovePrivateVariables(c *check.C) {
+func (s *S) TestUnsetHandlerRemovePrivateVariables(c *check.C) {
 	a := app.App{
 		Name:     "letitbe",
 		Platform: "zend",
@@ -3447,7 +3447,7 @@ func (s *S) TestUnsetHandlerDoesNotRemovePrivateVariables(c *check.C) {
 	}
 	err := s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	url := fmt.Sprintf("/apps/%s/env?noRestart=false&env=DATABASE_HOST&env=DATABASE_USER&env=DATABASE_PASSWORD", a.Name)
+	url := fmt.Sprintf("/apps/%s/env?noRestart=false&env=DATABASE_PASSWORD", a.Name)
 	request, err := http.NewRequest("DELETE", url, nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -3459,11 +3459,8 @@ func (s *S) TestUnsetHandlerDoesNotRemovePrivateVariables(c *check.C) {
 	app, err := app.GetByName("letitbe")
 	c.Assert(err, check.IsNil)
 	expected := map[string]bind.EnvVar{
-		"DATABASE_PASSWORD": {
-			Name:   "DATABASE_PASSWORD",
-			Value:  "secret",
-			Public: false,
-		},
+		"DATABASE_HOST":     {Name: "DATABASE_HOST", Value: "localhost", Public: true},
+		"DATABASE_USER":     {Name: "DATABASE_USER", Value: "root", Public: true},
 	}
 	c.Assert(app.Env, check.DeepEquals, expected)
 }

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -3459,8 +3459,8 @@ func (s *S) TestUnsetHandlerRemovePrivateVariables(c *check.C) {
 	app, err := app.GetByName("letitbe")
 	c.Assert(err, check.IsNil)
 	expected := map[string]bind.EnvVar{
-		"DATABASE_HOST":     {Name: "DATABASE_HOST", Value: "localhost", Public: true},
-		"DATABASE_USER":     {Name: "DATABASE_USER", Value: "root", Public: true},
+		"DATABASE_HOST": {Name: "DATABASE_HOST", Value: "localhost", Public: true},
+		"DATABASE_USER": {Name: "DATABASE_USER", Value: "root", Public: true},
 	}
 	c.Assert(app.Env, check.DeepEquals, expected)
 }

--- a/app/actions.go
+++ b/app/actions.go
@@ -153,7 +153,6 @@ var exportEnvironmentsAction = action.Action{
 			app.UnsetEnvs(
 				bind.UnsetEnvApp{
 					VariableNames: vars,
-					PublicOnly:    false,
 					ShouldRestart: true,
 				}, nil)
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -1354,12 +1354,8 @@ func (app *App) unsetEnvsToApp(unsetEnvs bind.UnsetEnvApp, w io.Writer) error {
 		fmt.Fprintf(w, "---- Unsetting %d environment variables ----\n", len(unsetEnvs.VariableNames))
 	}
 	for _, name := range unsetEnvs.VariableNames {
-		var unset bool
-		e, err := app.getEnv(name)
-		if !unsetEnvs.PublicOnly || (err == nil && e.Public) {
-			unset = true
-		}
-		if unset {
+		_, err := app.getEnv(name)
+		if err == nil {
 			delete(app.Env, name)
 		}
 	}
@@ -1539,7 +1535,6 @@ func (app *App) RemoveInstance(instanceApp bind.InstanceApp, writer io.Writer) e
 		err = app.unsetEnvsToApp(
 			bind.UnsetEnvApp{
 				VariableNames: toUnsetEnvs,
-				PublicOnly:    false,
 				ShouldRestart: restart,
 			}, writer)
 		if err != nil {

--- a/app/bind/binder.go
+++ b/app/bind/binder.go
@@ -61,7 +61,6 @@ type SetEnvApp struct {
 
 type UnsetEnvApp struct {
 	VariableNames []string
-	PublicOnly    bool
 	ShouldRestart bool
 }
 

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -145,7 +145,6 @@ func (s *S) TestUnsetEnvs(c *check.C) {
 	app.UnsetEnvs(
 		bind.UnsetEnvApp{
 			VariableNames: []string{"http_proxy"},
-			PublicOnly:    false,
 			ShouldRestart: true,
 		}, nil)
 	c.Assert(app.env, check.DeepEquals, map[string]bind.EnvVar{})


### PR DESCRIPTION
Should fix bug #1589. 

I just wanted to point out that 7408d0e5 explicitly created this behavior but, looking at the code, I found no motive for this. For example, the PublicOnly flag always received the value false everywhere except in a test that verifies that it works. Since this was marked as a bug, I felt free to remove this behavior.