### PR TITLE
Fix platform builder

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -83,20 +83,12 @@ func PlatformAdd(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
-	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			err = platformBuilder.PlatformAdd(opts)
-			if err != nil {
-				return err
-			}
-			built = true
+			return platformBuilder.PlatformAdd(opts)
 		}
 	}
-	if !built {
-		return errors.New("No builder available")
-	}
-	return nil
+	return errors.New("No builder available")
 }
 
 func PlatformUpdate(opts PlatformOptions) error {
@@ -104,20 +96,12 @@ func PlatformUpdate(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
-	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			err = platformBuilder.PlatformUpdate(opts)
-			if err != nil {
-				return err
-			}
-			built = true
+			return platformBuilder.PlatformUpdate(opts)
 		}
 	}
-	if !built {
-		return errors.New("No builder available")
-	}
-	return nil
+	return errors.New("No builder available")
 }
 
 func PlatformRemove(name string) error {
@@ -125,18 +109,10 @@ func PlatformRemove(name string) error {
 	if err != nil {
 		return err
 	}
-	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			err = platformBuilder.PlatformRemove(name)
-			if err != nil {
-				return err
-			}
-			built = true
+			return platformBuilder.PlatformRemove(name)
 		}
 	}
-	if !built {
-		return errors.New("No builder available")
-	}
-	return nil
+	return errors.New("No builder available")
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -83,13 +83,18 @@ func PlatformAdd(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
+	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
 			err = platformBuilder.PlatformAdd(opts)
 			if err != nil {
 				return err
 			}
+			built = true
 		}
+	}
+	if !built {
+		return errors.New("No builder available")
 	}
 	return nil
 }
@@ -99,13 +104,18 @@ func PlatformUpdate(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
+	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
 			err = platformBuilder.PlatformUpdate(opts)
 			if err != nil {
 				return err
 			}
+			built = true
 		}
+	}
+	if !built {
+		return errors.New("No builder available")
 	}
 	return nil
 }
@@ -115,13 +125,18 @@ func PlatformRemove(name string) error {
 	if err != nil {
 		return err
 	}
+	built := false
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
 			err = platformBuilder.PlatformRemove(name)
 			if err != nil {
 				return err
 			}
+			built = true
 		}
+	}
+	if !built {
+		return errors.New("No builder available")
 	}
 	return nil
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,9 +5,11 @@
 package builder
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
+	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/provision"
 )
@@ -83,10 +85,18 @@ func PlatformAdd(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
+	multiErr := tsuruErrors.NewMultiError()
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			return platformBuilder.PlatformAdd(opts)
+			err = platformBuilder.PlatformAdd(opts)
+			if err == nil {
+				return nil
+			}
+			multiErr.Add(err)
 		}
+	}
+	if multiErr.Len() > 0 {
+		return fmt.Errorf("%s", multiErr)
 	}
 	return errors.New("No builder available")
 }
@@ -96,10 +106,18 @@ func PlatformUpdate(opts PlatformOptions) error {
 	if err != nil {
 		return err
 	}
+	multiErr := tsuruErrors.NewMultiError()
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			return platformBuilder.PlatformUpdate(opts)
+			err = platformBuilder.PlatformUpdate(opts)
+			if err == nil {
+				return nil
+			}
+			multiErr.Add(err)
 		}
+	}
+	if multiErr.Len() > 0 {
+		return fmt.Errorf("%s", multiErr)
 	}
 	return errors.New("No builder available")
 }
@@ -109,10 +127,18 @@ func PlatformRemove(name string) error {
 	if err != nil {
 		return err
 	}
+	multiErr := tsuruErrors.NewMultiError()
 	for _, b := range builders {
 		if platformBuilder, ok := b.(PlatformBuilder); ok {
-			return platformBuilder.PlatformRemove(name)
+			err = platformBuilder.PlatformRemove(name)
+			if err == nil {
+				return nil
+			}
+			multiErr.Add(err)
 		}
+	}
+	if multiErr.Len() > 0 {
+		return fmt.Errorf("%s", multiErr)
 	}
 	return errors.New("No builder available")
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,7 +5,6 @@
 package builder
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -96,7 +95,7 @@ func PlatformAdd(opts PlatformOptions) error {
 		}
 	}
 	if multiErr.Len() > 0 {
-		return fmt.Errorf("%s", multiErr)
+		return multiErr
 	}
 	return errors.New("No builder available")
 }
