### PR TITLE
all: use json-file log driver for deploy containers

### DIFF
--- a/builder/docker/container.go
+++ b/builder/docker/container.go
@@ -272,6 +272,9 @@ func (c *Container) hostConfig(app provision.App, isDeploy bool) (*docker.HostCo
 	}
 	hostConfig.OomScoreAdj = 1000
 	hostConfig.SecurityOpt, _ = config.GetList("docker:security-opts")
+	hostConfig.LogConfig = docker.LogConfig{
+		Type: dockercommon.JsonFileLogDriver,
+	}
 	if sharedBasedir != "" && sharedMount != "" {
 		if sharedIsolation {
 			var appHostDir string

--- a/provision/docker/container/container.go
+++ b/provision/docker/container/container.go
@@ -453,6 +453,9 @@ func (c *Container) hostConfig(app provision.App, isDeploy bool) (*docker.HostCo
 		}
 	} else {
 		hostConfig.OomScoreAdj = 1000
+		hostConfig.LogConfig = docker.LogConfig{
+			Type: dockercommon.JsonFileLogDriver,
+		}
 	}
 
 	hostConfig.SecurityOpt, _ = config.GetList("docker:security-opts")

--- a/provision/docker/container/container_test.go
+++ b/provision/docker/container/container_test.go
@@ -325,7 +325,7 @@ func (s *S) TestContainerCreateForDeploy(c *check.C) {
 	dockerContainer, err := client.InspectContainer(cont.ID)
 	c.Assert(err, check.IsNil)
 	c.Assert(dockerContainer.HostConfig.RestartPolicy.Name, check.Equals, "")
-	c.Assert(dockerContainer.HostConfig.LogConfig.Type, check.Equals, "")
+	c.Assert(dockerContainer.HostConfig.LogConfig.Type, check.Equals, "json-file")
 	c.Assert(dockerContainer.HostConfig.Memory, check.Equals, int64(0))
 	c.Assert(dockerContainer.HostConfig.MemorySwap, check.Equals, int64(0))
 	c.Assert(dockerContainer.HostConfig.CPUShares, check.Equals, int64(50))

--- a/provision/dockercommon/docker.go
+++ b/provision/dockercommon/docker.go
@@ -21,6 +21,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	JsonFileLogDriver = "json-file"
+)
+
 type Client interface {
 	PushImage(docker.PushImageOptions, docker.AuthConfiguration) error
 	InspectImage(string) (*docker.Image, error)

--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -292,10 +292,14 @@ func serviceSpecForApp(opts tsuruServiceOpts) (*swarm.ServiceSpec, error) {
 		Provisioner:   provisionerName,
 		Prefix:        tsuruLabelPrefix,
 	})
+	var logDriver *swarm.Driver
 	srvName := serviceNameForApp(opts.app, opts.process)
 	if opts.isDeploy {
 		opts.replicas = 1
 		srvName = fmt.Sprintf("%s-build", srvName)
+		logDriver = &swarm.Driver{
+			Name: dockercommon.JsonFileLogDriver,
+		}
 	}
 	if opts.isIsolatedRun {
 		opts.replicas = 1
@@ -322,6 +326,7 @@ func serviceSpecForApp(opts tsuruServiceOpts) (*swarm.ServiceSpec, error) {
 			Placement: &swarm.Placement{
 				Constraints: opts.constraints,
 			},
+			LogDriver: logDriver,
 		},
 		Networks:     networks,
 		EndpointSpec: endpointSpec,


### PR DESCRIPTION
This ensures we always have the output log from the deploy.