### PR TITLE
event: outputs better error message for repeated cancelations

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -64,18 +64,19 @@ var (
 	throttlingInfo  = map[string]ThrottlingSpec{}
 	errInvalidQuery = errors.New("invalid query")
 
-	ErrNotCancelable     = errors.New("event is not cancelable")
-	ErrEventNotFound     = errors.New("event not found")
-	ErrNoTarget          = ErrValidation("event target is mandatory")
-	ErrNoKind            = ErrValidation("event kind is mandatory")
-	ErrNoOwner           = ErrValidation("event owner is mandatory")
-	ErrNoOpts            = ErrValidation("event opts is mandatory")
-	ErrNoInternalKind    = ErrValidation("event internal kind is mandatory")
-	ErrNoAllowed         = errors.New("event allowed is mandatory")
-	ErrNoAllowedCancel   = errors.New("event allowed cancel is mandatory for cancelable events")
-	ErrInvalidOwner      = ErrValidation("event owner must not be set on internal events")
-	ErrInvalidKind       = ErrValidation("event kind must not be set on internal events")
-	ErrInvalidTargetType = errors.New("invalid event target type")
+	ErrNotCancelable          = errors.New("event is not cancelable")
+	ErrCancelAlreadyRequested = errors.New("event cancel already requested")
+	ErrEventNotFound          = errors.New("event not found")
+	ErrNoTarget               = ErrValidation("event target is mandatory")
+	ErrNoKind                 = ErrValidation("event kind is mandatory")
+	ErrNoOwner                = ErrValidation("event owner is mandatory")
+	ErrNoOpts                 = ErrValidation("event opts is mandatory")
+	ErrNoInternalKind         = ErrValidation("event internal kind is mandatory")
+	ErrNoAllowed              = errors.New("event allowed is mandatory")
+	ErrNoAllowedCancel        = errors.New("event allowed cancel is mandatory for cancelable events")
+	ErrInvalidOwner           = ErrValidation("event owner must not be set on internal events")
+	ErrInvalidKind            = ErrValidation("event kind must not be set on internal events")
+	ErrInvalidTargetType      = errors.New("invalid event target type")
 
 	OwnerTypeUser     = ownerType("user")
 	OwnerTypeApp      = ownerType("app")
@@ -945,7 +946,10 @@ func (e *Event) TryCancel(reason, owner string) error {
 	}
 	_, err = coll.Find(bson.M{"_id": e.ID, "cancelinfo.asked": false}).Apply(change, &e.eventData)
 	if err == mgo.ErrNotFound {
-		return ErrEventNotFound
+		if _, errID := GetByID(e.UniqueID); errID == ErrEventNotFound {
+			return ErrEventNotFound
+		}
+		err = ErrCancelAlreadyRequested
 	}
 	return err
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -456,6 +456,22 @@ func (s *S) TestEventCancel(c *check.C) {
 	})
 }
 
+func (s *S) TestEventCancelMulttipleTimes(c *check.C) {
+	evt, err := New(&Opts{
+		Target:        Target{Type: "app", Value: "myapp"},
+		Kind:          permission.PermAppUpdateEnvSet,
+		Owner:         s.token,
+		Cancelable:    true,
+		Allowed:       Allowed(permission.PermAppReadEvents),
+		AllowedCancel: Allowed(permission.PermAppReadEvents),
+	})
+	c.Assert(err, check.IsNil)
+	err = evt.TryCancel("because I want", "admin@admin.com")
+	c.Assert(err, check.IsNil)
+	err = evt.TryCancel("because I still want", "admin@admin.com")
+	c.Assert(err, check.DeepEquals, ErrCancelAlreadyRequested)
+}
+
 func (s *S) TestEventCancelNotCancelable(c *check.C) {
 	evt, err := New(&Opts{
 		Target:  Target{Type: "app", Value: "myapp"},


### PR DESCRIPTION
Currently if we try to cancel the same event twice, the TryCancel message will output that the event requested does not exist. This handles this case better.