### PR TITLE
service: prevents BindSyncer from flooding events

### DIFF
--- a/service/sync.go
+++ b/service/sync.go
@@ -127,7 +127,6 @@ func (b *bindSyncer) Shutdown(ctx context.Context) error {
 }
 
 func (b *bindSyncer) sync(a bind.App) (err error) {
-	var changed bool
 	binds := make(map[string][]string)
 	unbinds := make(map[string][]string)
 	evt, err := event.NewInternal(&event.Opts{
@@ -146,7 +145,7 @@ func (b *bindSyncer) sync(a bind.App) (err error) {
 		if err != nil {
 			evt.Logf(err.Error())
 		}
-		if changed || err != nil {
+		if len(binds)+len(unbinds) > 0 || err != nil {
 			evt.DoneCustomData(err, map[string]interface{}{
 				"binds":   binds,
 				"unbinds": unbinds,
@@ -178,7 +177,6 @@ func (b *bindSyncer) sync(a bind.App) (err error) {
 			if _, ok := boundUnits[u]; ok {
 				delete(boundUnits, u)
 			} else {
-				changed = true
 				log.Debugf("[bind-syncer] binding unit %q from app %q from %s:%s\n", u.ID, a.GetName(), instance.ServiceName, instance.Name)
 				err = instance.BindUnit(a, u)
 				binds[instance.Name] = append(binds[instance.Name], u.GetID())
@@ -190,7 +188,6 @@ func (b *bindSyncer) sync(a bind.App) (err error) {
 			}
 		}
 		for u := range boundUnits {
-			changed = true
 			log.Debugf("[bind-syncer] unbinding unit %q from app %q from %s:%s\n", u.ID, a.GetName(), instance.ServiceName, instance.Name)
 			err = instance.UnbindUnit(a, u)
 			unbinds[instance.Name] = append(unbinds[instance.Name], u.GetID())

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -137,10 +137,10 @@ func (s *SyncSuite) TestBindSyncer(c *check.C) {
 		Kind: "bindsyncer",
 		EndCustomData: map[string]interface{}{
 			"binds": map[string][]interface{}{
-				"my-mysql": []interface{}{"my-app-0"},
+				"my-mysql": {"my-app-0"},
 			},
 			"unbinds": map[string][]interface{}{
-				"my-mysql": []interface{}{"wrong"},
+				"my-mysql": {"wrong"},
 			},
 		},
 	}, eventtest.HasEvent)

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/tsuru/tsuru/event/eventtest"
+
 	"github.com/tsuru/tsuru/api/shutdown"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/storage"
@@ -127,6 +129,21 @@ func (s *SyncSuite) TestBindSyncer(c *check.C) {
 	evts, err := event.All()
 	c.Assert(err, check.IsNil)
 	c.Assert(evts, check.HasLen, 1)
+	c.Assert(eventtest.EventDesc{
+		Target: event.Target{
+			Type:  event.TargetTypeApp,
+			Value: "my-app",
+		},
+		Kind: "bindsyncer",
+		EndCustomData: map[string]interface{}{
+			"binds": map[string][]interface{}{
+				"my-mysql": []interface{}{"my-app-0"},
+			},
+			"unbinds": map[string][]interface{}{
+				"my-mysql": []interface{}{"wrong"},
+			},
+		},
+	}, eventtest.HasEvent)
 }
 
 func (s *SyncSuite) TestBindSyncerNoOp(c *check.C) {


### PR DESCRIPTION
This PR makes sure that BindSyncer only creates events when it actually changes one of the Binds on an app.