### PR TITLE
provision/kubernetes: ugly hack for deploy containers to wait each other

### DIFF
--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
@@ -452,6 +453,73 @@ func (s *S) TestServiceManagerDeployServiceWithLimits(c *check.C) {
 	c.Assert(dep.Spec.Template.Spec.Containers[0].Resources, check.DeepEquals, apiv1.ResourceRequirements{
 		Limits: apiv1.ResourceList{
 			apiv1.ResourceMemory: *expectedMemory,
+		},
+	})
+}
+
+func (s *S) TestCreateBuildPodContainers(c *check.C) {
+	a, _, rollback := s.defaultReactions(c)
+	defer rollback()
+	err := createBuildPod(buildPodParams{
+		client:           s.client.clusterClient,
+		app:              a,
+		sourceImage:      "myimg",
+		destinationImage: "destimg",
+	})
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.Core().Pods(s.client.Namespace()).List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(pods.Items, check.HasLen, 1)
+	containers := pods.Items[0].Spec.Containers
+	c.Assert(containers, check.HasLen, 2)
+	sort.Slice(containers, func(i, j int) bool { return containers[i].Name < containers[j].Name })
+	runAsUser := int64(1000)
+	c.Assert(containers, check.DeepEquals, []apiv1.Container{
+		{
+			Name:  "committer-cont",
+			Image: "docker:1.11.2",
+			VolumeMounts: []apiv1.VolumeMount{
+				{Name: "dockersock", MountPath: dockerSockPath},
+				{Name: "intercontainer", MountPath: buildIntercontainerPath},
+			},
+			TTY: true,
+			Command: []string{
+				"sh", "-ec",
+				`
+							while [ ! -f /tmp/intercontainer/status ]; do sleep 1; done
+							exit_code=$(cat /tmp/intercontainer/status)
+							[ "${exit_code}" != "0" ] && exit "${exit_code}"
+							id=$(docker ps -aq -f "label=io.kubernetes.container.name=myapp-v1-deploy" -f "label=io.kubernetes.pod.name=$(hostname)")
+							img="destimg"
+							echo
+							echo '---- Building application image ----'
+							docker commit "${id}" "${img}" >/dev/null
+							sz=$(docker history "${img}" | head -2 | tail -1 | grep -E -o '[0-9.]+\s[a-zA-Z]+\s*$' | sed 's/[[:space:]]*$//g')
+							echo " ---> Sending image to repository (${sz})"
+							docker push "${img}"
+							touch /tmp/intercontainer/done
+						`,
+			},
+		},
+		{
+			Name:  "myapp-v1-deploy",
+			Image: "myimg",
+			Command: []string{"/bin/sh", "-lc", `
+		cat >/home/application/archive.tar.gz && tsuru_unit_agent   myapp "/var/lib/tsuru/deploy archive file:///home/application/archive.tar.gz" deploy
+		exit_code=$?
+		echo "${exit_code}" >/tmp/intercontainer/status
+		[ "${exit_code}" != "0" ] && exit "${exit_code}"
+		while [ ! -f /tmp/intercontainer/done ]; do sleep 1; done
+	`},
+			Stdin:     true,
+			StdinOnce: true,
+			Env:       []apiv1.EnvVar{{Name: "TSURU_HOST", Value: ""}},
+			SecurityContext: &apiv1.SecurityContext{
+				RunAsUser: &runAsUser,
+			},
+			VolumeMounts: []apiv1.VolumeMount{
+				{Name: "intercontainer", MountPath: buildIntercontainerPath},
+			},
 		},
 	})
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -20,7 +20,6 @@ import (
 	tsuruNet "github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/cluster"
-	"github.com/tsuru/tsuru/provision/dockercommon"
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	"github.com/tsuru/tsuru/set"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -671,15 +670,9 @@ func (p *kubernetesProvisioner) UploadDeploy(a provision.App, archiveFile io.Rea
 		return "", err
 	}
 	defer cleanupPod(client, deployPodName)
-	cmds := dockercommon.ArchiveDeployCmds(a, "file:///home/application/archive.tar.gz")
-	if len(cmds) != 3 {
-		return "", errors.Errorf("unexpected cmds list: %#v", cmds)
-	}
-	cmds[2] = fmt.Sprintf("cat >/home/application/archive.tar.gz && %s", cmds[2])
 	params := buildPodParams{
 		app:              a,
 		client:           client,
-		buildCmd:         cmds,
 		sourceImage:      baseImage,
 		destinationImage: buildingImage,
 		attachInput:      archiveFile,

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -333,15 +333,6 @@ func (s *S) TestRegisterUnitDeployUnit(c *check.C) {
 		destinationImage: "destimg",
 	})
 	c.Assert(err, check.IsNil)
-	podID, err := deployPodNameForApp(a)
-	c.Assert(err, check.IsNil)
-	err = s.p.RegisterUnit(a, podID, map[string]interface{}{
-		"processes": map[string]interface{}{
-			"web":    "w1",
-			"worker": "w2",
-		},
-	})
-	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	meta, err := image.GetImageMetaData("destimg")
 	c.Assert(err, check.IsNil)
 	c.Assert(meta, check.DeepEquals, image.ImageMetadata{
@@ -349,8 +340,10 @@ func (s *S) TestRegisterUnitDeployUnit(c *check.C) {
 		CustomData:      map[string]interface{}{},
 		LegacyProcesses: map[string]string{},
 		Processes: map[string][]string{
-			"web":    {"w1"},
-			"worker": {"w2"},
+			// Processes from RegisterUnit call in suite_test.go as deploy pod
+			// reaction.
+			"web":    {"python myapp.py"},
+			"worker": {"python myworker.py"},
 		},
 	})
 }


### PR DESCRIPTION
This serves both as a workaround to kubernetes/kubernetes#51142 and to help
prevent kubernetes' GC from removing the main container while we're running
docker commit on it. This latter issue should be fixed once moby/moby#30696
is in.