### PR TITLE
api: uses header to decide error verbosity

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -105,10 +105,7 @@ func errorHandlingMiddleware(w http.ResponseWriter, r *http.Request, next http.H
 	next(w, r)
 	err := context.GetRequestError(r)
 	if err != nil {
-		verbosity, errConv := strconv.Atoi(r.Header.Get(cmd.VerbosityHeader))
-		if errConv != nil {
-			verbosity = 0
-		}
+		verbosity, _ := strconv.Atoi(r.Header.Get(cmd.VerbosityHeader))
 		code := http.StatusInternalServerError
 		switch t := errors.Cause(err).(type) {
 		case *tsuruErrors.ValidationError:

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/codegangsta/negroni"
@@ -20,6 +21,7 @@ import (
 	"github.com/tsuru/tsuru/api/context"
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/cmd"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/io"
 	"github.com/tsuru/tsuru/log"
@@ -103,12 +105,21 @@ func errorHandlingMiddleware(w http.ResponseWriter, r *http.Request, next http.H
 	next(w, r)
 	err := context.GetRequestError(r)
 	if err != nil {
+		verbosity, errConv := strconv.Atoi(r.Header.Get(cmd.VerbosityHeader))
+		if errConv != nil {
+			verbosity = 0
+		}
 		code := http.StatusInternalServerError
 		switch t := errors.Cause(err).(type) {
 		case *tsuruErrors.ValidationError:
 			code = http.StatusBadRequest
 		case *tsuruErrors.HTTP:
 			code = t.Code
+		}
+		if verbosity == 0 {
+			err = fmt.Errorf("%s", err)
+		} else {
+			err = fmt.Errorf("%+v", err)
 		}
 		flushing, ok := w.(*io.FlushingWriter)
 		if ok && flushing.Wrote() {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -12,10 +12,15 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 
 	"github.com/pkg/errors"
 	tsuruerr "github.com/tsuru/tsuru/errors"
 	tsuruio "github.com/tsuru/tsuru/io"
+)
+
+const (
+	VerbosityHeader = "X-Tsuru-Verbosity"
 )
 
 var errUnauthorized = &tsuruerr.HTTP{Code: http.StatusUnauthorized, Message: "unauthorized"}
@@ -57,6 +62,7 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 	if token, err := ReadToken(); err == nil && token != "" {
 		request.Header.Set("Authorization", "bearer "+token)
 	}
+	request.Header.Add(VerbosityHeader, strconv.Itoa(c.Verbosity))
 	request.Close = true
 	if c.Verbosity >= 1 {
 		fmt.Fprintf(c.context.Stdout, "*************************** <Request uri=%q> **********************************\n", request.URL.RequestURI())

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -289,3 +289,18 @@ func (s *S) TestStreamJSONResponse(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Equals, "hello!")
 }
+
+func (s *S) TestShouldIncludeVerbosityHeader(c *check.C) {
+	request, err := http.NewRequest("GET", "/", nil)
+	c.Assert(err, check.IsNil)
+	trans := cmdtest.Transport{Message: "", Status: http.StatusOK}
+	var buf bytes.Buffer
+	context := Context{
+		Stdout: &buf,
+	}
+	client := NewClient(&http.Client{Transport: &trans}, &context, globalManager)
+	client.Verbosity = 2
+	_, err = client.Do(request)
+	c.Assert(err, check.IsNil)
+	c.Assert(request.Header.Get(VerbosityHeader), check.Equals, "2")
+}


### PR DESCRIPTION
This PR adds a header to control how verbose errors are sent to clients, i.e if they include a stack trace. This header is set using the `--verbosity` flag on our client.

Fixes #1647 