### PR TITLE
fix service unbind causing wrong env vars to be removed from app

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -921,13 +921,11 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	return a.SetEnvs(
-		bind.SetEnvApp{
-			Envs:          variables,
-			PublicOnly:    true,
-			ShouldRestart: !e.NoRestart,
-		}, writer,
-	)
+	return a.SetEnvs(bind.SetEnvArgs{
+		Envs:          variables,
+		ShouldRestart: !e.NoRestart,
+		Writer:        writer,
+	})
 }
 
 // title: unset envs
@@ -977,13 +975,11 @@ func unsetEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) 
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	noRestart, _ := strconv.ParseBool(r.FormValue("noRestart"))
-	return a.UnsetEnvs(
-		bind.UnsetEnvApp{
-			VariableNames: variables,
-			PublicOnly:    true,
-			ShouldRestart: !noRestart,
-		}, writer,
-	)
+	return a.UnsetEnvs(bind.UnsetEnvArgs{
+		VariableNames: variables,
+		ShouldRestart: !noRestart,
+		Writer:        writer,
+	})
 }
 
 // title: set cname
@@ -1238,7 +1234,7 @@ func bindServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token) (
 		return err
 	}
 	fmt.Fprintf(writer, "\nInstance %q is now bound to the app %q.\n", instanceName, appName)
