### PR TITLE
event: adds basic instrumentation

### DIFF
--- a/event/block.go
+++ b/event/block.go
@@ -29,7 +29,7 @@ type ErrEventBlocked struct {
 	block *Block
 }
 
-func (e *ErrEventBlocked) Error() string {
+func (e ErrEventBlocked) Error() string {
 	return fmt.Sprintf("error running %q on %s(%s): %s",
 		e.event.Kind,
 		e.event.Target.Type,
@@ -136,7 +136,7 @@ func checkIsBlocked(evt *Event) error {
 	}
 	for _, b := range blocks {
 		if b.Blocks(evt) {
-			return &ErrEventBlocked{event: evt, block: &b}
+			return ErrEventBlocked{event: evt, block: &b}
 		}
 	}
 	return nil

--- a/event/block_test.go
+++ b/event/block_test.go
@@ -109,8 +109,8 @@ func (s *S) TestCheckIsBlocked(c *check.C) {
 			if errBlock == nil {
 				c.Fatalf("(%d) Expected %#+v. Got nil", i, t.blockedBy)
 			}
-			errBlock.(*ErrEventBlocked).block.StartTime = t.blockedBy.StartTime
-			expectedErr = &ErrEventBlocked{event: t.event, block: t.blockedBy}
+			errBlock.(ErrEventBlocked).block.StartTime = t.blockedBy.StartTime
+			expectedErr = ErrEventBlocked{event: t.event, block: t.blockedBy}
 		}
 		if !reflect.DeepEqual(errBlock, expectedErr) {
 			c.Errorf("(%d) Expected %#+v. Got %#+v", i, expectedErr, errBlock)

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -265,7 +265,7 @@ func (s *S) TestNewEventBlocked(c *check.C) {
 		Allowed: Allowed(permission.PermAppReadEvents),
 	})
 	c.Assert(err, check.NotNil)
-	c.Assert(err.(*ErrEventBlocked).block, check.DeepEquals, &blocks[0])
+	c.Assert(err.(ErrEventBlocked).block, check.DeepEquals, &blocks[0])
 	evts, err := All()
 	c.Assert(err, check.IsNil)
 	c.Assert(evts, check.HasLen, 1)


### PR DESCRIPTION
This PR adds some metrics to the events package. Added metrics are:

1. tsuru_events_current - tracking the number of events running by kind
2. tsuru_events_duration_seconds - tracks the duration of each event. Defining the buckets for the histogram is kinda tricky since the expected duration of each kind of event is highly variable.
3. tsuru_events_rejected - tracks the events that failed to be created, there are specific "reasons" for blocked events, locked events and throttled events.

This is how they look on `/metrics`:

```
# HELP tsuru_events_current The number of events currently running
# TYPE tsuru_events_current gauge
tsuru_events_current{kind="app.deploy"} 0
tsuru_events_current{kind="bindsyncer"} 0
tsuru_events_current{kind="event-block.add"} 0
tsuru_events_current{kind="event-block.remove"} 0

# HELP tsuru_events_duration_seconds The duration of events in seconds
# TYPE tsuru_events_duration_seconds histogram
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="1"} 4
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="5"} 4
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="10"} 4
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="60"} 4
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="600"} 5
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="1800"} 5
tsuru_events_duration_seconds_bucket{kind="app.deploy",le="+Inf"} 5
tsuru_events_duration_seconds_sum{kind="app.deploy"} 96.92284384
tsuru_events_duration_seconds_count{kind="app.deploy"} 5

# HELP tsuru_events_rejected The total number of events rejected
# TYPE tsuru_events_rejected counter
tsuru_events_rejected{kind="app.deploy",reason="blocked"} 4
tsuru_events_rejected{kind="bindsyncer",reason="blocked"} 2
```

This adds `(1+9+4) * (number of events kinds)` time series to be exposed by our `/metrics` endpoint. I think this number is still OK, but we might need to aggregate events by some criteria other than the event kind.