### PR TITLE
Fix service instance update

### DIFF
--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -510,6 +510,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 		Description: "desc",
+		TeamOwner:   "owner",
 	}
 	err := si.Create()
 	c.Assert(err, check.IsNil)
@@ -531,7 +532,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 	c.Assert(err, check.IsNil)
 	c.Assert(instance.Name, check.Equals, "brainsql")
 	c.Assert(instance.ServiceName, check.Equals, "mysql")
-	c.Assert(instance.Teams, check.DeepEquals, si.Teams)
+	c.Assert(instance.Teams, check.DeepEquals, append(si.Teams, "owner"))
 	c.Assert(instance.Apps, check.DeepEquals, si.Apps)
 	c.Assert(instance.Description, check.Equals, "changed")
 	c.Assert(eventtest.EventDesc{
@@ -576,7 +577,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTeamOwner(c *check.C
 	c.Assert(err, check.IsNil)
 	c.Assert(instance.Name, check.Equals, "brainsql")
 	c.Assert(instance.ServiceName, check.Equals, "mysql")
-	c.Assert(instance.Teams, check.DeepEquals, si.Teams)
+	c.Assert(instance.Teams, check.DeepEquals, append(si.Teams, "changed"))
 	c.Assert(instance.Apps, check.DeepEquals, si.Apps)
 	c.Assert(instance.TeamOwner, check.Equals, "changed")
 	c.Assert(eventtest.EventDesc{
@@ -600,6 +601,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTags(c *check.C) {
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 		Tags:        []string{"tag a"},
+		TeamOwner:   "owner",
 	}
 	err := si.Create()
 	c.Assert(err, check.IsNil)
@@ -621,7 +623,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTags(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(instance.Name, check.Equals, "brainsql")
 	c.Assert(instance.ServiceName, check.Equals, "mysql")
-	c.Assert(instance.Teams, check.DeepEquals, si.Teams)
+	c.Assert(instance.Teams, check.DeepEquals, append(si.Teams, "owner"))
 	c.Assert(instance.Apps, check.DeepEquals, si.Apps)
 	c.Assert(instance.Tags, check.DeepEquals, []string{"tag b", "tag c"})
 	c.Assert(eventtest.EventDesc{

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -162,7 +162,14 @@ func (si *ServiceInstance) Update(updateData ServiceInstance) error {
 	} else {
 		updateData.Tags = tags
 	}
-	return conn.ServiceInstances().Update(bson.M{"name": si.Name, "service_name": si.ServiceName}, updateData)
+	return conn.ServiceInstances().Update(
+		bson.M{"name": si.Name, "service_name": si.ServiceName},
+		bson.M{"$set": bson.M{
+			"description": updateData.Description,
+			"tags":        updateData.Tags,
+			"teamowner":   updateData.TeamOwner,
+		}},
+	)
 }
 
 func (si *ServiceInstance) updateData(update bson.M) error {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -164,11 +164,16 @@ func (si *ServiceInstance) Update(updateData ServiceInstance) error {
 	}
 	return conn.ServiceInstances().Update(
 		bson.M{"name": si.Name, "service_name": si.ServiceName},
-		bson.M{"$set": bson.M{
-			"description": updateData.Description,
-			"tags":        updateData.Tags,
-			"teamowner":   updateData.TeamOwner,
-		}},
+		bson.M{
+			"$set": bson.M{
+				"description": updateData.Description,
+				"tags":        updateData.Tags,
+				"teamowner":   updateData.TeamOwner,
+			},
+			"$addToSet": bson.M{
+				"teams": updateData.TeamOwner,
+			},
+		},
 	)
 }
 

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -555,18 +555,21 @@ func (s *InstanceSuite) TestUpdateServiceInstance(c *check.C) {
 	instance := ServiceInstance{Name: "instance", ServiceName: "mongodb", PlanName: "small", TeamOwner: s.team.Name, Tags: []string{"tag1"}}
 	err = CreateServiceInstance(instance, &srv, s.user, "")
 	c.Assert(err, check.IsNil)
-	instance.Description = "desc"
-	instance.Tags = []string{"tag2"}
-	instance.TeamOwner = "new-team-owner"
-	err = instance.Update(instance)
-	c.Assert(err, check.IsNil)
 	var si ServiceInstance
+	err = s.conn.ServiceInstances().Find(bson.M{"name": "instance"}).One(&si)
+	c.Assert(err, check.IsNil)
+	newTeam := authTypes.Team{Name: "new-team-owner"}
+	si.Description = "desc"
+	si.Tags = []string{"tag2"}
+	si.TeamOwner = newTeam.Name
+	err = instance.Update(si)
+	c.Assert(err, check.IsNil)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": "instance"}).One(&si)
 	c.Assert(err, check.IsNil)
 	c.Assert(si.PlanName, check.Equals, "small")
 	c.Assert(si.Description, check.Equals, "desc")
 	c.Assert(si.Tags, check.DeepEquals, []string{"tag2"})
-	c.Assert(si.TeamOwner, check.Equals, "new-team-owner")
+	c.Assert(si.TeamOwner, check.Equals, newTeam.Name)
 }
 
 func (s *InstanceSuite) TestUpdateServiceInstanceRemovesDuplicatedAndEmptyTags(c *check.C) {

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -570,6 +570,7 @@ func (s *InstanceSuite) TestUpdateServiceInstance(c *check.C) {
 	c.Assert(si.Description, check.Equals, "desc")
 	c.Assert(si.Tags, check.DeepEquals, []string{"tag2"})
 	c.Assert(si.TeamOwner, check.Equals, newTeam.Name)
+	c.Assert(si.Teams, check.DeepEquals, []string{s.team.Name, newTeam.Name})
 }
 
 func (s *InstanceSuite) TestUpdateServiceInstanceRemovesDuplicatedAndEmptyTags(c *check.C) {


### PR DESCRIPTION
When the service instance team owner is updated, adds it to the teams array.

Also, makes the update operation safer, allowing only a subset of allowed fields to be updated.