### PR TITLE
Service Bind sync

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -4389,7 +4389,7 @@ func (s *S) TestUnbindHandler(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"painkiller"},
-		Units:       []string{units[0].ID},
+		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
@@ -4487,7 +4487,7 @@ func (s *S) TestUnbindNoRestartFlag(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"painkiller"},
-		Units:       []string{units[0].ID},
+		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
@@ -4590,14 +4590,14 @@ func (s *S) TestUnbindWithSameInstanceName(c *check.C) {
 			ServiceName: "mysql",
 			Teams:       []string{s.team.Name},
 			Apps:        []string{"painkiller"},
-			Units:       []string{units[0].ID},
+			BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 		},
 		{
 			Name:        "my-mysql",
 			ServiceName: "mysql2",
 			Teams:       []string{s.team.Name},
 			Apps:        []string{"painkiller"},
-			Units:       []string{units[0].ID},
+			BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 		},
 	}
 	for _, instance := range instances {

--- a/api/server.go
+++ b/api/server.go
@@ -418,21 +418,12 @@ func startServer(handler http.Handler) {
 	if err != nil {
 		fatal(err)
 	}
-	syncer := &service.BindSyncer{
-		Interval:  time.Minute * 5,
-		AppLister: bindAppsLister,
-	}
-	err = syncer.Start()
-	if err != nil {
-		fatal(err)
-	}
 	srv := &http.Server{
 		ReadTimeout:  time.Duration(readTimeout) * time.Second,
 		WriteTimeout: time.Duration(writeTimeout) * time.Second,
 		Addr:         listen,
 		Handler:      handler,
 	}
-	shutdown.Register(syncer)
 	shutdown.Register(&logTracker)
 	shutdown.Register(srv)
 	shutdownChan := make(chan bool)
@@ -510,6 +501,10 @@ func startServer(handler http.Handler) {
 	err = event.LoadThrottling()
 	if err != nil {
 		fatal(errors.Wrap(err, "unable to load events throttling config"))
+	}
+	err = service.InitializeSync(bindAppsLister)
+	if err != nil {
+		fatal(err)
 	}
 	fmt.Println("Checking components status:")
 	results := hc.Check()

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -751,7 +751,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWithSameInstaceName(c *c
 			ServiceName: "foo",
 			Teams:       []string{s.team.Name},
 			Apps:        []string{"app-instance"},
-			Units:       []string{units[0].ID},
+			BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 		},
 		{
 			Name:        "foo-instance",
@@ -871,7 +871,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithUn
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"painkiller"},
-		Units:       []string{units[0].ID},
+		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
@@ -922,7 +922,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithNo
 		ServiceName: "mysqlremove",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"app1"},
-		Units:       []string{units[0].ID},
+		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
@@ -973,7 +973,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithNo
 		ServiceName: "mysqlremove",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"app", "app2"},
-		Units:       []string{units[0].ID},
+		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)