@@ -117,7 +116,7 @@ func PlatformUpdate(opts PlatformOptions) error {
 		}
 	}
 	if multiErr.Len() > 0 {
-		return fmt.Errorf("%s", multiErr)
+		return multiErr
 	}
 	return errors.New("No builder available")
 }
@@ -138,7 +137,7 @@ func PlatformRemove(name string) error {
 		}
 	}
 	if multiErr.Len() > 0 {
-		return fmt.Errorf("%s", multiErr)
+		return multiErr
 	}
 	return errors.New("No builder available")
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -24,14 +24,11 @@ var _ = check.Suite(S{})
 var _ PlatformBuilder = &customPlatformBuilder{}
 var _ Builder = &customPlatformBuilder{}
 
-var platformOpCalls = 0
-
 func callCounter(PlatformOptions, string) error {
-	platformOpCalls++
 	return nil
 }
+
 func callCounterWithError(PlatformOptions, string) error {
-	platformOpCalls++
 	return errors.New("something is wrong")
 }
 
@@ -109,9 +106,7 @@ func (s S) TestPlatformAdd(c *check.C) {
 	}
 	Register("builder1", &b1)
 	Register("builder2", &b2)
-	platformOpCalls = 0
 	err := PlatformAdd(PlatformOptions{})
-	c.Assert(platformOpCalls, check.Equals, 1)
 	c.Assert(err, check.IsNil)
 }
 
@@ -124,9 +119,7 @@ func (s S) TestPlatformAddError(c *check.C) {
 	}
 	Register("builder1", &b1)
 	Register("builder2", &b2)
-	platformOpCalls = 0
 	err := PlatformAdd(PlatformOptions{})
-	c.Assert(platformOpCalls, check.Equals, 2)
 	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong")
 }
 
@@ -144,9 +137,7 @@ func (s S) TestPlatformUpdate(c *check.C) {
 	}
 	Register("builder1", &b1)
 	Register("builder2", &b2)
-	platformOpCalls = 0
 	err := PlatformUpdate(PlatformOptions{})
-	c.Assert(platformOpCalls, check.Equals, 2)
 	c.Assert(err, check.IsNil)
 }
 
@@ -163,9 +154,7 @@ func (s S) TestPlatformUpdateError(c *check.C) {
 	Register("builder1", &b1)
 	Register("builder2", &b2)
 	Register("builder3", &b3)
-	platformOpCalls = 0
 	err := PlatformUpdate(PlatformOptions{})
-	c.Assert(platformOpCalls, check.Equals, 3)
 	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong something is wrong")
 }
 
@@ -187,9 +176,7 @@ func (s S) TestPlatformRemove(c *check.C) {
 	Register("builder1", &b1)
 	Register("builder2", &b2)
 	Register("builder3", &b3)
-	platformOpCalls = 0
 	err := PlatformRemove("platform-name")
-	c.Assert(platformOpCalls, check.Equals, 3)
 	c.Assert(err, check.IsNil)
 }
 
@@ -202,9 +189,7 @@ func (s S) TestPlatformRemoveError(c *check.C) {
 	}
 	Register("builder1", &b1)
 	Register("builder2", &b2)
-	platformOpCalls = 0
 	err := PlatformRemove("platform-name")