-	envs := a.InstanceEnv(instanceName)
+	envs := a.InstanceEnvs(serviceName, instanceName)
 	if len(envs) > 0 {
 		fmt.Fprintf(writer, "The following environment variables are available for use in your app:\n\n")
 		for k := range envs {

--- a/app/actions.go
+++ b/app/actions.go
@@ -133,12 +133,10 @@ var exportEnvironmentsAction = action.Action{
 			{Name: "TSURU_APPDIR", Value: defaultAppDir},
 			{Name: "TSURU_APP_TOKEN", Value: t.GetValue()},
 		}
-		err = app.setEnvsToApp(
-			bind.SetEnvApp{
-				Envs:          envVars,
-				PublicOnly:    false,
-				ShouldRestart: false,
-			}, nil)
+		err = app.SetEnvs(bind.SetEnvArgs{
+			Envs:          envVars,
+			ShouldRestart: false,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -150,12 +148,10 @@ var exportEnvironmentsAction = action.Action{
 		app, err := GetByName(app.Name)
 		if err == nil {
 			vars := []string{"TSURU_APPNAME", "TSURU_APPDIR", "TSURU_APP_TOKEN"}
-			app.UnsetEnvs(
-				bind.UnsetEnvApp{
-					VariableNames: vars,
-					PublicOnly:    false,
-					ShouldRestart: true,
-				}, nil)
+			app.UnsetEnvs(bind.UnsetEnvArgs{
+				VariableNames: vars,
+				ShouldRestart: true,
+			})
 		}
 	},
 	MinParams: 1,

--- a/app/actions_test.go
+++ b/app/actions_test.go
@@ -165,7 +165,7 @@ func (s *S) TestExportEnvironmentsForward(c *check.C) {
 	c.Assert(result, check.Equals, nil)
 	gotApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
-	appEnv := gotApp.InstanceEnv("")
+	appEnv := gotApp.Envs()
 	c.Assert(appEnv["TSURU_APPNAME"].Value, check.Equals, app.Name)
 	c.Assert(appEnv["TSURU_APPNAME"].Public, check.Equals, false)
 	c.Assert(appEnv["TSURU_APP_TOKEN"].Value, check.Not(check.Equals), "")

--- a/app/bind/binder.go
+++ b/app/bind/binder.go
@@ -10,9 +10,14 @@ import "io"
 
 // EnvVar represents a environment variable for an app.
 type EnvVar struct {
-	Name         string `json:"name"`
-	Value        string `json:"value"`
-	Public       bool   `json:"public"`
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Public bool   `json:"public"`
+}
+
+type ServiceEnvVar struct {
+	EnvVar       `bson:",inline"`
+	ServiceName  string `json:"-"`
 	InstanceName string `json:"-"`
 }
 
@@ -32,41 +37,34 @@ type App interface {
 	// GetUnits returns the app units.
 	GetUnits() ([]Unit, error)
 
-	// InstanceEnv returns the app environment variables.
-	InstanceEnv(string) map[string]EnvVar
-
-	// SetEnvs adds environment variables in the app.
-	SetEnvs(setEnvs SetEnvApp, w io.Writer) error
-
-	// UnsetEnvs removes the given environment variables from the app.
-	UnsetEnvs(unsetEnvs UnsetEnvApp, w io.Writer) error
-
 	// AddInstance adds an instance to the application.
-	AddInstance(instanceApp InstanceApp, writer io.Writer) error
+	AddInstance(args AddInstanceArgs) error
 
 	// RemoveInstance removes an instance from the application.
-	RemoveInstance(instanceApp InstanceApp, writer io.Writer) error
+	RemoveInstance(args RemoveInstanceArgs) error
 }
 
-type ServiceInstance struct {
-	Name string            `json:"instance_name"`
-	Envs map[string]string `json:"envs"`
-}
-
-type SetEnvApp struct {
+type SetEnvArgs struct {
 	Envs          []EnvVar
-	PublicOnly    bool
+	Writer        io.Writer
 	ShouldRestart bool
 }
 
-type UnsetEnvApp struct {
+type UnsetEnvArgs struct {
 	VariableNames []string
-	PublicOnly    bool
+	Writer        io.Writer
 	ShouldRestart bool
 }
 
-type InstanceApp struct {
+type AddInstanceArgs struct {
+	Envs          []ServiceEnvVar
+	Writer        io.Writer
+	ShouldRestart bool
+}
+
+type RemoveInstanceArgs struct {
 	ServiceName   string
-	Instance      ServiceInstance
+	InstanceName  string
+	Writer        io.Writer
 	ShouldRestart bool
 }

--- a/app/migrate/migrate.go
+++ b/app/migrate/migrate.go
@@ -5,8 +5,12 @@
 package migrate
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 
+	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/router"
 	"gopkg.in/mgo.v2/bson"
@@ -47,6 +51,56 @@ func MigrateAppPlanRouterToRouter() error {
 			r = app.Plan.Router
 		}
 		err = conn.Apps().Update(bson.M{"name": app.Name}, bson.M{"$set": bson.M{"router": r}})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func MigrateAppTsuruServicesVarToServiceEnvs() error {
+	conn, err := db.Conn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	iter := conn.Apps().Find(nil).Iter()
+	var a app.App
+	for iter.Next(&a) {
+		serviceEnvVar := a.Env[app.TsuruServicesEnvVar]
+		if serviceEnvVar.Value == "" {
+			continue
+		}
+		var data map[string][]struct {
+			InstanceName string            `json:"instance_name"`
+			Envs         map[string]string `json:"envs"`
+		}
+		err = json.Unmarshal([]byte(serviceEnvVar.Value), &data)
+		if err != nil {
+			return err
+		}
+		var serviceNames []string
+		for serviceName := range data {
+			serviceNames = append(serviceNames, serviceName)
+		}
+		sort.Strings(serviceNames)
+		var serviceEnvs []bind.ServiceEnvVar
+		for _, serviceName := range serviceNames {
+			instances := data[serviceName]
+			for _, instance := range instances {
+				for k, v := range instance.Envs {
+					serviceEnvs = append(serviceEnvs, bind.ServiceEnvVar{
+						ServiceName:  serviceName,
+						InstanceName: instance.InstanceName,
+						EnvVar:       bind.EnvVar{Name: k, Value: v},
+					})
+				}
+			}
+		}
+		err = conn.Apps().Update(bson.M{"name": a.Name}, bson.M{
+			"$push":  bson.M{"serviceenvs": bson.M{"$each": serviceEnvs, "$position": 0}},
+			"$unset": bson.M{"env." + app.TsuruServicesEnvVar: ""},
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/tsurud/migrate.go
+++ b/cmd/tsurud/migrate.go
@@ -78,6 +78,10 @@ func init() {
 	if err != nil {
 		log.Fatalf("unable to register migration: %s", err)
 	}
+	err = migration.Register("migrate-app-service-envs", appMigrate.MigrateAppTsuruServicesVarToServiceEnvs)
+	if err != nil {
+		log.Fatalf("unable to register migration: %s", err)
+	}
 	err = migration.RegisterOptional("migrate-roles", migrateRoles)
 	if err != nil {
 		log.Fatalf("unable to register migration: %s", err)

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -116,6 +116,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 								"[ -d /home/application/current ] && cd /home/application/current; curl -fsSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register && exec cm1",
 							},
 							Env: []apiv1.EnvVar{
+								{Name: "TSURU_SERVICES", Value: "{}"},
 								{Name: "TSURU_PROCESSNAME", Value: "p1"},
 								{Name: "TSURU_HOST", Value: ""},
 								{Name: "port", Value: "8888"},

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -64,13 +64,6 @@ func (s *S) TestFakeAppGetSwap(c *check.C) {
 	c.Assert(app.GetSwap(), check.Equals, int64(0))
 }
 
-func (s *S) TestFakeAppSerializeEnvVars(c *check.C) {
-	app := NewFakeApp("sou", "otm", 0)
-	err := app.SerializeEnvVars()
-	c.Assert(err, check.IsNil)
-	c.Assert(app.Commands, check.DeepEquals, []string{"serialize"})
-}
-
 func (s *S) TestEnvs(c *check.C) {
 	app := FakeApp{name: "time"}
 	env := bind.EnvVar{
@@ -103,12 +96,10 @@ func (s *S) TestSetEnvs(c *check.C) {
 			Public: true,
 		},
 	}
-	app.SetEnvs(
-		bind.SetEnvApp{
-			Envs:          envs,
-			PublicOnly:    false,
-			ShouldRestart: true,
-		}, nil)
+	app.SetEnvs(bind.SetEnvArgs{
+		Envs:          envs,
+		ShouldRestart: true,
+	})
 	expected := map[string]bind.EnvVar{
 		"http_proxy": {
 			Name:   "http_proxy",
@@ -142,12 +133,10 @@ func (s *S) TestUnsetEnvs(c *check.C) {
 		Public: true,
 	}
 	app.SetEnv(env)
-	app.UnsetEnvs(
-		bind.UnsetEnvApp{
-			VariableNames: []string{"http_proxy"},
-			PublicOnly:    false,
-			ShouldRestart: true,
-		}, nil)
+	app.UnsetEnvs(bind.UnsetEnvArgs{
+		VariableNames: []string{"http_proxy"},
+		ShouldRestart: true,
+	})
 	c.Assert(app.env, check.DeepEquals, map[string]bind.EnvVar{})
 }
 
@@ -208,100 +197,113 @@ func (s *S) TestFakeAppGetCname(c *check.C) {
 	c.Assert(app.GetCname(), check.DeepEquals, []string{"cname1", "cname2"})
 }
 
-func (s *S) TestFakeAppGetInstances(c *check.C) {
-	instance1 := bind.ServiceInstance{Name: "inst1"}
-	instance2 := bind.ServiceInstance{Name: "inst2"}
-	app := NewFakeApp("sou", "otm", 0)
-	app.instances["mysql"] = []bind.ServiceInstance{instance1, instance2}
-	instances := app.GetInstances("mysql")
-	c.Assert(instances, check.DeepEquals, []bind.ServiceInstance{instance1, instance2})
-	instances = app.GetInstances("mongodb")
-	c.Assert(instances, check.HasLen, 0)
-}
-
 func (s *S) TestFakeAppAddInstance(c *check.C) {
-	instance1 := bind.ServiceInstance{Name: "inst1"}
-	instance2 := bind.ServiceInstance{Name: "inst2"}
 	app := NewFakeApp("sou", "otm", 0)
-	err := app.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance1,
-			ShouldRestart: true,
-		}, nil)
+	err := app.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{
+				ServiceName:  "mysql",
+				InstanceName: "inst1",
+				EnvVar:       bind.EnvVar{Name: "env1", Value: "val1"},
+			},
+		},
+		ShouldRestart: true,
+	})
 	c.Assert(err, check.IsNil)
-	err = app.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   "mongodb",
-			Instance:      instance2,
-			ShouldRestart: false,
-		}, nil)
+	err = app.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{
+				ServiceName:  "mongodb",
+				InstanceName: "inst2",
+				EnvVar:       bind.EnvVar{Name: "env2", Value: "val2"},
+			},
+		},
+		ShouldRestart: true,
+	})
 	c.Assert(err, check.IsNil)
-	instances := app.GetInstances("mysql")
-	c.Assert(instances, check.DeepEquals, []bind.ServiceInstance{instance1})
-	instances = app.GetInstances("mongodb")
-	c.Assert(instances, check.DeepEquals, []bind.ServiceInstance{instance2})
-	instances = app.GetInstances("redis")
-	c.Assert(instances, check.HasLen, 0)
+	envs := app.GetServiceEnvs()
+	c.Assert(envs, check.DeepEquals, []bind.ServiceEnvVar{
+		{
+			ServiceName:  "mysql",
+			InstanceName: "inst1",
+			EnvVar:       bind.EnvVar{Name: "env1", Value: "val1"},
+		},
+		{
+			ServiceName:  "mongodb",
+			InstanceName: "inst2",
+			EnvVar:       bind.EnvVar{Name: "env2", Value: "val2"},
+		},
+	})
 }
 
 func (s *S) TestFakeAppRemoveInstance(c *check.C) {
-	instance1 := bind.ServiceInstance{Name: "inst1"}
-	instance2 := bind.ServiceInstance{Name: "inst2"}
 	app := NewFakeApp("sou", "otm", 0)
-	app.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance1,
-			ShouldRestart: true,
-		}, nil)
-	app.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   "mongodb",
-			Instance:      instance2,
-			ShouldRestart: false,
-		}, nil)
-	err := app.RemoveInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance1,
-			ShouldRestart: true,
-		}, nil)
+	err := app.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{
+				ServiceName:  "mysql",
+				InstanceName: "inst1",
+				EnvVar:       bind.EnvVar{Name: "env1", Value: "val1"},
+			},
+		},
+		ShouldRestart: true,
+	})
 	c.Assert(err, check.IsNil)
