### PR TITLE
Scheduler

### DIFF
--- a/provision/docker/docker.go
+++ b/provision/docker/docker.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	mathRand "math/rand"
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
@@ -178,7 +177,10 @@ func (p *dockerProvisioner) GetDockerClient(app provision.App) (*docker.Client, 
 		if len(nodes) < 1 {
 			return nil, errors.New("There is no Docker node. Add one with `tsuru node-add`")
 		}
-		nodeAddr = nodes[mathRand.Intn(len(nodes))].Address
+		nodeAddr, _, err = p.scheduler.minMaxNodes(nodes, "", "")
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		nodes, err := cluster.NodesForMetadata(map[string]string{"pool": app.GetPool()})
 		if err != nil {

--- a/provision/docker/scheduler.go
+++ b/provision/docker/scheduler.go
@@ -158,9 +158,11 @@ func (s *segregatedScheduler) aggregateContainersByHost(hosts []string) (map[str
 
 func (s *segregatedScheduler) aggregateContainersByHostAppProcess(hosts []string, appName, process string) (map[string]int, error) {
 	matcher := bson.M{
-		"appname":  appName,
 		"hostaddr": bson.M{"$in": hosts},
 		"id":       bson.M{"$nin": s.ignoredContainers},
+	}
+	if appName != "" {
+		matcher["appname"] = appName
 	}
 	if process == "" {
 		matcher["$or"] = []bson.M{{"processname": bson.M{"$exists": false}}, {"processname": ""}}

--- a/provision/docker/scheduler.go
+++ b/provision/docker/scheduler.go
@@ -171,7 +171,10 @@ func (s *segregatedScheduler) aggregateContainersByHostAppProcess(hosts []string
 }
 
 func (s *segregatedScheduler) GetRemovableContainer(appName string, process string) (string, error) {
-	a, _ := app.GetByName(appName)
+	a, err := app.GetByName(appName)
+	if err != nil {
+		return "", err
+	}
 	nodes, err := s.provisioner.Nodes(a)
 	if err != nil {
 		return "", err

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -810,6 +810,16 @@ func (s *S) TestGetRemovableContainer(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
+func (s *S) TestGetRemovableContainerWithoutAppOrProcess(c *check.C) {
+	scheduler := segregatedScheduler{provisioner: s.p}
+	cont, err := scheduler.GetRemovableContainer("", "web")
+	c.Assert(cont, check.Equals, "")
+	c.Assert(err, check.NotNil)
+	cont, err = scheduler.GetRemovableContainer("appname", "")
+	c.Assert(cont, check.Equals, "")
+	c.Assert(err, check.NotNil)
+}
+
 func (s *S) TestNodesToHosts(c *check.C) {
 	nodes := []cluster.Node{
 		{Address: "http://server1:1234"},


### PR DESCRIPTION
With these changes, when you ask for a Docker node without specifying an app (for platform building), it uses the scheduler, instead of randomly choosing a node.