-	c.Assert(platformOpCalls, check.Equals, 2)
 	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong")
 }
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -70,7 +70,7 @@ func (s S) SetUpTest(c *check.C) {
 
 func (s S) TestRegisterAndGetBuilder(c *check.C) {
 	var b Builder
-	Register("builder", b)
+	Register("my-builder", b)
 	got, err := Get("my-builder")
 	c.Assert(err, check.IsNil)
 	c.Check(got, check.DeepEquals, b)
@@ -83,8 +83,8 @@ func (s S) TestRegisterAndGetBuilder(c *check.C) {
 func (s S) TestGetDefaultBuilder(c *check.C) {
 	var b1, b2 Builder
 	DefaultBuilder = "default-builder"
-	Register("builder1", b1)
-	Register("builder2", b2)
+	Register("default-builder", b1)
+	Register("other-builder", b2)
 	got, err := GetDefault()
 	c.Check(err, check.IsNil)
 	c.Check(got, check.DeepEquals, b1)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -109,7 +109,7 @@ func (s S) TestPlatformAdd(c *check.C) {
 	Register("default-builder", &b3)
 	err := PlatformAdd(PlatformOptions{})
 	c.Assert(err, check.IsNil)
-	c.Assert(platformAddCalls, check.Equals, 3)
+	c.Assert(platformAddCalls, check.Equals, 1)
 }
 
 func (s S) TestPlatformAddError(c *check.C) {
@@ -149,7 +149,7 @@ func (s S) TestPlatformUpdate(c *check.C) {
 	Register("default-builder", &b3)
 	err := PlatformUpdate(PlatformOptions{})
 	c.Assert(err, check.IsNil)
-	c.Assert(platformUpdateCalls, check.Equals, 3)
+	c.Assert(platformUpdateCalls, check.Equals, 1)
 }
 
 func (s S) TestPlatformUpdateError(c *check.C) {
@@ -189,7 +189,7 @@ func (s S) TestPlatformRemove(c *check.C) {
 	Register("default-builder", &b3)
 	err := PlatformRemove("platform-name")
 	c.Assert(err, check.IsNil)
-	c.Assert(platformRemoveCalls, check.Equals, 3)
+	c.Assert(platformRemoveCalls, check.Equals, 1)
 }
 
 func (s S) TestPlatformRemoveError(c *check.C) {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -124,6 +124,11 @@ func (s S) TestPlatformAddError(c *check.C) {
 	c.Assert(err, check.ErrorMatches, errMsg)
 }
 
+func (s S) TestPlatformAddNoBuilder(c *check.C) {
+	err := PlatformAdd(PlatformOptions{})
+	c.Assert(err, check.ErrorMatches, "No builder available")
+}
+
 func (s S) TestPlatformUpdate(c *check.C) {
 	platformUpdateCalls := 0
 	callCounter := func(PlatformOptions, string) error {
@@ -159,6 +164,11 @@ func (s S) TestPlatformUpdateError(c *check.C) {
 	c.Assert(err, check.ErrorMatches, errMsg)
 }
 
+func (s S) TestPlatformUpdateNoBuilder(c *check.C) {
+	err := PlatformUpdate(PlatformOptions{})
+	c.Assert(err, check.ErrorMatches, "No builder available")
+}
+
 func (s S) TestPlatformRemove(c *check.C) {
 	platformRemoveCalls := 0
 	callCounter := func(PlatformOptions, string) error {
@@ -192,4 +202,9 @@ func (s S) TestPlatformRemoveError(c *check.C) {
 	Register("my-builder", &b1)
 	err := PlatformRemove("platform-name")
 	c.Assert(err, check.ErrorMatches, errMsg)
+}
+
+func (s S) TestPlatformRemoveNoBuilder(c *check.C) {
+	err := PlatformRemove("platform-name")
+	c.Assert(err, check.ErrorMatches, "No builder available")
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -120,7 +120,7 @@ func (s S) TestPlatformAddError(c *check.C) {
 	Register("builder1", &b1)
 	Register("builder2", &b2)
 	err := PlatformAdd(PlatformOptions{})
-	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong")
+	c.Assert(err, check.ErrorMatches, "(?s).*something is wrong.*something is wrong.*")
 }
 
 func (s S) TestPlatformAddNoBuilder(c *check.C) {
@@ -155,7 +155,7 @@ func (s S) TestPlatformUpdateError(c *check.C) {
 	Register("builder2", &b2)
 	Register("builder3", &b3)
 	err := PlatformUpdate(PlatformOptions{})
-	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong something is wrong")
+	c.Assert(err, check.ErrorMatches, "(?s).*something is wrong.*something is wrong.*something is wrong.*")
 }
 
 func (s S) TestPlatformUpdateNoBuilder(c *check.C) {
@@ -190,7 +190,7 @@ func (s S) TestPlatformRemoveError(c *check.C) {
 	Register("builder1", &b1)
 	Register("builder2", &b2)
 	err := PlatformRemove("platform-name")
-	c.Assert(err, check.ErrorMatches, "something is wrong something is wrong")
+	c.Assert(err, check.ErrorMatches, "(?s).*something is wrong.*something is wrong.*")
 }
 
 func (s S) TestPlatformRemoveNoBuilder(c *check.C) {

--- a/builder/docker/platform.go
+++ b/builder/docker/platform.go
@@ -134,18 +134,9 @@ func getDockerClient() (*docker.Client, error) {
 }
 
 func (b *dockerBuilder) PlatformRemove(name string) error {
-	provisioners, err := provision.Registry()
+	client, err := getDockerClient()
 	if err != nil {
 		return err
-	}
-	var client *docker.Client
-	for _, p := range provisioners {
-		if provisioner, ok := p.(provision.BuilderDeploy); ok {
-			client, err = provisioner.GetDockerClient(nil)
-			if err != nil {
-				return err
-			}
-		}
 	}
 	img, err := client.InspectImage(image.PlatformImageName(name))
 	if err != nil {

--- a/builder/docker/platform.go
+++ b/builder/docker/platform.go
@@ -69,10 +69,16 @@ func (b *dockerBuilder) buildPlatform(name string, args map[string]string, w io.
 	for _, p := range provisioners {
 		if provisioner, ok := p.(provision.BuilderDeploy); ok {
 			client, err = provisioner.GetDockerClient(nil)
-			if err != nil {
-				return err
+			if client != nil && err == nil {
+				break
 			}
 		}
+	}
+	if client == nil {
+		if err != nil {
+			return err
+		}
+		return errors.New("No Docker nodes available")
 	}
 	buildOptions := docker.BuildImageOptions{
 		Name:              imageName,

--- a/builder/docker/platform.go
+++ b/builder/docker/platform.go
@@ -8,7 +8,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -128,7 +127,7 @@ func getDockerClient() (*docker.Client, error) {
 		}
 	}
 	if multiErr.Len() > 0 {
-		return nil, fmt.Errorf("%s", multiErr)
+		return nil, multiErr
 	}
 	return nil, errors.New("No Docker nodes available")
 }

--- a/builder/docker/platform_test.go
+++ b/builder/docker/platform_test.go
@@ -115,7 +115,7 @@ func (s *S) TestPlatformAddProvisionerError(c *check.C) {
 		Args:   args,
 		Output: ioutil.Discard,
 	})
-	c.Assert(err, check.ErrorMatches, "No node found")
+	c.Assert(err, check.ErrorMatches, "(?m).*No node found.*")
 }
 
 func (s *S) TestPlatformAddNoProvisioner(c *check.C) {
@@ -183,7 +183,7 @@ func (s *S) TestPlatformRemoveProvisionerError(c *check.C) {
 	defer server.Stop()
 	var b dockerBuilder
 	err = b.PlatformRemove("test")
-	c.Assert(err, check.ErrorMatches, "No node found")
+	c.Assert(err, check.ErrorMatches, "(?m).*No node found.*")
 }
 
 func (s *S) TestPlatformRemoveNoProvisioner(c *check.C) {

--- a/builder/docker/platform_test.go
+++ b/builder/docker/platform_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tsuru/tsuru/app/image"
 	"github.com/tsuru/tsuru/builder"
 	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/provisiontest"
 	"gopkg.in/check.v1"
 )
 
@@ -97,7 +98,7 @@ func (s *S) TestPlatformAddShouldValidateArgs(c *check.C) {
 	c.Assert(err.Error(), check.Equals, "Dockerfile parameter must be a URL")
 }
 
-func (s *S) TestPlatformAddWithoutNode(c *check.C) {
+func (s *S) TestPlatformAddProvisionerError(c *check.C) {
 	var requests []*http.Request
 	server, err := testing.NewServer("127.0.0.1:0", nil, func(r *http.Request) {
 		requests = append(requests, r)
@@ -114,7 +115,33 @@ func (s *S) TestPlatformAddWithoutNode(c *check.C) {
 		Args:   args,
 		Output: ioutil.Discard,
 	})
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "No node found")
+}
+
+func (s *S) TestPlatformAddNoProvisioner(c *check.C) {
+	provision.Unregister("fake")
+	defer func() {
+		provision.Register("fake", func() (provision.Provisioner, error) {
+			return provisiontest.ProvisionerInstance, nil
+		})
+	}()
+	var requests []*http.Request
+	server, err := testing.NewServer("127.0.0.1:0", nil, func(r *http.Request) {
+		requests = append(requests, r)
+	})
+	c.Assert(err, check.IsNil)
+	defer server.Stop()
+	config.Set("docker:registry", "localhost:3030")
+	defer config.Unset("docker:registry")
+	b := dockerBuilder{}
+	args := make(map[string]string)
+	args["dockerfile"] = "http://localhost/Dockerfile"
+	err = b.PlatformAdd(builder.PlatformOptions{
+		Name:   "test",
+		Args:   args,
+		Output: ioutil.Discard,
+	})
+	c.Assert(err, check.ErrorMatches, "No Docker nodes available")
 }
 
 func (s *S) TestPlatformRemove(c *check.C) {


### PR DESCRIPTION
When building platforms, instead of trying to build it for every available builder, now it stops after the first successful build.

Eventually, when we start supporting other types of containers, we will need to change this behavior.