-	instances := app.GetInstances("mysql")
-	c.Assert(instances, check.HasLen, 0)
-	instances = app.GetInstances("mongodb")
-	c.Assert(instances, check.HasLen, 1)
+	err = app.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{
+				ServiceName:  "mongodb",
+				InstanceName: "inst2",
+				EnvVar:       bind.EnvVar{Name: "env2", Value: "val2"},
+			},
+		},
+		ShouldRestart: true,
+	})
+	c.Assert(err, check.IsNil)
+	err = app.RemoveInstance(bind.RemoveInstanceArgs{
+		ServiceName:   "mysql",
+		InstanceName:  "inst1",
+		ShouldRestart: true,
+	})
+	c.Assert(err, check.IsNil)
+	envs := app.GetServiceEnvs()
+	c.Assert(envs, check.DeepEquals, []bind.ServiceEnvVar{
+		{
+			ServiceName:  "mongodb",
+			InstanceName: "inst2",
+			EnvVar:       bind.EnvVar{Name: "env2", Value: "val2"},
+		},
+	})
 }
 
 func (s *S) TestFakeAppRemoveInstanceNotFound(c *check.C) {
-	instance1 := bind.ServiceInstance{Name: "inst1"}
-	instance2 := bind.ServiceInstance{Name: "inst2"}
 	app := NewFakeApp("sou", "otm", 0)
-	app.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance1,
-			ShouldRestart: true,
-		}, nil)
-	err := app.RemoveInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance2,
-			ShouldRestart: true,
-		}, nil)
+	err := app.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{
+				ServiceName:  "mysql",
+				InstanceName: "inst1",
+				EnvVar:       bind.EnvVar{Name: "env1", Value: "val1"},
+			},
+		},
+		ShouldRestart: true,
+	})
+	c.Assert(err, check.IsNil)
+	err = app.RemoveInstance(bind.RemoveInstanceArgs{
+		ServiceName:   "mysql",
+		InstanceName:  "inst2",
+		ShouldRestart: true,
+	})
 	c.Assert(err.Error(), check.Equals, "instance not found")
 }
 
 func (s *S) TestFakeAppRemoveInstanceServiceNotFound(c *check.C) {
-	instance := bind.ServiceInstance{Name: "inst1"}
 	app := NewFakeApp("sou", "otm", 0)
-	err := app.RemoveInstance(
-		bind.InstanceApp{
-			ServiceName:   "mysql",
-			Instance:      instance,
-			ShouldRestart: true,
-		}, nil)
+	err := app.RemoveInstance(bind.RemoveInstanceArgs{
+		ServiceName:   "mysql",
+		InstanceName:  "inst2",
+		ShouldRestart: true,
+	})
 	c.Assert(err.Error(), check.Equals, "instance not found")
 }
 

