### PR TITLE
autoscale: always enabled and skipping provisioners with error

### DIFF
--- a/api/autoscale_test.go
+++ b/api/autoscale_test.go
@@ -146,15 +146,13 @@ func (s *S) TestAutoScaleListRulesEmpty(c *check.C) {
 }
 
 func (s *S) TestAutoScaleListRulesWithLegacyConfig(c *check.C) {
+	config.Set("docker:auto-scale:enabled", true)
 	config.Set("docker:auto-scale:metadata-filter", "mypool")
 	config.Set("docker:auto-scale:max-container-count", 4)
 	config.Set("docker:auto-scale:scale-down-ratio", 1.5)
 	config.Set("docker:auto-scale:prevent-rebalance", true)
 	config.Set("docker:scheduler:max-used-memory", 0.9)
-	defer config.Unset("docker:auto-scale:metadata-filter")
-	defer config.Unset("docker:auto-scale:max-container-count")
-	defer config.Unset("docker:auto-scale:scale-down-ratio")
-	defer config.Unset("docker:auto-scale:prevent-rebalance")
+	defer config.Unset("docker:auto-scale")
 	defer config.Unset("docker:scheduler:max-used-memory")
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest("GET", "/node/autoscale/rules", nil)
@@ -198,6 +196,8 @@ func (s *S) TestAutoScaleListRulesWithDBConfig(c *check.C) {
 }
 
 func (s *S) TestAutoScaleSetRule(c *check.C) {
+	config.Set("docker:auto-scale:enabled", true)
+	defer config.Unset("docker:auto-scale-enabled")
 	config.Set("docker:scheduler:total-memory-metadata", "maxmemory")
 	defer config.Unset("docker:scheduler:total-memory-metadata")
 	rule := autoscale.Rule{
@@ -286,6 +286,8 @@ func (s *S) TestAutoScaleSetRuleExisting(c *check.C) {
 }
 
 func (s *S) TestAutoScaleDeleteRule(c *check.C) {
+	config.Set("docker:auto-scale:enabled", true)
+	defer config.Unset("docker:auto-scale-enabled")
 	rule := autoscale.Rule{MetadataFilter: "", Enabled: true, ScaleDownRatio: 1.1, MaxContainerCount: 5}
 	err := rule.Update()
 	c.Assert(err, check.IsNil)

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -188,7 +188,8 @@ func (a *Config) runScaler() (retErr error) {
 		var nodes []provision.Node
 		nodes, err = nodeProv.ListNodes(nil)
 		if err != nil {
-			return errors.Wrap(err, "error getting nodes")
+			a.logDebug("skipped provisioner, error getting nodes: %v", err)
+			continue
 		}
 		for _, n := range nodes {
 			provPoolMap[n.Pool()] = nodeProv

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -38,6 +38,7 @@ type Config struct {
 	TotalMemoryMetadata string
 	done                chan bool
 	writer              io.Writer
+	running             bool
 }
 
 func CurrentConfig() (*Config, error) {
@@ -114,6 +115,7 @@ func (a *Config) scalerForRule(rule *Rule) (autoScaler, error) {
 }
 
 func (a *Config) run() error {
+	a.running = true
 	for {
 		err := a.runScaler()
 		if err != nil {
@@ -146,12 +148,12 @@ func (a *Config) runOnce() error {
 	return err
 }
 
-func (a *Config) stop() {
-	a.done <- true
-}
-
 func (a *Config) Shutdown(ctx context.Context) error {
-	a.stop()
+	if !a.running {
+		return nil
+	}
+	a.done <- true
+	a.running = false
 	return nil
 }
 

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -36,7 +36,6 @@ type Config struct {
 	WaitTimeNewMachine  time.Duration
 	RunInterval         time.Duration
 	TotalMemoryMetadata string
-	Enabled             bool
 	done                chan bool
 	writer              io.Writer
 }
@@ -50,9 +49,6 @@ func CurrentConfig() (*Config, error) {
 
 func Initialize() error {
 	globalConfig = newConfig()
-	if !globalConfig.Enabled {
-		return nil
-	}
 	shutdown.Register(globalConfig)
 	go globalConfig.run()
 	return nil
@@ -65,7 +61,6 @@ func RunOnce(w io.Writer) error {
 }
 
 func newConfig() *Config {
-	enabled, _ := config.GetBool("docker:auto-scale:enabled")
 	waitSecondsNewMachine, _ := config.GetInt("docker:auto-scale:wait-new-time")
 	runInterval, _ := config.GetInt("docker:auto-scale:run-interval")
 	totalMemoryMetadata, _ := config.GetString("docker:scheduler:total-memory-metadata")
@@ -73,7 +68,6 @@ func newConfig() *Config {
 		TotalMemoryMetadata: totalMemoryMetadata,
 		WaitTimeNewMachine:  time.Duration(waitSecondsNewMachine) * time.Second,
 		RunInterval:         time.Duration(runInterval) * time.Second,
-		Enabled:             enabled,
 		done:                make(chan bool),
 	}
 	if c.RunInterval == 0 {
@@ -157,10 +151,7 @@ func (a *Config) stop() {
 }
 
 func (a *Config) Shutdown(ctx context.Context) error {
-	if a.Enabled {
-		a.stop()
-		a.Enabled = false
-	}
+	a.stop()
 	return nil
 }
 

--- a/autoscale/autoscale_test.go
+++ b/autoscale/autoscale_test.go
@@ -99,6 +99,7 @@ func (s *S) TearDownTest(c *check.C) {
 	config.Unset("docker:auto-scale:metadata-filter")
 	config.Unset("docker:auto-scale:scale-down-ratio")
 	config.Unset("docker:scheduler:max-used-memory")
+	config.Unset("docker:auto-scale:enabled")
 	config.Unset("docker:scheduler:total-memory-metadata")
 }
 

--- a/autoscale/autoscale_test.go
+++ b/autoscale/autoscale_test.go
@@ -87,6 +87,7 @@ func (s *S) SetUpTest(c *check.C) {
 	)
 	iaas.RegisterIaasProvider("my-scale-iaas", healerConst)
 	config.Set("docker:auto-scale:max-container-count", 2)
+	config.Set("docker:auto-scale:enabled", true)
 	s.logBuf = safe.NewBuffer(nil)
 	log.SetLogger(log.NewWriterLogger(s.logBuf, true))
 }

--- a/autoscale/rule.go
+++ b/autoscale/rule.go
@@ -114,6 +114,7 @@ func DeleteRule(metadataFilter string) error {
 }
 
 func legacyAutoScaleRule() *Rule {
+	enabled, _ := config.GetBool("docker:auto-scale:enabled")
 	metadataFilter, _ := config.GetString("docker:auto-scale:metadata-filter")
 	maxContainerCount, _ := config.GetInt("docker:auto-scale:max-container-count")
 	scaleDownRatio, _ := config.GetFloat("docker:auto-scale:scale-down-ratio")
@@ -123,7 +124,7 @@ func legacyAutoScaleRule() *Rule {
 		MetadataFilter:    metadataFilter,
 		ScaleDownRatio:    float32(scaleDownRatio),
 		PreventRebalance:  preventRebalance,
-		Enabled:           true,
+		Enabled:           enabled,
 	}
 }
 

--- a/docs/advanced_topics/node_scaling.rst
+++ b/docs/advanced_topics/node_scaling.rst
@@ -5,7 +5,8 @@
 Node Auto Scaling
 =================
 
-Node auto scaling can be enabled by setting `docker:auto-scale:enabled` to true.
+Node auto scaling can be enabled by setting `docker:auto-scale:enabled` to true or
+by using ``tsuru node autoscale rule set`` to configure a autoscale rule.
 It will try to add, remove and rebalance docker nodes used by tsuru.
 
 Node scaling algorithms run in clusters of docker nodes, each cluster is based
@@ -105,5 +106,5 @@ You can list auto scale events with `tsuru docker-autoscale-list`
 Running auto scale once
 -----------------------
 
-Even if you have `docker:auto-scale:enabled` set to false, you can make tsuru
+Even if you have not enabled autoscale, you can make tsuru 
 trigger the execution of the auto scale algorithm by running `tsuru docker-autoscale-run`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -996,7 +996,9 @@ docker:auto-scale:enabled
 +++++++++++++++++++++++++
 
 Enable node auto scaling. See :doc:`node auto scaling
-</advanced_topics/node_scaling>` for more details. Defaults to false.
+</advanced_topics/node_scaling>` for more details. Defaults to false. Used as fallback
+for pools without rules set by ``tsuru node autoscale rule set``.
+
 
 docker:auto-scale:wait-new-time
 +++++++++++++++++++++++++++++++
@@ -1013,7 +1015,7 @@ docker:auto-scale:metadata-filter
 +++++++++++++++++++++++++++++++++
 
 The name of a pool where auto scale will be enabled. Leave unset to allow
-dynamically configuring with ``tsuru docker-autoscale-rule-set``.
+dynamically configuring with ``tsuru node-autoscale-rule-set``.
 
 docker:auto-scale:max-container-count
 +++++++++++++++++++++++++++++++++++++

--- a/provision/docker/scheduler.go
+++ b/provision/docker/scheduler.go
@@ -104,11 +104,7 @@ func (s *segregatedScheduler) filterByMemoryUsage(a *app.App, nodes []cluster.No
 		}
 	}
 	if len(nodeList) == 0 {
-		cfg, _ := autoscale.CurrentConfig()
-		autoScaleEnabled := false
-		if cfg != nil {
-			autoScaleEnabled = cfg.Enabled
-		}
+		var autoScaleEnabled bool
 		rule, _ := autoscale.AutoScaleRuleForMetadata(a.Pool)
 		if rule != nil {
 			autoScaleEnabled = rule.Enabled

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -244,8 +244,8 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	autoscale.Initialize()
 	defer func() {
-		cur, err := autoscale.CurrentConfig()
-		c.Assert(err, check.IsNil)
+		cur, errCfg := autoscale.CurrentConfig()
+		c.Assert(errCfg, check.IsNil)
 		cur.Shutdown(context.Background())
 	}()
 	logBuf := bytes.NewBuffer(nil)

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -233,8 +233,15 @@ func (s *S) TestSchedulerScheduleWithMemoryAwareness(c *check.C) {
 }
 
 func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
-	config.Set("docker:auto-scale:enabled", true)
-	defer config.Unset("docker:auto-scale:enabled")
+	config.Set("docker:scheduler:total-memory-metadata", "memory")
+	defer config.Unset("docker:scheduler:total-memory-metadata")
+	rule := autoscale.Rule{
+		MetadataFilter: "mypool",
+		MaxMemoryRatio: 0.1,
+		Enabled:        true,
+	}
+	err := rule.Update()
+	c.Assert(err, check.IsNil)
 	autoscale.Initialize()
 	defer func() {
 		cur, err := autoscale.CurrentConfig()
@@ -245,7 +252,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
 	log.SetLogger(log.NewWriterLogger(logBuf, false))
 	defer log.SetLogger(nil)
 	app1 := app.App{Name: "skyrim", Plan: app.Plan{Memory: 60000}, Pool: "mypool"}
-	err := s.storage.Apps().Insert(app1)
+	err = s.storage.Apps().Insert(app1)
 	c.Assert(err, check.IsNil)
 	app2 := app.App{Name: "oblivion", Plan: app.Plan{Memory: 20000}, Pool: "mypool"}
 	err = s.storage.Apps().Insert(app2)


### PR DESCRIPTION
This PR removes the need to enable the autoscale using the configuration file and only relies on the rules registered for each pool.

This also makes sure we skip provisioners with error instead of checking other provisioners nodes.

Fixes #1456.