### PR TITLE
provision/swarm,kubernetes: ignores errors when registering units

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -207,7 +207,7 @@ func extraRegisterCmds(a provision.App) string {
 		host += "/"
 	}
 	token := a.Envs()["TSURU_APP_TOKEN"].Value
-	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, a.GetName())
+	return fmt.Sprintf(`curl -sSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, a.GetName())
 }
 
 func probeFromHC(hc provision.TsuruYamlHealthcheck, port int) (*apiv1.Probe, error) {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -207,7 +207,7 @@ func extraRegisterCmds(a provision.App) string {
 		host += "/"
 	}
 	token := a.Envs()["TSURU_APP_TOKEN"].Value
-	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register`, token, host, a.GetName())
+	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, a.GetName())
 }
 
 func probeFromHC(hc provision.TsuruYamlHealthcheck, port int) (*apiv1.Probe, error) {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -113,7 +113,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 							Command: []string{
 								"/bin/sh",
 								"-lc",
-								"[ -d /home/application/current ] && cd /home/application/current; curl -fsSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register && exec cm1",
+								"[ -d /home/application/current ] && cd /home/application/current; curl -fsSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
 							},
 							Env: []apiv1.EnvVar{
 								{Name: "TSURU_SERVICES", Value: "{}"},

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -113,7 +113,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 							Command: []string{
 								"/bin/sh",
 								"-lc",
-								"[ -d /home/application/current ] && cd /home/application/current; curl -fsSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
+								"[ -d /home/application/current ] && cd /home/application/current; curl -sSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
 							},
 							Env: []apiv1.EnvVar{
 								{Name: "TSURU_SERVICES", Value: "{}"},

--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -297,7 +297,7 @@ func extraRegisterCmds(app provision.App) string {
 		host += "/"
 	}
 	token := app.Envs()["TSURU_APP_TOKEN"].Value
-	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register`, token, host, app.GetName())
+	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, app.GetName())
 }
 
 func serviceSpecForApp(opts tsuruServiceOpts) (*swarm.ServiceSpec, error) {

--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -297,7 +297,7 @@ func extraRegisterCmds(app provision.App) string {
 		host += "/"
 	}
 	token := app.Envs()["TSURU_APP_TOKEN"].Value
-	return fmt.Sprintf(`curl -fsSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, app.GetName())
+	return fmt.Sprintf(`curl -sSL -m15 -XPOST -d"hostname=$(hostname)" -o/dev/null -H"Content-Type:application/x-www-form-urlencoded" -H"Authorization:bearer %s" %sapps/%s/units/register || true`, token, host, app.GetName())
 }
 
 func serviceSpecForApp(opts tsuruServiceOpts) (*swarm.ServiceSpec, error) {


### PR DESCRIPTION
This PR makes swarm and kubernetes ignore the result of the curl for registering the unit with the tsuru api. 