--- a/service/actions.go
+++ b/service/actions.go
@@ -179,26 +179,34 @@ var setBoundEnvsAction = &action.Action{
 		if args == nil {
 			return nil, errors.New("invalid arguments for pipeline, expected *bindPipelineArgs")
 		}
-		instance := bind.ServiceInstance{
-			Name: args.serviceInstance.Name,
-			Envs: ctx.Previous.(map[string]string),
+		envMap := ctx.Previous.(map[string]string)
+		envs := make([]bind.ServiceEnvVar, 0, len(envMap))
+		for k, v := range envMap {
+			envs = append(envs, bind.ServiceEnvVar{
+				ServiceName:  args.serviceInstance.ServiceName,
+				InstanceName: args.serviceInstance.Name,
+				EnvVar: bind.EnvVar{
+					Public: false,
+					Name:   k,
+					Value:  v,
+				},
+			})
 		}
-		return instance, args.app.AddInstance(
-			bind.InstanceApp{
-				ServiceName:   args.serviceInstance.ServiceName,
-				Instance:      instance,
-				ShouldRestart: args.shouldRestart,
-			}, args.writer)
+		addArgs := bind.AddInstanceArgs{
+			Envs:          envs,
+			ShouldRestart: args.shouldRestart,
+			Writer:        args.writer,
+		}
+		return addArgs, args.app.AddInstance(addArgs)
 	},
 	Backward: func(ctx action.BWContext) {
 		args, _ := ctx.Params[0].(*bindPipelineArgs)
-		instance := ctx.FWResult.(bind.ServiceInstance)
-		err := args.app.RemoveInstance(
-			bind.InstanceApp{
-				ServiceName:   args.serviceInstance.ServiceName,
-				Instance:      instance,
-				ShouldRestart: args.shouldRestart,
-			}, args.writer)
+		err := args.app.RemoveInstance(bind.RemoveInstanceArgs{
+			ServiceName:   args.serviceInstance.ServiceName,
+			InstanceName:  args.serviceInstance.Name,
+			ShouldRestart: args.shouldRestart,
+			Writer:        args.writer,
+		})
 		if err != nil {
 			log.Errorf("[set-bound-envs backward] failed to remove instance: %s", err)
 		}
@@ -363,16 +371,12 @@ var removeBoundEnvs = action.Action{
 			return nil, errors.New("invalid arguments for pipeline, expected *bindPipelineArgs")
 		}
 		si := args.serviceInstance
-		instance := bind.ServiceInstance{Name: si.Name, Envs: make(map[string]string)}
-		for k, envVar := range args.app.InstanceEnv(si.Name) {
-			instance.Envs[k] = envVar.Value
-		}
-		return nil, args.app.RemoveInstance(
-			bind.InstanceApp{
-				ServiceName:   si.ServiceName,
-				Instance:      instance,
-				ShouldRestart: args.shouldRestart,
-			}, args.writer)
+		return nil, args.app.RemoveInstance(bind.RemoveInstanceArgs{
+			ServiceName:   si.ServiceName,
+			InstanceName:  si.Name,
+			ShouldRestart: args.shouldRestart,
+			Writer:        args.writer,
+		})
 	},
 	Backward: func(ctx action.BWContext) {
 	},

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -663,13 +663,13 @@ func (s *InstanceSuite) TestUnbindApp(c *check.C) {
 	}
 	err = si.Create()
 	c.Assert(err, check.IsNil)
-	instance := bind.ServiceInstance{Name: si.Name, Envs: map[string]string{"ENV1": "VAL1", "ENV2": "VAL2"}}
-	err = a.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   si.ServiceName,
-			Instance:      instance,
-			ShouldRestart: true,
-		}, nil)
+	err = a.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{EnvVar: bind.EnvVar{Name: "ENV1", Value: "VAL1"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+			{EnvVar: bind.EnvVar{Name: "ENV2", Value: "VAL2"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+		},
+		ShouldRestart: true,
+	})
 	c.Assert(err, check.IsNil)
 	units, err := a.Units()
 	c.Assert(err, check.IsNil)
@@ -695,7 +695,7 @@ func (s *InstanceSuite) TestUnbindApp(c *check.C) {
 	siDB, err := GetServiceInstance("mysql", si.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(siDB.Apps, check.DeepEquals, []string{})
-	c.Assert(a.GetInstances("mysql"), check.DeepEquals, []bind.ServiceInstance{})
+	c.Assert(a.GetServiceEnvs(), check.DeepEquals, []bind.ServiceEnvVar{})
 }
 
 func (s *InstanceSuite) TestUnbindAppFailureInUnbindAppCall(c *check.C) {
@@ -725,13 +725,13 @@ func (s *InstanceSuite) TestUnbindAppFailureInUnbindAppCall(c *check.C) {
 	}
 	err = si.Create()
 	c.Assert(err, check.IsNil)
-	instance := bind.ServiceInstance{Name: si.Name, Envs: map[string]string{"ENV1": "VAL1", "ENV2": "VAL2"}}
-	err = a.AddInstance(
-		bind.InstanceApp{
-			ServiceName:   si.ServiceName,
-			Instance:      instance,
-			ShouldRestart: true,
-		}, nil)
+	err = a.AddInstance(bind.AddInstanceArgs{
+		Envs: []bind.ServiceEnvVar{
+			{EnvVar: bind.EnvVar{Name: "ENV1", Value: "VAL1"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+			{EnvVar: bind.EnvVar{Name: "ENV2", Value: "VAL2"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+		},
+		ShouldRestart: true,
+	})
 	c.Assert(err, check.IsNil)
 	units, err := a.Units()
 	c.Assert(err, check.IsNil)
@@ -762,7 +762,10 @@ func (s *InstanceSuite) TestUnbindAppFailureInUnbindAppCall(c *check.C) {
 	siDB, err := GetServiceInstance(si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(siDB.Apps, check.DeepEquals, []string{"myapp"})
-	c.Assert(a.GetInstances("mysql"), check.DeepEquals, []bind.ServiceInstance{instance})
+	c.Assert(a.GetServiceEnvs(), check.DeepEquals, []bind.ServiceEnvVar{
+		{EnvVar: bind.EnvVar{Name: "ENV1", Value: "VAL1"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+		{EnvVar: bind.EnvVar{Name: "ENV2", Value: "VAL2"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+	})
 }
 
 func (s *InstanceSuite) TestUnbindAppFailureInAppEnvSet(c *check.C) {
@@ -858,8 +861,9 @@ func (s *InstanceSuite) TestBindAppFullPipeline(c *check.C) {
 	siDB, err := GetServiceInstance(si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(siDB.Apps, check.DeepEquals, []string{"myapp"})
-	c.Assert(a.GetInstances("mysql"), check.DeepEquals, []bind.ServiceInstance{
-		{Name: "my-mysql", Envs: map[string]string{"ENV1": "VAL1", "ENV2": "VAL2"}},
+	c.Assert(a.GetServiceEnvs(), check.DeepEquals, []bind.ServiceEnvVar{
+		{EnvVar: bind.EnvVar{Name: "ENV1", Value: "VAL1"}, ServiceName: "mysql", InstanceName: "my-mysql"},
+		{EnvVar: bind.EnvVar{Name: "ENV2", Value: "VAL2"}, ServiceName: "mysql", InstanceName: "my-mysql"},
 	})
 }
 


### PR DESCRIPTION
Currently, after binding two service-instances with the same name (but different services) to a single app may cause tsuru to remove environment variables injected by both instances when unbinding either service-instance.

This PR also improves existing test cases and add new ones to ensure this bug is reproducible and gone for good.