### PR TITLE
api/context: replaces gorilla/context with stdlib context

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -4937,7 +4937,9 @@ func (s *S) TestGetApp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	expected, err := app.GetByName(a.Name)
 	c.Assert(err, check.IsNil)
-	app, err := getAppFromContext(a.Name, nil)
+	r, err := http.NewRequest(http.MethodGet, "", nil)
+	c.Assert(err, check.IsNil)
+	app, err := getAppFromContext(a.Name, r)
 	c.Assert(err, check.IsNil)
 	c.Assert(app, check.DeepEquals, *expected)
 }

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -26,11 +26,17 @@ const (
 )
 
 func Clear(r *http.Request) {
+	if r == nil {
+		return
+	}
 	newReq := r.WithContext(context.Background())
 	*r = *newReq
 }
 
 func GetApp(r *http.Request) *app.App {
+	if r == nil {
+		return nil
+	}
 	if v, ok := r.Context().Value(appContextKey).(*app.App); ok {
 		return v
 	}
@@ -43,6 +49,9 @@ func SetApp(r *http.Request, a *app.App) {
 }
 
 func GetAuthToken(r *http.Request) auth.Token {
+	if r == nil {
+		return nil
+	}
 	if v, ok := r.Context().Value(tokenContextKey).(auth.Token); ok {
 		return v
 	}
@@ -67,6 +76,9 @@ func AddRequestError(r *http.Request, err error) {
 }
 
 func GetRequestError(r *http.Request) error {
+	if r == nil {
+		return nil
+	}
 	if v, ok := r.Context().Value(errorContextKey).(error); ok {
 		return v
 	}
@@ -79,6 +91,9 @@ func SetDelayedHandler(r *http.Request, h http.Handler) {
 }
 
 func GetDelayedHandler(r *http.Request) http.Handler {
+	if r == nil {
+		return nil
+	}
 	if v, ok := r.Context().Value(delayedHandlerKey).(http.Handler); ok {
 		return v
 	}
@@ -91,6 +106,9 @@ func SetPreventUnlock(r *http.Request) {
 }
 
 func IsPreventUnlock(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
 	if v, ok := r.Context().Value(preventUnlockKey).(bool); ok {
 		return v
 	}
@@ -103,6 +121,9 @@ func SetRequestID(r *http.Request, requestIDHeader, requestID string) {
 }
 
 func GetRequestID(r *http.Request, requestIDHeader string) string {
+	if r == nil {
+		return ""
+	}
 	requestID := r.Context().Value(reqIDHeaderCtxKey(requestIDHeader))
 	if requestID == nil {
 		return ""

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gorilla/context"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
@@ -61,10 +60,12 @@ func (s *S) TearDownSuite(c *check.C) {
 func (s *S) TestClear(c *check.C) {
 	r, err := http.NewRequest("GET", "/", nil)
 	c.Assert(err, check.IsNil)
-	context.Set(r, "my-key", "value")
+	SetRequestID(r, "X-RID", "xpto")
+	val := GetRequestID(r, "X-RID")
+	c.Assert(val, check.DeepEquals, "xpto")
 	Clear(r)
-	val := context.Get(r, "my-key")
-	c.Assert(val, check.IsNil)
+	val = GetRequestID(r, "X-RID")
+	c.Assert(val, check.DeepEquals, "")
 }
 
 func (s *S) TestGetAuthToken(c *check.C) {

--- a/api/shutdown/shutdown_test.go
+++ b/api/shutdown/shutdown_test.go
@@ -57,7 +57,7 @@ func (s *S) TestDoTimeout(c *check.C) {
 		sleep: time.Duration(2) * time.Second,
 	}
 	Register(ts)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 	err := Do(ctx, ioutil.Discard)
 	cancel()
 	c.Assert(err, check.DeepEquals, context.DeadlineExceeded)

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -12,8 +12,8 @@ import (
 
 	stdcontext "context"
 
-	"github.com/gorilla/context"
 	"github.com/tsuru/config"
+
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/auth/native"
@@ -131,7 +131,6 @@ func (s *S) TearDownTest(c *check.C) {
 	s.provisioner.Reset()
 	s.conn.Close()
 	s.logConn.Close()
-	context.Purge(-1)
 }
 
 func (s *S) TearDownSuite(c *check.C) {


### PR DESCRIPTION
This PR replaces the use of gorilla/context in the api/context pkg with the std library context (introduced in go 1.7).

Fixes #1503