### PR TITLE
net,provision/docker: disable following redirects on healthchecks

### DIFF
--- a/net/client.go
+++ b/net/client.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func makeTimeoutHTTPClient(dialTimeout time.Duration, fullTimeout time.Duration, maxIdle int) (*http.Client, *net.Dialer) {
+func makeTimeoutHTTPClient(dialTimeout time.Duration, fullTimeout time.Duration, maxIdle int, followRedirects bool) (*http.Client, *net.Dialer) {
 	dialer := &net.Dialer{
 		Timeout:   dialTimeout,
 		KeepAlive: 30 * time.Second,
@@ -23,6 +23,11 @@ func makeTimeoutHTTPClient(dialTimeout time.Duration, fullTimeout time.Duration,
 		},
 		Timeout: fullTimeout,
 	}
+	if !followRedirects {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
 	return client, dialer
 }
 
@@ -31,8 +36,9 @@ const (
 )
 
 var (
-	Dial5Full300Client, Dial5Dialer  = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, 5)
-	Dial5FullUnlimitedClient, _      = makeTimeoutHTTPClient(5*time.Second, 0, 5)
-	Dial5Full300ClientNoKeepAlive, _ = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, -1)
-	Dial5Full60ClientNoKeepAlive, _  = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1)
+	Dial5Full300Client, Dial5Dialer           = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, 5, true)
+	Dial5FullUnlimitedClient, _               = makeTimeoutHTTPClient(5*time.Second, 0, 5, true)
+	Dial5Full300ClientNoKeepAlive, _          = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, -1, true)
+	Dial5Full60ClientNoKeepAlive, _           = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, true)
+	Dial5Full60ClientNoKeepAliveNoRedirect, _ = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, false)
 )

--- a/provision/docker/healthcheck.go
+++ b/provision/docker/healthcheck.go
@@ -63,7 +63,7 @@ func runHealthcheck(cont *container.Container, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		rsp, err := net.Dial5Full60ClientNoKeepAlive.Do(req)
+		rsp, err := net.Dial5Full60ClientNoKeepAliveNoRedirect.Do(req)
 		if err != nil {
 			lastError = errors.Wrapf(err, "healthcheck fail(%s)", cont.ShortID())
 		} else {


### PR DESCRIPTION
This PR creates a new client to our net package that does not follow any redirects and uses this client for `provision/docker` healthchecks.