--- a/app/app.go
+++ b/app/app.go
@@ -483,7 +483,7 @@ func processTags(tags []string) []string {
 // them. This method is used by Destroy (before destroying the app, it unbinds
 // all service instances). Refer to Destroy docs for more details.
 func (app *App) unbind() error {
-	instances, err := app.serviceInstances()
+	instances, err := service.GetServiceInstancesBoundToApp(app.Name)
 	if err != nil {
 		return err
 	}
@@ -626,7 +626,7 @@ func Delete(app *App, w io.Writer) error {
 }
 
 func (app *App) BindUnit(unit *provision.Unit) error {
-	instances, err := app.serviceInstances()
+	instances, err := service.GetServiceInstancesBoundToApp(app.Name)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func (app *App) BindUnit(unit *provision.Unit) error {
 }
 
 func (app *App) UnbindUnit(unit *provision.Unit) error {
-	instances, err := app.serviceInstances()
+	instances, err := service.GetServiceInstancesBoundToApp(app.Name)
 	if err != nil {
 		return err
 	}
@@ -663,21 +663,6 @@ func (app *App) UnbindUnit(unit *provision.Unit) error {
 		}
 	}
 	return nil
-}
-
-func (app *App) serviceInstances() ([]service.ServiceInstance, error) {
-	conn, err := db.Conn()
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-	var instances []service.ServiceInstance
-	q := bson.M{"apps": bson.M{"$in": []string{app.Name}}}
-	err = conn.ServiceInstances().Find(q).All(&instances)
-	if err != nil {
-		return nil, err
-	}
-	return instances, nil
 }
 
 // AddUnits creates n new units within the provisioner, saves new units in the

--- a/provision/docker/suite_test.go
+++ b/provision/docker/suite_test.go
@@ -197,7 +197,7 @@ func (s *S) startMultipleServersCluster() (*dockerProvisioner, error) {
 	return &p, nil
 }
 
-func (s *S) addServiceInstance(c *check.C, appName string, units []string, fn http.HandlerFunc) func() {
+func (s *S) addServiceInstance(c *check.C, appName string, unitsIDs []string, fn http.HandlerFunc) func() {
 	ts := httptest.NewServer(fn)
 	ret := func() {
 		ts.Close()
@@ -207,7 +207,17 @@ func (s *S) addServiceInstance(c *check.C, appName string, units []string, fn ht
 	srvc := service.Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}, Password: "abcde"}
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
-	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{}, Units: units, Apps: []string{appName}}
+	var units []service.Unit
+	for _, s := range unitsIDs {
+		units = append(units, service.Unit{ID: s})
+	}
+	instance := service.ServiceInstance{
+		Name:        "my-mysql",
+		ServiceName: "mysql",
+		Teams:       []string{},
+		BoundUnits:  units,
+		Apps:        []string{appName},
+	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
 	return ret

--- a/provision/swarm/provisioner_test.go
+++ b/provision/swarm/provisioner_test.go
@@ -1120,7 +1120,7 @@ func (s *S) TestRegisterUnit(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(tasks, check.HasLen, 1)
 	var serviceBodies []string
-	rollback := s.addServiceInstance(c, a.Name, nil, func(w http.ResponseWriter, r *http.Request) {
+	rollback := s.addServiceInstance(c, a.Name, func(w http.ResponseWriter, r *http.Request) {
 		data, _ := ioutil.ReadAll(r.Body)
 		serviceBodies = append(serviceBodies, string(data))
 		w.WriteHeader(http.StatusOK)
@@ -1178,7 +1178,7 @@ func (s *S) TestRegisterUnitNotBuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(conts, check.HasLen, 1)
 	var serviceBodies []string
-	rollback := s.addServiceInstance(c, a.Name, nil, func(w http.ResponseWriter, r *http.Request) {
+	rollback := s.addServiceInstance(c, a.Name, func(w http.ResponseWriter, r *http.Request) {
 		data, _ := ioutil.ReadAll(r.Body)
 		serviceBodies = append(serviceBodies, string(data))
 		w.WriteHeader(http.StatusOK)
@@ -1316,7 +1316,7 @@ func (s *S) TestDeployServiceBind(c *check.C) {
 	c.Assert(err, check.IsNil)
 	attached := s.attachRegister(c, srv, true, a)
 	var serviceBodies []string
-	rollback := s.addServiceInstance(c, a.Name, nil, func(w http.ResponseWriter, r *http.Request) {
+	rollback := s.addServiceInstance(c, a.Name, func(w http.ResponseWriter, r *http.Request) {
 		data, _ := ioutil.ReadAll(r.Body)
 		serviceBodies = append(serviceBodies, string(data))
 		w.WriteHeader(http.StatusOK)

--- a/provision/swarm/suite_test.go
+++ b/provision/swarm/suite_test.go
@@ -90,7 +90,7 @@ func (s *S) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) addServiceInstance(c *check.C, appName string, units []string, fn http.HandlerFunc) func() {
+func (s *S) addServiceInstance(c *check.C, appName string, fn http.HandlerFunc) func() {
 	ts := httptest.NewServer(fn)
 	ret := func() {
 		ts.Close()
@@ -100,7 +100,7 @@ func (s *S) addServiceInstance(c *check.C, appName string, units []string, fn ht
 	srvc := service.Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}, Password: "abcde"}
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
-	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{}, Units: units, Apps: []string{appName}}
+	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{}, Apps: []string{appName}}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)
 	return ret

--- a/service/actions_test.go
+++ b/service/actions_test.go
@@ -376,7 +376,7 @@ func (s *S) TestUnbindUnitsForward(c *check.C) {
 	}
 	siDB, err := GetServiceInstance(si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(siDB.Units, check.DeepEquals, []string{})
+	c.Assert(siDB.BoundUnits, check.DeepEquals, []Unit{})
 }
 
 func (s *S) TestUnbindUnitsForwardPartialFailure(c *check.C) {
@@ -428,8 +428,12 @@ func (s *S) TestUnbindUnitsForwardPartialFailure(c *check.C) {
 	}
 	siDB, err := GetServiceInstance(si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
-	sort.Strings(siDB.Units)
-	c.Assert(siDB.Units, check.DeepEquals, []string{
+	var unitIDs []string
+	for _, u := range siDB.BoundUnits {
+		unitIDs = append(unitIDs, u.ID)
+	}
+	sort.Strings(unitIDs)
+	c.Assert(unitIDs, check.DeepEquals, []string{
 		"myapp-0",
 		"myapp-1",
 		"myapp-2",
@@ -474,8 +478,12 @@ func (s *S) TestUnbindUnitsBackward(c *check.C) {
 	}
 	siDB, err := GetServiceInstance(si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
-	sort.Strings(siDB.Units)
-	c.Assert(siDB.Units, check.DeepEquals, []string{
+	var unitIDs []string
+	for _, u := range siDB.BoundUnits {
+		unitIDs = append(unitIDs, u.ID)
+	}
+	sort.Strings(unitIDs)
+	c.Assert(unitIDs, check.DeepEquals, []string{
 		"myapp-0",
 		"myapp-1",
 		"myapp-2",

--- a/service/bind_test.go
+++ b/service/bind_test.go
@@ -294,7 +294,7 @@ func (s *BindSuite) TestUnbindUnit(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
-		Units:       []string{units[0].GetID()},
+		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}},
 	}
 	instance.Create()
 	units, err = a.GetUnits()
@@ -304,7 +304,7 @@ func (s *BindSuite) TestUnbindUnit(c *check.C) {
 	c.Assert(called, check.Equals, true)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": "my-mysql"}).One(&instance)
 	c.Assert(err, check.IsNil)
-	c.Assert(instance.Units, check.HasLen, 0)
+	c.Assert(instance.BoundUnits, check.HasLen, 0)
 }
 
 func (s *BindSuite) TestUnbindMultiUnits(c *check.C) {
@@ -336,7 +336,7 @@ func (s *BindSuite) TestUnbindMultiUnits(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
-		Units:       []string{units[0].GetID(), units[1].GetID()},
+		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}, {ID: units[1].GetID(), IP: units[1].GetIp()}},
 	}
 	instance.Create()
 	err = instance.UnbindApp(a, true, nil)
@@ -410,7 +410,7 @@ func (s *BindSuite) TestUnbindCallsTheUnbindMethodFromAPI(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
-		Units:       []string{units[0].GetID()},
+		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}},
 	}
 	err = instance.Create()
 	c.Assert(err, check.IsNil)

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -391,6 +391,21 @@ func GetServiceInstance(serviceName string, instanceName string) (*ServiceInstan
 	return &instance, nil
 }
 
+func GetServiceInstancesBoundToApp(appName string) ([]ServiceInstance, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	var instances []ServiceInstance
+	q := bson.M{"apps": bson.M{"$in": []string{appName}}}
+	err = conn.ServiceInstances().Find(q).All(&instances)
+	if err != nil {
+		return nil, err
+	}
+	return instances, nil
+}
+
 func processTags(tags []string) []string {
 	if tags == nil {
 		return nil

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -40,8 +40,7 @@ type ServiceInstance struct {
 	ServiceName string `bson:"service_name"`
 	PlanName    string `bson:"plan_name"`
 	Apps        []string
-	Units       []string
-	UnitsData   []Unit
+	BoundUnits  []Unit `bson:"bound_units"`
 	Teams       []string
 	TeamOwner   string
 	Description string

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -150,7 +150,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToApp(c *check.C) {
 		Tags:        []string{},
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"app1", "app2"},
-		Units:       []string{},
+		BoundUnits:  []Unit{},
 	}
 	err = s.conn.ServiceInstances().Insert(&sInstance)
 	c.Assert(err, check.IsNil)
@@ -159,7 +159,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToApp(c *check.C) {
 		ServiceName: "mysql",
 		Tags:        []string{},
 		Apps:        []string{"app1"},
-		Units:       []string{},
+		BoundUnits:  []Unit{},
 		Teams:       []string{},
 	}
 	err = s.conn.ServiceInstances().Insert(&sInstance2)

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -140,6 +140,40 @@ func (s *InstanceSuite) TestBindApp(c *check.C) {
 	c.Assert(buf.String(), check.Equals, "")
 }
 
+func (s *InstanceSuite) TestGetServiceInstancesBoundToApp(c *check.C) {
+	srvc := Service{Name: "mysql"}
+	err := s.conn.Services().Insert(&srvc)
+	c.Assert(err, check.IsNil)
+	sInstance := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Tags:        []string{},
+		Teams:       []string{s.team.Name},
+		Apps:        []string{"app1", "app2"},
+		Units:       []string{},
+	}
+	err = s.conn.ServiceInstances().Insert(&sInstance)
+	c.Assert(err, check.IsNil)
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Tags:        []string{},
+		Apps:        []string{"app1"},
+		Units:       []string{},
+		Teams:       []string{},
+	}
+	err = s.conn.ServiceInstances().Insert(&sInstance2)
+	c.Assert(err, check.IsNil)
+	sInstances, err := GetServiceInstancesBoundToApp("app2")
+	c.Assert(err, check.IsNil)
+	expected := []ServiceInstance{sInstance}
+	c.Assert(sInstances, check.DeepEquals, expected)
+	sInstances, err = GetServiceInstancesBoundToApp("app1")
+	c.Assert(err, check.IsNil)
+	expected = []ServiceInstance{sInstance, sInstance2}
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
 func (s *InstanceSuite) TestGetServiceInstancesByServices(c *check.C) {
 	srvc := Service{Name: "mysql"}
 	err := s.conn.Services().Insert(&srvc)

--- a/service/sync.go
+++ b/service/sync.go
@@ -1,0 +1,138 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/app/bind"
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/log"
+	"github.com/tsuru/tsuru/permission"
+)
+
+type BindSyncer struct {
+	Interval  time.Duration
+	AppLister func() ([]bind.App, error)
+
+	started  bool
+	shutdown chan struct{}
+	done     chan struct{}
+}
+
+// Start starts the sync process on a different goroutine
+func (b *BindSyncer) Start() error {
+	if b.started {
+		return errors.New("syncer already started")
+	}
+	if b.AppLister == nil {
+		return errors.New("must set app lister function")
+	}
+	if b.Interval == 0 {
+		b.Interval = 5 * time.Minute
+	}
+	b.shutdown = make(chan struct{}, 1)
+	b.done = make(chan struct{})
+	b.started = true
+	fmt.Printf("[bind-syncer] starting. Running every %s.\n", b.Interval)
+	go func(d time.Duration) {
+		for {
+			select {
+			case <-time.After(d):
+				log.Debug("[bind-syncer] starting run")
+				apps, err := b.AppLister()
+				if err != nil {
+					log.Errorf("[bind-syncer] error listing apps: %v. Aborting sync.", err)
+					break
+				}
+				for _, a := range apps {
+					err = b.sync(a)
+					if err != nil {
+						log.Errorf("[bind-syncer] error syncing app %q: %v", a.GetName(), err)
+					}
+				}
+				log.Debugf("[bind-syncer] finished running. Synced %d apps.", len(apps))
+				d = b.Interval
+			case <-b.shutdown:
+				b.done <- struct{}{}
+				return
+			}
+		}
+	}(time.Millisecond * 100)
+	return nil
+}
+
+// Shutdown shutdowns BindSyncer waiting for the current sync
+// to complete
+func (b *BindSyncer) Shutdown(ctx context.Context) error {
+	if !b.started {
+		return nil
+	}
+	b.shutdown <- struct{}{}
+	select {
+	case <-b.done:
+	case <-ctx.Done():
+	}
+	b.started = false
+	return ctx.Err()
+}
+
+func (b *BindSyncer) sync(a bind.App) (err error) {
+	evt, err := event.NewInternal(&event.Opts{
+		Target:       event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		InternalKind: "bindsyncer",
+		Allowed:      event.Allowed(permission.PermAppReadEvents, permission.Context(permission.CtxApp, a.GetName())),
+	})
+	if err != nil {
+		if _, ok := err.(event.ErrEventLocked); ok {
+			log.Debugf("[bind-syncer] skipping sync for app %q: event locked", a.GetName())
+			return nil
+		}
+		return errors.Wrap(err, "error trying to insert bind sync event, aborted")
+	}
+	defer func() { evt.Done(err) }()
+	log.Debugf("[bind-syncer] starting sync for app %q", a.GetName())
+	appUnits, err := a.GetUnits()
+	if err != nil {
+		return errors.Wrap(err, "error getting units from app")
+	}
+	units := make([]Unit, len(appUnits))
+	for i := range appUnits {
+		units[i] = Unit{ID: appUnits[i].GetID(), IP: appUnits[i].GetIp()}
+	}
+	instances, err := GetServiceInstancesBoundToApp(a.GetName())
+	if err != nil {
+		return errors.WithMessage(err, "error retrieving service instances bound to app")
+	}
+	for _, instance := range instances {
+		boundUnits := make(map[Unit]struct{})
+		for _, u := range instance.UnitsData {
+			boundUnits[u] = struct{}{}
+		}
+		for _, u := range units {
+			if _, ok := boundUnits[u]; ok {
+				delete(boundUnits, u)
+			} else {
+				log.Debugf("[bind-syncer] binding unit %q from app %q from %s:%s\n", u.ID, a.GetName(), instance.ServiceName, instance.Name)
+				err = instance.BindUnit(a, u)
+				if err != nil {
+					log.Errorf("[bind-syncer] failed to bind unit %q: %v", u.ID, err)
+				}
+			}
+		}
+		for u := range boundUnits {
+			log.Debugf("[bind-syncer] unbinding unit %q from app %q from %s:%s\n", u.ID, a.GetName(), instance.ServiceName, instance.Name)
+			err = instance.UnbindUnit(a, u)
+			if err != nil {
+				log.Errorf("[bind-syncer] failed to unbind unit %q: %v", u.ID, err)
+			}
+		}
+	}
+	log.Debugf("[bind-syncer] finished sync for app %q", a.GetName())
+	return nil
+}

--- a/service/sync.go
+++ b/service/sync.go
@@ -111,7 +111,7 @@ func (b *BindSyncer) sync(a bind.App) (err error) {
 	}
 	for _, instance := range instances {
 		boundUnits := make(map[Unit]struct{})
-		for _, u := range instance.UnitsData {
+		for _, u := range instance.BoundUnits {
 			boundUnits[u] = struct{}{}
 		}
 		for _, u := range units {

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"time"
+
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/app/bind"
+	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/auth/native"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/provisiontest"
+	"github.com/tsuru/tsuru/router/routertest"
+	"github.com/tsuru/tsuru/service"
+	check "gopkg.in/check.v1"
+)
+
+type SyncSuite struct {
+	conn *db.Storage
+	user auth.User
+	team auth.Team
+}
+
+var _ = check.Suite(&SyncSuite{})
+
+func (s *SyncSuite) SetUpSuite(c *check.C) {
+	var err error
+	config.Set("database:url", "127.0.0.1:27017")
+	config.Set("database:name", "tsuru_service_bind_test")
+	config.Set("routers:fake:type", "fake")
+	s.conn, err = db.Conn()
+	c.Assert(err, check.IsNil)
+	app.AuthScheme = auth.Scheme(native.NativeScheme{})
+}
+
+func (s *SyncSuite) SetUpTest(c *check.C) {
+	provisiontest.ProvisionerInstance.Reset()
+	routertest.FakeRouter.Reset()
+	dbtest.ClearAllCollections(s.conn.Apps().Database)
+	s.user = auth.User{Email: "sad-but-true@metallica.com"}
+	err := s.user.Create()
+	c.Assert(err, check.IsNil)
+	s.team = auth.Team{Name: "metallica"}
+	err = s.conn.Teams().Insert(s.team)
+	c.Assert(err, check.IsNil)
+	opts := provision.AddPoolOptions{Name: "pool1", Default: true, Provisioner: "fake"}
+	err = provision.AddPool(opts)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SyncSuite) TearDownSuite(c *check.C) {
+	s.conn.Apps().Database.DropDatabase()
+	s.conn.Close()
+}
+
+func (s *SyncSuite) TestBindSyncer(c *check.C) {
+	h := service.TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	srvc := service.Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}, Password: "s3cr3t"}
+	err := srvc.Create()
+	c.Assert(err, check.IsNil)
+	srvc = service.Service{Name: "mysql2", Endpoint: map[string]string{"production": ts.URL}, Password: "s3cr3t"}
+	err = srvc.Create()
+	c.Assert(err, check.IsNil)
+	a := &app.App{Name: "my-app", Platform: "python", TeamOwner: s.team.Name}
+	err = app.CreateApp(a, &s.user)
+	c.Assert(err, check.IsNil)
+	err = a.AddUnits(1, "", nil)
+	c.Assert(err, check.IsNil)
+	units, err := a.GetUnits()
+	c.Assert(err, check.IsNil)
+	instance := &service.ServiceInstance{
+		Name:        "my-mysql",
+		ServiceName: "mysql",
+		Teams:       []string{s.team.Name},
+		Apps:        []string{a.GetName()},
+		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}, {ID: "wrong", IP: "wrong"}},
+	}
+	err = instance.Create()
+	c.Assert(err, check.IsNil)
+	instance = &service.ServiceInstance{
+		Name:        "my-mysql",
+		ServiceName: "mysql2",
+		Teams:       []string{s.team.Name},
+		Apps:        []string{a.GetName()},
+		BoundUnits:  []service.Unit{},
+	}
+	err = instance.Create()
+	c.Assert(err, check.IsNil)
+	callCh := make(chan struct{})
+	b := service.BindSyncer{
+		AppLister: func() ([]bind.App, error) {
+			callCh <- struct{}{}
+			return []bind.App{a}, nil
+		},
+	}
+	err = b.Start()
+	c.Assert(err, check.IsNil)
+	<-callCh
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	err = b.Shutdown(ctx)
+	cancel()
+	c.Assert(err, check.IsNil)
+	instance, err = service.GetServiceInstance("mysql", "my-mysql")
+	c.Assert(err, check.IsNil)
+	c.Assert(instance.BoundUnits, check.DeepEquals, []service.Unit{
+		{ID: units[0].GetID(), IP: units[0].GetIp()},
+	})
+	instance, err = service.GetServiceInstance("mysql2", "my-mysql")
+	c.Assert(err, check.IsNil)
+	c.Assert(instance.BoundUnits, check.DeepEquals, []service.Unit{
+		{ID: units[0].GetID(), IP: units[0].GetIp()},
+	})
+}


### PR DESCRIPTION
This PR adds a goroutine that syncs every application service binds every each given interval. This is required for provisioners which we are not aware when a unit is rescheduled, such as kubernetes or swarm. This will also remove the dependency on the service API since the bind/unbind operation will be able to fail when the unit is rescheduled and will by retried by the syncer.

