### PR TITLE
Moves app.Bind to app.RegisterUnit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1722,7 +1722,21 @@ func (app *App) RegisterUnit(unitId string, customData map[string]interface{}) e
 	if err != nil {
 		return err
 	}
-	return prov.RegisterUnit(app, unitId, customData)
+	err = prov.RegisterUnit(app, unitId, customData)
+	if err != nil {
+		return err
+	}
+	units, err := prov.Units(app)
+	if err != nil {
+		return err
+	}
+	for i := range units {
+		if units[i].GetID() == unitId {
+			err = app.BindUnit(&units[i])
+			break
+		}
+	}
+	return err
 }
 
 func (app *App) GetRouterName() (string, error) {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -382,10 +382,6 @@ func (p *kubernetesProvisioner) RegisterUnit(a provision.App, unitID string, cus
 	if len(units) == 0 {
 		return errors.Errorf("unable to convert pod to unit: %#v", pod)
 	}
-	err = a.BindUnit(&units[0])
-	if err != nil {
-		return errors.WithStack(err)
-	}
 	if customData == nil {
 		return nil
 	}

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -321,7 +321,6 @@ func (s *S) TestRegisterUnit(c *check.C) {
 	c.Assert(units, check.HasLen, 1)
 	err = s.p.RegisterUnit(a, units[0].ID, nil)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
-	c.Assert(a.HasBind(&units[0]), check.Equals, true)
 }
 
 func (s *S) TestRegisterUnitDeployUnit(c *check.C) {

--- a/provision/swarm/provisioner.go
+++ b/provision/swarm/provisioner.go
@@ -344,14 +344,6 @@ func (p *swarmProvisioner) RoutableAddresses(a provision.App) ([]url.URL, error)
 	return addrs, nil
 }
 
-func bindUnit(a provision.App, unit *provision.Unit) error {
-	err := a.BindUnit(unit)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
 func findTaskByContainerId(tasks []swarm.Task, unitId string) (*swarm.Task, error) {
 	for i, t := range tasks {
 		if strings.HasPrefix(t.Status.ContainerStatus.ContainerID, unitId) {
@@ -378,25 +370,12 @@ func (p *swarmProvisioner) RegisterUnit(a provision.App, unitId string, customDa
 	if err != nil {
 		return err
 	}
+	if customData == nil {
+		return nil
+	}
 	task, err := findTaskByContainerId(tasks, unitId)
 	if err != nil {
 		return err
-	}
-	service, err := client.InspectService(task.ServiceID)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	node, err := client.InspectNode(task.NodeID)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	unit := taskToUnit(task, service, node, a)
-	err = bindUnit(a, &unit)
-	if err != nil {
-		return err
-	}
-	if customData == nil {
-		return nil
 	}
 	labels := provision.LabelSet{Labels: task.Spec.ContainerSpec.Labels, Prefix: tsuruLabelPrefix}
 	if !labels.IsDeploy() {

--- a/provision/swarm/suite_test.go
+++ b/provision/swarm/suite_test.go
@@ -6,8 +6,6 @@ package swarm
 
 import (
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/tsuru/config"
@@ -20,10 +18,8 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/quota"
 	"github.com/tsuru/tsuru/router/routertest"
-	"github.com/tsuru/tsuru/service"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/check.v1"
-	"gopkg.in/mgo.v2/bson"
 )
 
 type S struct {
@@ -88,20 +84,4 @@ func (s *S) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.token, err = nativeScheme.Login(map[string]string{"email": s.user.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-}
-
-func (s *S) addServiceInstance(c *check.C, appName string, fn http.HandlerFunc) func() {
-	ts := httptest.NewServer(fn)
-	ret := func() {
-		ts.Close()
-		s.conn.Services().Remove(bson.M{"_id": "mysql"})
-		s.conn.ServiceInstances().Remove(bson.M{"_id": "my-mysql"})
-	}
-	srvc := service.Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}, Password: "abcde"}
-	err := srvc.Create()
-	c.Assert(err, check.IsNil)
-	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{}, Apps: []string{appName}}
-	err = instance.Create()
-	c.Assert(err, check.IsNil)
-	return ret
 }

--- a/service/actions.go
+++ b/service/actions.go
@@ -238,7 +238,7 @@ var bindUnitsAction = &action.Action{
 				defer wg.Done()
 				unit := units[i]
 				err := si.BindUnit(args.app, unit)
-				if err == nil || err == ErrUnitAlreadyBound {
+				if err == nil {
 					unboundCh <- unit
 				} else {
 					errCh <- err

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -199,8 +199,7 @@ func (c *Client) BindApp(instance *ServiceInstance, app bind.App) (map[string]st
 }
 
 func (c *Client) BindUnit(instance *ServiceInstance, app bind.App, unit bind.Unit) error {
-	log.Debugf("Calling bind of instance %q and %q unit at %q API",
-		instance.Name, unit.GetIp(), instance.ServiceName)
+	log.Debugf("Calling bind of instance %q and %q unit at %q API", instance.Name, unit.GetIp(), instance.ServiceName)
 	var resp *http.Response
 	params := map[string][]string{
 		"app-host":  {app.GetIp()},

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -29,7 +29,6 @@ var (
 	ErrTeamMandatory             = errors.New("please specify the team that owns the service instance")
 	ErrAppAlreadyBound           = errors.New("app is already bound to this service instance")
 	ErrAppNotBound               = errors.New("app is not bound to this service instance")
-	ErrUnitAlreadyBound          = errors.New("unit is already bound to this service instance")
 	ErrUnitNotBound              = errors.New("unit is not bound to this service instance")
 	ErrServiceInstanceBound      = errors.New("This service instance is bound to at least one app. Unbind them before removing it")
 )
@@ -215,7 +214,7 @@ func (si *ServiceInstance) BindUnit(app bind.App, unit bind.Unit) error {
 	err = conn.ServiceInstances().Update(bson.M{"name": si.Name, "service_name": si.ServiceName, "bound_units.id": bson.M{"$ne": unit.GetID()}}, updateOp)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return ErrUnitAlreadyBound
+			return nil
 		}
 		return err
 	}


### PR DESCRIPTION
This PR moves the call to app.Bind from the provisioners to the app.RegisterUnit method.
This also changes ServiceInstance.BindUnit to **not** return an error when the unit is already bound to the service.