### PR TITLE
Service instance update endpoint

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -4033,7 +4033,7 @@ func (s *S) TestBindHandlerEndpointIsDown(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{
 		Name:      "painkiller",
@@ -4083,7 +4083,7 @@ func (s *S) TestBindHandler(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{
 		Name:      "painkiller",
@@ -4144,7 +4144,7 @@ func (s *S) TestBindHandlerReturns400IfServiceIsBlacklistedAndItsTheOnlyService(
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	err = pool.SetPoolConstraint(&pool.PoolConstraint{
 		PoolExpr:  s.Pool,
@@ -4176,7 +4176,7 @@ func (s *S) TestBindHandlerReturns400IfServiceIsBlacklistedAndMoreServicesAvaila
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	err = pool.SetPoolConstraint(&pool.PoolConstraint{
 		PoolExpr:  s.Pool,
@@ -4218,7 +4218,7 @@ func (s *S) TestBindHandlerWithoutEnvsDontRestartTheApp(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{
 		Name:      "painkiller",
@@ -4290,7 +4290,7 @@ func (s *S) TestBindHandlerReturns403IfTheUserDoesNotHaveAccessToTheInstance(c *
 		Context: permission.Context(permission.CtxTeam, s.team.Name),
 	})
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql"}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "serviceapp", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(&a, s.user)
@@ -4309,7 +4309,7 @@ func (s *S) TestBindHandlerReturns403IfTheUserDoesNotHaveAccessToTheInstance(c *
 
 func (s *S) TestBindHandlerReturns404IfTheAppDoesNotExist(c *check.C) {
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/instances/%s/unknown?:instance=%s&:app=unknown&:service=%s&noRestart=false", instance.ServiceName,
 		instance.Name, instance.Name, instance.ServiceName)
@@ -4333,7 +4333,7 @@ func (s *S) TestBindHandlerReturns403IfTheUserDoesNotHaveAccessToTheApp(c *check
 		Context: permission.Context(permission.CtxTeam, "other-team"),
 	})
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "serviceapp", Platform: "zend"}
 	err = s.conn.Apps().Insert(a)
@@ -4368,14 +4368,14 @@ func (s *S) TestBindWithManyInstanceNameWithSameNameAndNoRestartFlag(c *check.C)
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	instance2 := service.ServiceInstance{
 		Name:        "my-mysql",
 		ServiceName: "mysql2",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance2.Create()
+	err = s.conn.ServiceInstances().Insert(instance2)
 	c.Assert(err, check.IsNil)
 	a := app.App{
 		Name:      "painkiller",
@@ -4463,7 +4463,7 @@ func (s *S) TestUnbindHandler(c *check.C) {
 		Apps:        []string{"painkiller"},
 		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	otherApp, err := app.GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -4561,7 +4561,7 @@ func (s *S) TestUnbindNoRestartFlag(c *check.C) {
 		Apps:        []string{"painkiller"},
 		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	otherApp, err := app.GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -4673,7 +4673,7 @@ func (s *S) TestUnbindWithSameInstanceName(c *check.C) {
 		},
 	}
 	for _, instance := range instances {
-		err = instance.Create()
+		err = s.conn.ServiceInstances().Insert(instance)
 		c.Assert(err, check.IsNil)
 	}
 	url := fmt.Sprintf("/services/%s/instances/%s/%s?:instance=%s&:app=%s&:service=%s&noRestart=true", instances[1].ServiceName, instances[1].Name, a.Name,
@@ -4717,7 +4717,7 @@ func (s *S) TestUnbindHandlerReturns403IfTheUserDoesNotHaveAccessToTheInstance(c
 		Context: permission.Context(permission.CtxTeam, s.team.Name),
 	})
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql"}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "serviceapp", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(&a, s.user)
@@ -4736,7 +4736,7 @@ func (s *S) TestUnbindHandlerReturns403IfTheUserDoesNotHaveAccessToTheInstance(c
 
 func (s *S) TestUnbindHandlerReturns404IfTheAppDoesNotExist(c *check.C) {
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/instances/%s/unknown?:service=%s&:instance=%s&:app=unknown&noRestart=false", instance.ServiceName,
 		instance.Name, instance.ServiceName, instance.Name)
@@ -4760,7 +4760,7 @@ func (s *S) TestUnbindHandlerReturns403IfTheUserDoesNotHaveAccessToTheApp(c *che
 		Context: permission.Context(permission.CtxTeam, "other-team"),
 	})
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err := instance.Create()
+	err := s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "serviceapp", Platform: "zend"}
 	err = s.conn.Apps().Insert(a)

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -50,6 +50,7 @@ type AuthSuite struct {
 	token      auth.Token
 	server     *authtest.SMTPServer
 	testServer http.Handler
+	conn       *db.Storage
 }
 
 var _ = check.Suite(&AuthSuite{})
@@ -73,28 +74,25 @@ func (s *AuthSuite) SetUpSuite(c *check.C) {
 	provision.DefaultProvisioner = "fake"
 	app.AuthScheme = nativeScheme
 	s.testServer = RunServer(true)
+	s.conn, err = db.Conn()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *AuthSuite) TearDownSuite(c *check.C) {
+	defer s.conn.Close()
 	s.server.Stop()
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
-	conn.Apps().Database.DropDatabase()
+	s.conn.Apps().Database.DropDatabase()
 }
 
 func (s *AuthSuite) SetUpTest(c *check.C) {
 	provisiontest.ProvisionerInstance.Reset()
 	routertest.FakeRouter.Reset()
 	repositorytest.Reset()
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
-	dbtest.ClearAllCollections(conn.Apps().Database)
+	dbtest.ClearAllCollections(s.conn.Apps().Database)
 	s.createUserAndTeam(c)
 	app.PlatformService().Insert(appTypes.Platform{Name: "python"})
 	opts := pool.AddPoolOptions{Name: "test1", Default: true}
-	err = pool.AddPool(opts)
+	err := pool.AddPool(opts)
 	c.Assert(err, check.IsNil)
 }
 
@@ -289,13 +287,11 @@ func (s *AuthSuite) TestLoginShouldCreateTokenInTheDatabaseAndReturnItWithinTheR
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var user auth.User
-	conn, _ := db.Conn()
-	defer conn.Close()
-	err = conn.Users().Find(bson.M{"email": "nobody@globo.com"}).One(&user)
+	err = s.conn.Users().Find(bson.M{"email": "nobody@globo.com"}).One(&user)
 	c.Assert(err, check.IsNil)
 	var recorderJSON map[string]string
 	json.Unmarshal(recorder.Body.Bytes(), &recorderJSON)
-	n, err := conn.Tokens().Find(bson.M{"token": recorderJSON["token"]}).Count()
+	n, err := s.conn.Tokens().Find(bson.M{"token": recorderJSON["token"]}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(n, check.Equals, 1)
 }
@@ -507,7 +503,6 @@ func (s *AuthSuite) TestRemoveTeamGives403WhenTeamHasAccessToAnyApp(c *check.C) 
 	a := app.App{Name: "i-should", Platform: "python", TeamOwner: team.Name}
 	err = app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
-	defer app.Delete(&a, nil)
 	request, err := http.NewRequest("DELETE", fmt.Sprintf("/teams/%s?:name=%s", team.Name, team.Name), nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -526,10 +521,10 @@ func (s *AuthSuite) TestRemoveTeamGives403WhenTeamHasAccessToAnyServiceInstance(
 	err := auth.TeamService().Insert(team)
 	c.Assert(err, check.IsNil)
 	si1 := service.ServiceInstance{Name: "my_nosql", ServiceName: "nosql-service", Teams: []string{team.Name}}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{Name: "my_nosql-2", ServiceName: "nosql-service", Teams: []string{team.Name}}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("DELETE", fmt.Sprintf("/teams/%s?:name=%s", team.Name, team.Name), nil)
 	c.Assert(err, check.IsNil)
@@ -624,13 +619,6 @@ func (s *AuthSuite) TestListTeamsReturns204IfTheUserHasNoTeam(c *check.C) {
 }
 
 func (s *AuthSuite) TestAddKeyToUser(c *check.C) {
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
-	defer func() {
-		s.user.RemoveKey(repository.Key{Name: "the-key"})
-		conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
-	}()
 	b := strings.NewReader("name=the-key&key=my-key")
 	request, err := http.NewRequest("POST", "/users/keys", b)
 	c.Assert(err, check.IsNil)
@@ -696,15 +684,8 @@ func (s *AuthSuite) TestAddKeyToUserKeyManagerDisabled(c *check.C) {
 }
 
 func (s *AuthSuite) TestAddKeyToUserReturnsConflictIfTheKeyIsAlreadyPresent(c *check.C) {
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	s.user.AddKey(repository.Key{Name: "the-key", Body: "my-key"}, false)
-	conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
-	defer func() {
-		s.user.RemoveKey(repository.Key{Name: "the-key", Body: "my-key"})
-		conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
-	}()
+	s.conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
 	b := strings.NewReader("name=the-key&key=your-key")
 	request, err := http.NewRequest("POST", "/users/keys", b)
 	c.Assert(err, check.IsNil)
@@ -717,15 +698,8 @@ func (s *AuthSuite) TestAddKeyToUserReturnsConflictIfTheKeyIsAlreadyPresent(c *c
 }
 
 func (s *AuthSuite) TestAddKeyForcingUpdate(c *check.C) {
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	s.user.AddKey(repository.Key{Name: "the-key", Body: "my-key"}, false)
-	conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
-	defer func() {
-		s.user.RemoveKey(repository.Key{Name: "the-key", Body: "my-key"})
-		conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
-	}()
+	s.conn.Users().Update(bson.M{"email": s.user.Email}, s.user)
 	b := strings.NewReader("name=the-key&key=my-other-key&force=true")
 	request, err := http.NewRequest("POST", "/users/keys", b)
 	c.Assert(err, check.IsNil)
@@ -848,8 +822,6 @@ func (s *AuthSuite) TestListKeysKeyManagerDisabled(c *check.C) {
 }
 
 func (s *AuthSuite) TestRemoveUser(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "her-voices@painofsalvation.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
@@ -860,7 +832,7 @@ func (s *AuthSuite) TestRemoveUser(c *check.C) {
 	recorder := httptest.NewRecorder()
 	err = removeUser(recorder, request, token)
 	c.Assert(err, check.IsNil)
-	n, err := conn.Users().Find(bson.M{"email": u.Email}).Count()
+	n, err := s.conn.Users().Find(bson.M{"email": u.Email}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(n, check.Equals, 0)
 	c.Assert(eventtest.EventDesc{
@@ -874,8 +846,6 @@ func (s *AuthSuite) TestRemoveUser(c *check.C) {
 }
 
 func (s *AuthSuite) TestRemoveUserProvidingOwnEmail(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "her-voices@painofsalvation.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
@@ -886,7 +856,7 @@ func (s *AuthSuite) TestRemoveUserProvidingOwnEmail(c *check.C) {
 	recorder := httptest.NewRecorder()
 	err = removeUser(recorder, request, token)
 	c.Assert(err, check.IsNil)
-	n, err := conn.Users().Find(bson.M{"email": u.Email}).Count()
+	n, err := s.conn.Users().Find(bson.M{"email": u.Email}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(n, check.Equals, 0)
 	c.Assert(eventtest.EventDesc{
@@ -903,8 +873,6 @@ func (s *AuthSuite) TestRemoveUserProvidingOwnEmail(c *check.C) {
 }
 
 func (s *AuthSuite) TestRemoveAnotherUser(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "her-voices@painofsalvation.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
@@ -914,7 +882,7 @@ func (s *AuthSuite) TestRemoveAnotherUser(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	n, err := conn.Users().Find(bson.M{"email": u.Email}).Count()
+	n, err := s.conn.Users().Find(bson.M{"email": u.Email}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(n, check.Equals, 0)
 	c.Assert(eventtest.EventDesc{
@@ -989,15 +957,11 @@ func (s *AuthSuite) TestChangePasswordReturns412IfNewPasswordIsInvalid(c *check.
 }
 
 func (s *AuthSuite) TestChangePasswordReturns412IfNewPasswordAndConfirmPasswordDidntMatch(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := &auth.User{Email: "me@globo.com.com", Password: "123456"}
 	_, err := nativeScheme.Create(u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	body := strings.NewReader("old=123456&new=12345678&confirm=1234567810")
 	request, err := http.NewRequest("PUT", "/users/password", body)
 	c.Assert(err, check.IsNil)
@@ -1046,13 +1010,9 @@ func (s *AuthSuite) TestResetPasswordStep1(c *check.C) {
 	recorder := httptest.NewRecorder()
 	err := resetPassword(recorder, request)
 	c.Assert(err, check.IsNil)
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	var m map[string]interface{}
-	err = conn.PasswordTokens().Find(bson.M{"useremail": s.user.Email}).One(&m)
+	err = s.conn.PasswordTokens().Find(bson.M{"useremail": s.user.Email}).One(&m)
 	c.Assert(err, check.IsNil)
-	defer conn.PasswordTokens().RemoveId(m["_id"])
 	err = tsurutest.WaitCondition(time.Second, func() bool {
 		s.server.RLock()
 		defer s.server.RUnlock()
@@ -1096,18 +1056,14 @@ func (s *AuthSuite) TestResetPasswordInvalidEmail(c *check.C) {
 }
 
 func (s *AuthSuite) TestResetPasswordStep2(c *check.C) {
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
 	user := auth.User{Email: "uns@alanis.com", Password: "145678"}
-	err = user.Create()
+	err := user.Create()
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": user.Email})
 	oldPassword := user.Password
 	err = nativeScheme.StartPasswordReset(&user)
 	c.Assert(err, check.IsNil)
 	var t map[string]interface{}
-	err = conn.PasswordTokens().Find(bson.M{"useremail": user.Email}).One(&t)
+	err = s.conn.PasswordTokens().Find(bson.M{"useremail": user.Email}).One(&t)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/users/%s/password?:email=%s&token=%s", user.Email, user.Email, t["_id"])
 	request, _ := http.NewRequest("POST", url, nil)
@@ -1176,15 +1132,11 @@ func (s *AuthSuite) TestAuthScheme(c *check.C) {
 }
 
 func (s *AuthSuite) TestRegenerateAPITokenHandler(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "zobomafoo@zimbabue.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("POST", "/users/api-key", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "b "+token.GetValue())
@@ -1195,7 +1147,7 @@ func (s *AuthSuite) TestRegenerateAPITokenHandler(c *check.C) {
 	var got string
 	err = json.NewDecoder(recorder.Body).Decode(&got)
 	c.Assert(err, check.IsNil)
-	count, err := conn.Users().Find(bson.M{"apikey": got}).Count()
+	count, err := s.conn.Users().Find(bson.M{"apikey": got}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(count, check.Equals, 1)
 	c.Assert(eventtest.EventDesc{
@@ -1206,15 +1158,11 @@ func (s *AuthSuite) TestRegenerateAPITokenHandler(c *check.C) {
 }
 
 func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndIsAdminUser(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "leto@arrakis.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token := s.token
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("POST", "/users/api-key?user=leto@arrakis.com", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -1223,7 +1171,7 @@ func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndIsAdminUser(c *chec
 	var got string
 	err = json.NewDecoder(recorder.Body).Decode(&got)
 	c.Assert(err, check.IsNil)
-	count, err := conn.Users().Find(bson.M{"apikey": got}).Count()
+	count, err := s.conn.Users().Find(bson.M{"apikey": got}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(count, check.Equals, 1)
 	c.Assert(eventtest.EventDesc{
@@ -1237,15 +1185,11 @@ func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndIsAdminUser(c *chec
 }
 
 func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndNotAdminUser(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "user@example.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("POST", "/users/api-key?user=myadmin@arrakis.com", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -1255,15 +1199,11 @@ func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndNotAdminUser(c *che
 }
 
 func (s *AuthSuite) TestShowAPITokenForUserWithNoToken(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "zobomafoo@zimbabue.com", Password: "123456"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("GET", "/users/api-key", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -1272,21 +1212,17 @@ func (s *AuthSuite) TestShowAPITokenForUserWithNoToken(c *check.C) {
 	var got string
 	err = json.NewDecoder(recorder.Body).Decode(&got)
 	c.Assert(err, check.IsNil)
-	count, err := conn.Users().Find(bson.M{"apikey": got}).Count()
+	count, err := s.conn.Users().Find(bson.M{"apikey": got}).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(count, check.Equals, 1)
 }
 
 func (s *AuthSuite) TestShowAPITokenForUserWithToken(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	u := auth.User{Email: "zobomafoo@zimbabue.com", Password: "123456", APIKey: "238hd23ubd923hd923j9d23ndibde"}
 	_, err := nativeScheme.Create(&u)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": u.Email})
 	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("GET", "/users/api-key", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "b "+token.GetValue())
@@ -1301,8 +1237,6 @@ func (s *AuthSuite) TestShowAPITokenForUserWithToken(c *check.C) {
 }
 
 func (s *AuthSuite) TestShowAPITokenOtherUserAndIsAdminUser(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	user := auth.User{
 		Email:    "user@example.com",
 		Password: "123456",
@@ -1310,9 +1244,7 @@ func (s *AuthSuite) TestShowAPITokenOtherUserAndIsAdminUser(c *check.C) {
 	}
 	_, err := nativeScheme.Create(&user)
 	c.Assert(err, check.IsNil)
-	defer conn.Users().Remove(bson.M{"email": user.Email})
 	token := s.token
-	defer conn.Tokens().Remove(bson.M{"token": token.GetValue()})
 	request, err := http.NewRequest("GET", "/users/api-key?user=user@example.com", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
@@ -1325,8 +1257,6 @@ func (s *AuthSuite) TestShowAPITokenOtherUserAndIsAdminUser(c *check.C) {
 }
 
 func (s *AuthSuite) TestShowAPITokenOtherUserWithoutPermission(c *check.C) {
-	conn, _ := db.Conn()
-	defer conn.Close()
 	users := []auth.User{
 		{
 			Email:    "user1@example.com",
@@ -1342,7 +1272,6 @@ func (s *AuthSuite) TestShowAPITokenOtherUserWithoutPermission(c *check.C) {
 	for _, u := range users {
 		_, err := nativeScheme.Create(&u)
 		c.Assert(err, check.IsNil)
-		defer conn.Users().Remove(bson.M{"email": u.Email})
 	}
 	token := userWithPermission(c)
 	request, err := http.NewRequest("GET", "/users/api-key?user=user@example.com", nil)

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -98,8 +98,7 @@ func createServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	err = service.CreateServiceInstance(instance, &srv, user, requestID)
 	if err == service.ErrInstanceNameAlreadyExists {
 		return &tsuruErrors.HTTP{
@@ -191,8 +190,7 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	if tags != nil {
 		si.Tags = tags
 	}
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	return si.Update(srv, *si, requestID)
 }
 
@@ -256,8 +254,7 @@ func removeServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 			}
 		}
 	}
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	err = service.DeleteInstance(serviceInstance, requestID)
 	if err != nil {
 		if err == service.ErrServiceInstanceBound {
@@ -386,8 +383,7 @@ func serviceInstanceStatus(w http.ResponseWriter, r *http.Request, t auth.Token)
 		return permission.ErrUnauthorized
 	}
 	var b string
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	if b, err = serviceInstance.Status(requestID); err != nil {
 		return errors.Wrap(err, "Could not retrieve status of service instance, error")
 	}
@@ -427,8 +423,7 @@ func serviceInstance(w http.ResponseWriter, r *http.Request, t auth.Token) error
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	info, err := serviceInstance.Info(requestID)
 	if err != nil {
 		return err
@@ -534,8 +529,7 @@ func servicePlans(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			return permission.ErrUnauthorized
 		}
 	}
-	requestIDHeader, _ := config.GetString("request-id-header")
-	requestID := context.GetRequestID(r, requestIDHeader)
+	requestID := requestIDHeader(r)
 	plans, err := service.GetPlansByServiceName(serviceName, requestID)
 	if err != nil {
 		return err
@@ -699,4 +693,9 @@ func sortedServiceNames(services map[string]*service.ServiceModel) []string {
 	}
 	sort.Strings(serviceNames)
 	return serviceNames
+}
+
+func requestIDHeader(r *http.Request) string {
+	requestIDHeader, _ := config.GetString("request-id-header")
+	return context.GetRequestID(r, requestIDHeader)
 }

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -138,6 +138,10 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	description := r.FormValue("description")
 	teamOwner := r.FormValue("teamowner")
 	tags := r.Form["tag"]
+	srv, err := getService(serviceName)
+	if err != nil {
+		return err
+	}
 	si, err := getServiceInstanceOrError(serviceName, instanceName)
 	if err != nil {
 		return err
@@ -187,7 +191,9 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	if tags != nil {
 		si.Tags = tags
 	}
-	return si.Update(*si)
+	requestIDHeader, _ := config.GetString("request-id-header")
+	requestID := context.GetRequestID(r, requestIDHeader)
+	return si.Update(srv, *si, requestID)
 }
 
 // title: remove service instance

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -520,7 +520,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 		Description: "desc",
 		TeamOwner:   s.team.Name,
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	params := map[string]interface{}{
 		"description": "changed",
@@ -565,7 +565,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTeamOwner(c *check.C
 		Teams:       []string{s.team.Name},
 		TeamOwner:   s.team.Name,
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	t := authTypes.Team{Name: "changed"}
 	err = auth.TeamService().Insert(t)
@@ -614,7 +614,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTags(c *check.C) {
 		Tags:        []string{"tag a"},
 		TeamOwner:   s.team.Name,
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	params := map[string]interface{}{
 		"tag": []string{"tag b", "tag c"},
@@ -660,7 +660,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithEmptyTagRemovesTags(
 		TeamOwner:   s.team.Name,
 		Tags:        []string{"tag a"},
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	params := map[string]interface{}{
 		"tag": []string{""},
@@ -706,7 +706,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithoutPermissions(c *ch
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	params := map[string]interface{}{
 		"description": "changed",
@@ -725,7 +725,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceEmptyFields(c *check.C) 
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 	}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	params := map[string]interface{}{
 		"description": "",
@@ -767,7 +767,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceServiceInstance(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstance("foo", "foo-instance", c)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -838,7 +838,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWithSameInstaceName(c *c
 		},
 	}
 	for _, instance := range si {
-		err = instance.Create()
+		err = s.conn.ServiceInstances().Insert(instance)
 		c.Assert(err, check.IsNil)
 	}
 	recorder, request := makeRequestToRemoveServiceInstance("foo2", "foo-instance", c)
@@ -873,7 +873,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWithoutPermissionShouldR
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo-service"}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstance("foo-service", "foo-instance", c)
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -886,7 +886,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsShould
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Apps: []string{"foo-bar"}, Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstance("foo", "foo-instance", c)
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -950,7 +950,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithUn
 		Apps:        []string{"painkiller"},
 		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstanceWithUnbind("mysql", "my-mysql", c)
 	err = removeServiceInstance(recorder, request, s.token)
@@ -1001,7 +1001,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithNo
 		Apps:        []string{"app1"},
 		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstanceWithNoUnbind("mysqlremove", "my-mysql", c)
 	err = removeServiceInstance(recorder, request, s.token)
@@ -1052,7 +1052,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithNo
 		Apps:        []string{"app", "app2"},
 		BoundUnits:  []service.Unit{{ID: units[0].ID, IP: units[0].IP}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstanceWithNoUnbind("mysqlremove", "my-mysql", c)
 	err = removeServiceInstance(recorder, request, s.token)
@@ -1076,7 +1076,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceShouldCallTheServiceAPI(c *check
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "purity-instance", ServiceName: "purity", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToRemoveServiceInstance("purity", "purity-instance", c)
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -1118,7 +1118,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstances(c *check.C) {
 		Apps:        []string{"globo"},
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	instance2 := service.ServiceInstance{
 		Name:        "mongodb-other",
@@ -1126,7 +1126,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstances(c *check.C) {
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 	}
-	err = instance2.Create()
+	err = s.conn.ServiceInstances().Insert(instance2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/services/instances", nil)
 	c.Assert(err, check.IsNil)
@@ -1171,7 +1171,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesAppFilter(c *check.C) {
 		Apps:        []string{"globo"},
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	instance2 := service.ServiceInstance{
 		Name:        "mongodb-other",
@@ -1179,7 +1179,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesAppFilter(c *check.C) {
 		Apps:        []string{"other"},
 		Teams:       []string{s.team.Name},
 	}
-	err = instance2.Create()
+	err = s.conn.ServiceInstances().Insert(instance2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/services/instances?app=other", nil)
 	c.Assert(err, check.IsNil)
@@ -1211,7 +1211,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesReturnsOnlyServicesThatTh
 		ServiceName: "redis",
 		Apps:        []string{"globo"},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/services/instances", nil)
 	c.Assert(err, check.IsNil)
@@ -1238,14 +1238,14 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesFilterInstancesPerService
 			ServiceName: srv.Name,
 			Teams:       []string{s.team.Name},
 		}
-		err = instance.Create()
+		err = s.conn.ServiceInstances().Insert(instance)
 		c.Assert(err, check.IsNil)
 		instance = service.ServiceInstance{
 			Name:        srv.Name + "2",
 			ServiceName: srv.Name,
 			Teams:       []string{s.team.Name},
 		}
-		err = instance.Create()
+		err = s.conn.ServiceInstances().Insert(instance)
 		c.Assert(err, check.IsNil)
 	}
 	srv := service.Service{
@@ -1305,7 +1305,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceStatus(c *check.C) {
 	err := srv.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name, Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceStatus("mongodb", "my_nosql", c)
 	context.SetRequestID(request, requestIDHeader, "test")
@@ -1342,10 +1342,10 @@ func (s *ServiceInstanceSuite) TestServiceInstanceStatusWithSameInstanceName(c *
 	err = srv2.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name, Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{Name: "my_nosql", ServiceName: srv2.Name, Teams: []string{s.team.Name}}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceStatus("mongodb2", "my_nosql", c)
 	err = serviceInstanceStatus(recorder, request, s.token)
@@ -1369,7 +1369,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceStatusShouldReturnForbiddenWhe
 	err := srv.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceStatus("mongodb", "my_nosql", c)
 	err = serviceInstanceStatus(recorder, request, s.token)
@@ -1420,7 +1420,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfo(c *check.C) {
 		Description: "desc",
 		Tags:        []string{"tag 1"},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceInfo("mongodb", "my_nosql", s.token.GetValue(), c)
 	request.Header.Set(requestIDHeader, "test")
@@ -1468,7 +1468,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoNoPlanAndNoCustomInfo(c *c
 		TeamOwner:   s.team.Name,
 		Tags:        []string{"tag 1", "tag 2"},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceInfo("mongodb", "my_nosql", s.token.GetValue(), c)
 	s.testServer.ServeHTTP(recorder, request)
@@ -1505,7 +1505,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoShouldReturnForbiddenWhenU
 	err := srv.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := makeRequestToServiceInstanceInfo("mongodb", "my_nosql", s.token.GetValue(), c)
 	s.testServer.ServeHTTP(recorder, request)
@@ -1527,7 +1527,7 @@ func (s *ServiceInstanceSuite) TestServiceInfo(c *check.C) {
 		Apps:        []string{},
 		Teams:       []string{s.team.Name},
 	}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{
 		Name:        "your_nosql",
@@ -1535,7 +1535,7 @@ func (s *ServiceInstanceSuite) TestServiceInfo(c *check.C) {
 		Apps:        []string{"wordpress"},
 		Teams:       []string{s.team.Name},
 	}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/services/mongodb?:name=mongodb", nil)
 	c.Assert(err, check.IsNil)
@@ -1564,7 +1564,7 @@ func (s *ServiceInstanceSuite) TestServiceInfoShouldReturnOnlyInstancesOfTheSame
 		Apps:        []string{},
 		Teams:       []string{s.team.Name},
 	}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{
 		Name:        "your_nosql",
@@ -1572,7 +1572,7 @@ func (s *ServiceInstanceSuite) TestServiceInfoShouldReturnOnlyInstancesOfTheSame
 		Apps:        []string{"wordpress"},
 		Teams:       []string{},
 	}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", fmt.Sprintf("/services/%s?:name=%s", "mongodb", "mongodb"), nil)
 	c.Assert(err, check.IsNil)
@@ -1655,7 +1655,7 @@ func (s *ServiceInstanceSuite) TestGetServiceInstanceOrError(c *check.C) {
 	err := s.conn.Services().RemoveId(s.service.Name)
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo", ServiceName: "foo-service", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	rSi, err := getServiceInstanceOrError("foo-service", "foo")
 	c.Assert(err, check.IsNil)
@@ -1713,7 +1713,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxy(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/proxy/%s?callback=/mypath", si.ServiceName, si.Name)
 	request, err := http.NewRequest("GET", url, nil)
@@ -1754,7 +1754,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyPost(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/proxy/%s?callback=/mypath", si.ServiceName, si.Name)
 	body := strings.NewReader("my=awesome&body=1")
@@ -1806,7 +1806,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyPostRawBody(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/proxy/%s?callback=/mypath", si.ServiceName, si.Name)
 	body := strings.NewReader("something-something")
@@ -1846,7 +1846,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyNoContent(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/proxy/%s?callback=/mypath", si.ServiceName, si.Name)
 	request, err := http.NewRequest("GET", url, nil)
@@ -1868,7 +1868,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyError(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/%s/proxy/%s?callback=/mypath", si.ServiceName, si.Name)
 	request, err := http.NewRequest("GET", url, nil)
@@ -1890,7 +1890,7 @@ func (s *ServiceInstanceSuite) TestGrantRevokeServiceToTeam(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "si-test", ServiceName: "go", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	team := authTypes.Team{Name: "test"}
 	auth.TeamService().Insert(team)
@@ -1943,10 +1943,10 @@ func (s *ServiceInstanceSuite) TestGrantRevokeServiceToTeamWithManyInstanceName(
 		c.Assert(err, check.IsNil)
 	}
 	si := service.ServiceInstance{Name: "si-test", ServiceName: se[0].Name, Teams: []string{s.team.Name}}
-	err := si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{Name: "si-test", ServiceName: se[1].Name, Teams: []string{s.team.Name}}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	team := authTypes.Team{Name: "test"}
 	auth.TeamService().Insert(team)

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -508,7 +508,10 @@ func makeRequestToUpdateServiceInstance(params map[string]interface{}, serviceNa
 }
 
 func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check.C) {
+	requestIDHeader := "RequestID"
+	config.Set("request-id-header", requestIDHeader)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Header.Get(requestIDHeader), check.Equals, "test")
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
@@ -530,6 +533,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 		Context: permission.Context(permission.CtxServiceInstance, serviceIntancePermName("mysql", si.Name)),
 	})
 	recorder, request := makeRequestToUpdateServiceInstance(params, "mysql", "brainsql", token.GetValue(), c)
+	request.Header.Set(requestIDHeader, "test")
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var instance service.ServiceInstance

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -94,7 +94,7 @@ func (s *ProvisionSuite) TestServiceListGetAllServicesFromUsersTeam(c *check.C) 
 	err := srv.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name, Teams: []string{s.team.Name}, Tags: []string{"tag 1"}}
-	err := s.conn.ServiceInstances().Insert(si)
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := s.makeRequestToServicesHandler(c)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -94,7 +94,7 @@ func (s *ProvisionSuite) TestServiceListGetAllServicesFromUsersTeam(c *check.C) 
 	err := srv.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "my_nosql", ServiceName: srv.Name, Teams: []string{s.team.Name}, Tags: []string{"tag 1"}}
-	err = si.Create()
+	err := s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	recorder, request := s.makeRequestToServicesHandler(c)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -424,7 +424,7 @@ func (s *ProvisionSuite) TestDeleteHandlerReturns403WhenTheServiceHasInstance(c 
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: se.Name}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	u := fmt.Sprintf("/services/%s", se.Name)
 	recorder, request := s.makeRequest("DELETE", u, "", c)
@@ -451,7 +451,7 @@ func (s *ProvisionSuite) TestServiceProxy(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/proxy/service/%s?callback=/mypath", se.Name)
 	request, err := http.NewRequest("GET", url, nil)
@@ -498,7 +498,7 @@ func (s *ProvisionSuite) TestServiceProxyPost(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/proxy/service/%s?callback=/mypath", se.Name)
 	body := strings.NewReader("my=awesome&body=1")
@@ -557,7 +557,7 @@ func (s *ProvisionSuite) TestServiceProxyPostRawBody(c *check.C) {
 	err := se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/proxy/service/%s?callback=/mypath", se.Name)
 	body := strings.NewReader("something-something")
@@ -666,7 +666,7 @@ func (s *ProvisionSuite) TestServiceProxyAccessDenied(c *check.C) {
 	err = se.Create()
 	c.Assert(err, check.IsNil)
 	si := service.ServiceInstance{Name: "foo-instance", ServiceName: "foo", Teams: []string{s.team.Name}}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/services/proxy/service/%s?callback=/mypath", se.Name)
 	request, err := http.NewRequest("GET", url, nil)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -467,14 +467,14 @@ func (s *S) TestBindAndUnbindUnit(c *check.C) {
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{
 		Name:        "yourdb",
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	unit := provision.Unit{ID: "some-unit", IP: "127.0.2.1"}
 	err = app.BindUnit(&unit)
@@ -524,14 +524,14 @@ func (s *S) TestBindUnitWithError(c *check.C) {
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{
 		Name:        "yourdb",
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	unit := provision.Unit{ID: "some-unit", IP: "127.0.2.1"}
 	err = app.BindUnit(&unit)
@@ -764,7 +764,7 @@ func (s *S) TestRemoveUnits(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{app.Name},
 	}
-	instance.Create()
+	s.conn.ServiceInstances().Insert(instance)
 	err = CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	err = app.AddUnits(2, "web", nil)
@@ -3628,14 +3628,14 @@ func (s *S) TestAppRegisterUnitDoesBind(c *check.C) {
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si1.Create()
+	err = s.conn.ServiceInstances().Insert(si1)
 	c.Assert(err, check.IsNil)
 	si2 := service.ServiceInstance{
 		Name:        "yourdb",
 		ServiceName: "mysql",
 		Apps:        []string{app.Name},
 	}
-	err = si2.Create()
+	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&app, 1, "web", nil)
 	units, err := app.Units()

--- a/app/bind_test.go
+++ b/app/bind_test.go
@@ -27,7 +27,7 @@ func (s *S) TestDeleteShouldUnbindAppFromInstance(c *check.C) {
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "MyInstance", Apps: []string{"whichapp"}, ServiceName: srvc.Name}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := App{
 		Name:      "whichapp",

--- a/docs/services/api.rst
+++ b/docs/services/api.rst
@@ -93,7 +93,7 @@ what happened in the response body.
 Creating a new instance
 =======================
 
-This process begins when a tsuru customer creates an instance of the service
+This process begins when a tsuru user creates an instance of the service
 via command line tool:
 
 .. highlight:: bash
@@ -131,7 +131,7 @@ Updating a service instance
 ===========================
 
 This endpoint implementation is optional. The process begins when a tsuru
-customer updates properties of a service instance via command line tool:
+user updates properties of a service instance via command line tool:
 
 .. highlight:: bash
 
@@ -169,7 +169,7 @@ response body:
 Binding an app to a service instance
 ====================================
 
-This process begins when a tsuru customer binds an app to an instance of the
+This process begins when a tsuru user binds an app to an instance of the
 service via command line tool:
 
 .. highlight:: bash
@@ -246,7 +246,7 @@ Status codes for errors in the process:
 Unbind an app from a service instance
 =====================================
 
-This process begins when a tsuru customer unbinds an app from an instance of
+This process begins when a tsuru user unbinds an app from an instance of
 the service via command line:
 
 .. highlight:: bash
@@ -301,7 +301,7 @@ response body:
 Removing an instance
 ====================
 
-This process begins when a tsuru customer removes an instance of the service
+This process begins when a tsuru user removes an instance of the service
 via command line:
 
 .. highlight:: bash
@@ -336,7 +336,7 @@ response body:
 Checking the status of an instance
 ==================================
 
-This process begins when a tsuru customer wants to check the status of an
+This process begins when a tsuru user wants to check the status of an
 instance via command line:
 
 .. highlight:: bash

--- a/docs/services/api.rst
+++ b/docs/services/api.rst
@@ -9,6 +9,7 @@ API workflow
 tsuru sends requests to the service API to the following actions:
 
 * create a new instance of the service (``tsuru service-instance-add``)
+* update a service instance (``tsuru service-instance-update``)
 * bind an app with the service instance (``tsuru service-instance-bind``)
 * unbind an app from the service instance (``tsuru service-instance-unbind``)
 * destroy the service instance (``tsuru service-instance-remove``)
@@ -123,6 +124,45 @@ response body:
     * 201: when the instance is successfully created. There's no need to
       include any body, as tsuru doesn't expect to get any content back in case
       of success.
+    * 500: in case of any failure in the operation. tsuru expects that the
+      service API includes an explanation of the failure in the response body.
+
+Updating a service instance
+===========================
+
+This endpoint implementation is optional. The process begins when a tsuru
+customer updates properties of a service instance via command line tool:
+
+.. highlight:: bash
+
+::
+
+    $ tsuru service-instance-update mysql mysql_instance --description "new-description" --tag "tag1" --tag "tag2" --team-owner "new-team-owner"
+
+tsuru calls the service API to inform the instance update via PUT on ``/resources``
+(please notice that tsuru does not include a trailing slash) with the new, updated
+fields (description, tags and team owner). Example of request:
+
+::
+
+    PUT /resources/mysql_instance HTTP/1.1
+    Host: myserviceapi.com
+    Content-Length: 56
+    User-Agent: Go 1.1 package http
+    Accept: application/json
+    Authorization: Basic dXNlcjpwYXNzd29yZA==
+    Content-Type: application/x-www-form-urlencoded
+
+    description=new-description&tag=tag1&tag=tag2&team=new-team-owner
+
+The API should return the following HTTP response codes with the respective
+response body:
+
+    * 200: when the instance is successfully updated. There's no need to
+      include any body, as tsuru doesn't expect to get any content back in case
+      of success.
+    * 404: as this endpoint is optional, a 404 response code from the API is
+      ignored by tsuru.
     * 500: in case of any failure in the operation. tsuru expects that the
       service API includes an explanation of the failure in the response body.
 
@@ -330,7 +370,7 @@ response body:
 Additional info about an instance
 =================================
 
-When the user run ``tsuru service-info <service>`` or 
+When the user run ``tsuru service-info <service>`` or
 ``tsuru service-instance-info``, tsuru will get informations
 from all instances. This is an optional endpoint in the service API. Some
 services does not provide any extra information for instances. Example of

--- a/docs/services/build.rst
+++ b/docs/services/build.rst
@@ -148,6 +148,37 @@ Let's create the view for this action:
         # use the given parameters to create the instance
         return "", 201
 
+Updating service instances
+----------------------
+
+When a service instance is updated, tsuru sends a PUT to /resources with the updated
+parameters for the instance. If the service instance is successfully updated, your
+API should return 200 in status code.
+
+This endpoint is optional. That means you could leave it unimplemented and return a
+404 status code, and tsuru would simply ignore it.
+
+Here's an example implementation for this endpoint:
+
+.. highlight:: python
+
+::
+
+    from flask import request
+
+
+    @app.route("/resources", methods=["POST"])
+    def add_instance():
+
+    @app.route("/resources/<name>", methods=["PUT"])
+    def update_instance(name):
+        name = request.form.get("name")
+        description = request.form.get("description")
+        tags = request.form.get("tag")
+        team = request.form.get("team")
+        # use the given parameters to update the instance "name"
+        return "", 200
+
 Binding instances to apps
 -------------------------
 

--- a/provision/cluster/cluster_test.go
+++ b/provision/cluster/cluster_test.go
@@ -97,6 +97,7 @@ func Test(t *testing.T) {
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_kubernetes_cluster_tests_s")
 	var err error

--- a/provision/docker/actions_test.go
+++ b/provision/docker/actions_test.go
@@ -1053,7 +1053,7 @@ func (s *S) TestBindAndHealthcheckDontHealtcheckForErroredApps(c *check.C) {
 	}))
 	defer server.Close()
 	dbApp := &app.App{Name: "myapp"}
-	err := s.storage.Apps().Insert(dbApp)
+	err := s.conn.Apps().Insert(dbApp)
 	c.Assert(err, check.IsNil)
 	imageName := "tsuru/app-" + dbApp.Name
 	customData := map[string]interface{}{
@@ -1110,7 +1110,7 @@ func (s *S) TestBindAndHealthcheckDontHealtcheckForStoppedApps(c *check.C) {
 	}))
 	defer server.Close()
 	dbApp := &app.App{Name: "myapp"}
-	err := s.storage.Apps().Insert(dbApp)
+	err := s.conn.Apps().Insert(dbApp)
 	c.Assert(err, check.IsNil)
 	imageName := "tsuru/app-" + dbApp.Name
 	customData := map[string]interface{}{
@@ -1167,7 +1167,7 @@ func (s *S) TestBindAndHealthcheckForwardHealthcheckError(c *check.C) {
 	}))
 	defer server.Close()
 	dbApp := &app.App{Name: "myapp"}
-	err := s.storage.Apps().Insert(dbApp)
+	err := s.conn.Apps().Insert(dbApp)
 	c.Assert(err, check.IsNil)
 	imageName := "tsuru/app-" + dbApp.Name
 	customData := map[string]interface{}{
@@ -1216,7 +1216,7 @@ func (s *S) TestBindAndHealthcheckForwardRestartError(c *check.C) {
 		w.Write([]byte(`{"ID":"id","ExitCode":9}`))
 	}))
 	dbApp := &app.App{Name: "myapp"}
-	err := s.storage.Apps().Insert(dbApp)
+	err := s.conn.Apps().Insert(dbApp)
 	c.Assert(err, check.IsNil)
 	imageName := "tsuru/app-" + dbApp.Name
 	customData := map[string]interface{}{

--- a/provision/docker/container/suite_test.go
+++ b/provision/docker/container/suite_test.go
@@ -35,6 +35,7 @@ type S struct {
 func (s *S) SetUpSuite(c *check.C) {
 	s.user = "root"
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "docker_provision_container_tests")
 	config.Set("docker:cluster:mongo-url", "127.0.0.1:27017")

--- a/provision/docker/containers_linux_test.go
+++ b/provision/docker/containers_linux_test.go
@@ -80,7 +80,7 @@ func (s *S) TestRebalanceContainersManyAppsSegStress(c *check.C) {
 		appStruct := s.newAppFromFake(appInstance)
 		appStruct.TeamOwner = "team1"
 		appStruct.Pool = "pool1"
-		err = s.storage.Apps().Insert(appStruct)
+		err = s.conn.Apps().Insert(appStruct)
 		c.Assert(err, check.IsNil)
 	}
 	buf := safe.NewBuffer(nil)

--- a/provision/docker/containers_test.go
+++ b/provision/docker/containers_test.go
@@ -57,7 +57,7 @@ func (s *S) TestMoveContainers(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	err = p.MoveContainers("localhost", "127.0.0.1", buf)
@@ -103,7 +103,7 @@ func (s *S) TestMoveContainersUnknownDest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	err = p.MoveContainers("localhost", "unknown", buf)
@@ -152,7 +152,7 @@ func (s *S) TestMoveContainer(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	var serviceBodies []string
@@ -198,7 +198,7 @@ func (s *S) TestMoveContainerStopped(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	_, err = p.moveContainer(addedConts[0].ID[:6], "127.0.0.1", buf)
@@ -232,7 +232,7 @@ func (s *S) TestMoveContainerErrorStopped(c *check.C) {
 	err = addedConts[0].SetStatus(p, provision.StatusError, true)
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	_, err = p.moveContainer(addedConts[0].ID[:6], "127.0.0.1", buf)
@@ -266,7 +266,7 @@ func (s *S) TestMoveContainerErrorStarted(c *check.C) {
 	err = addedConts[0].SetStatus(p, provision.StatusError, true)
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	_, err = p.moveContainer(addedConts[0].ID[:6], "127.0.0.1", buf)
@@ -300,7 +300,7 @@ func (s *S) TestRebalanceContainers(c *check.C) {
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
 	appStruct.Pool = "test-default"
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	err = p.rebalanceContainers(buf, false)
@@ -350,7 +350,7 @@ func (s *S) TestRebalanceContainersSegScheduler(c *check.C) {
 	appStruct := s.newAppFromFake(appInstance)
 	appStruct.TeamOwner = "team1"
 	appStruct.Pool = "pool1"
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	c1, err := p.listContainersByHost("localhost")
 	c.Assert(err, check.IsNil)
@@ -404,7 +404,7 @@ func (s *S) TestRebalanceContainersByHost(c *check.C) {
 	appStruct := s.newAppFromFake(appInstance)
 	appStruct.TeamOwner = "team1"
 	appStruct.Pool = "pool1"
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	c1, err := p.listContainersByHost("localhost")
 	c.Assert(err, check.IsNil)
@@ -426,7 +426,7 @@ func (s *S) TestRebalanceContainersByHost(c *check.C) {
 func (s *S) TestAppLocker(c *check.C) {
 	appName := "myapp"
 	appDB := &app.App{Name: appName}
-	err := s.storage.Apps().Insert(appDB)
+	err := s.conn.Apps().Insert(appDB)
 	c.Assert(err, check.IsNil)
 	locker := &appLocker{}
 	hasLock := locker.Lock(appName)
@@ -455,7 +455,7 @@ func (s *S) TestAppLocker(c *check.C) {
 func (s *S) TestAppLockerBlockOtherLockers(c *check.C) {
 	appName := "myapp"
 	appDB := &app.App{Name: appName}
-	err := s.storage.Apps().Insert(appDB)
+	err := s.conn.Apps().Insert(appDB)
 	c.Assert(err, check.IsNil)
 	locker := &appLocker{}
 	hasLock := locker.Lock(appName)
@@ -504,11 +504,11 @@ func (s *S) TestRebalanceContainersManyApps(c *check.C) {
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
 	appStruct.Pool = "test-default"
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	appStruct2 := s.newAppFromFake(appInstance2)
 	appStruct2.Pool = "test-default"
-	err = s.storage.Apps().Insert(appStruct2)
+	err = s.conn.Apps().Insert(appStruct2)
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
 	c1, err := p.listContainersByHost("localhost")
@@ -552,7 +552,7 @@ func (s *S) TestRebalanceContainersDry(c *check.C) {
 	c.Assert(err, check.IsNil)
 	appStruct := s.newAppFromFake(appInstance)
 	appStruct.Pool = "test-default"
-	err = s.storage.Apps().Insert(appStruct)
+	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
 	router, err := getRouterForApp(appInstance)
 	c.Assert(err, check.IsNil)

--- a/provision/docker/docker_test.go
+++ b/provision/docker/docker_test.go
@@ -191,7 +191,7 @@ func (s *S) TestGetImageFromAppPlatform(c *check.C) {
 
 func (s *S) TestGetImageAppWhenDeployIsMultipleOf10(c *check.C) {
 	app := &app.App{Name: "app1", Platform: "python", Deploys: 20}
-	err := s.storage.Apps().Insert(app)
+	err := s.conn.Apps().Insert(app)
 	c.Assert(err, check.IsNil)
 	cont := container.Container{Container: types.Container{ID: "bleble", Type: app.Platform, AppName: app.Name, Image: "tsuru/app1"}}
 	coll := s.p.Collection()
@@ -454,7 +454,7 @@ func (s *S) TestGetDockerClientWithApp(c *check.C) {
 
 func (s *S) TestGetDockerClientWithoutApp(c *check.C) {
 	a1 := app.App{Name: "impius", Teams: []string{"tsuruteam", "nodockerforme"}, Pool: "pool1"}
-	err := s.storage.Apps().Insert(a1)
+	err := s.conn.Apps().Insert(a1)
 	c.Assert(err, check.IsNil)
 	cont1 := container.Container{Container: types.Container{ID: "1", Name: "cont1", AppName: a1.Name, ProcessName: "web"}}
 	cont2 := container.Container{Container: types.Container{ID: "2", Name: "cont2", AppName: a1.Name, ProcessName: "web"}}

--- a/provision/docker/dockertest/provisioner_test.go
+++ b/provision/docker/dockertest/provisioner_test.go
@@ -34,6 +34,7 @@ type S struct{}
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "docker_provision_dockertest_tests")
 	config.Set("docker:cluster:mongo-url", "127.0.0.1:27017")

--- a/provision/docker/fix_test.go
+++ b/provision/docker/fix_test.go
@@ -87,7 +87,7 @@ func (s *S) TestFixContainer(c *check.C) {
 	err := coll.Insert(cont)
 	c.Assert(err, check.IsNil)
 	defer coll.RemoveAll(bson.M{"appname": cont.AppName})
-	err = s.storage.Apps().Insert(&app.App{Name: cont.AppName})
+	err = s.conn.Apps().Insert(&app.App{Name: cont.AppName})
 	c.Assert(err, check.IsNil)
 	appInstance := provisiontest.NewFakeApp(cont.AppName, cont.Type, 0)
 	defer p.Destroy(appInstance)

--- a/provision/docker/healer/suite_test.go
+++ b/provision/docker/healer/suite_test.go
@@ -29,6 +29,7 @@ type S struct{}
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "docker_provision_healer_tests")
 	config.Set("docker:repository-namespace", "tsuru")

--- a/provision/docker/healthcheck_test.go
+++ b/provision/docker/healthcheck_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tsuru/tsuru/provision/docker/container"
 	"github.com/tsuru/tsuru/provision/docker/types"
 	"gopkg.in/check.v1"
-	"gopkg.in/mgo.v2/bson"
 )
 
 func (s *S) TestHealthcheck(c *check.C) {
@@ -40,9 +39,8 @@ func (s *S) TestHealthcheck(c *check.C) {
 	}
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -78,9 +76,8 @@ func (s *S) TestHealthcheckWithMatch(c *check.C) {
 	imageName := "tsuru/app"
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -112,9 +109,8 @@ func (s *S) TestHealthcheckDefaultCheck(c *check.C) {
 	}
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -134,9 +130,8 @@ func (s *S) TestHealthcheckNoHealthcheck(c *check.C) {
 	}))
 	defer server.Close()
 	a := app.App{Name: "myapp1"}
-	err := s.storage.Apps().Insert(a)
+	err := s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port}}
@@ -163,9 +158,8 @@ func (s *S) TestHealthcheckNoPath(c *check.C) {
 	}
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -202,9 +196,8 @@ func (s *S) TestHealthcheckKeepsTryingWithServerDown(c *check.C) {
 	imageName := "tsuru/app"
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -229,9 +222,8 @@ func (s *S) TestHealthcheckErrorsAfterMaxTime(c *check.C) {
 	}
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse("http://some-invalid-server-name.some-invalid-server-name.com:9123")
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}
@@ -281,9 +273,8 @@ func (s *S) TestHealthcheckSuccessfulWithAllowedFailures(c *check.C) {
 	imageName := "tsuru/app"
 	err := image.SaveImageCustomData(imageName, customData)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a)
+	err = s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
-	defer s.storage.Apps().RemoveAll(bson.M{"name": a.Name})
 	url, _ := url.Parse(server.URL)
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: imageName}}

--- a/provision/docker/image_test.go
+++ b/provision/docker/image_test.go
@@ -47,7 +47,7 @@ func (s *S) TestMigrateImages(c *check.C) {
 	c5, err := s.newContainer(&newContainerOpts{Image: "tsuru/app-app2", AppName: "app-app2"}, &p)
 	c.Assert(err, check.IsNil)
 	defer s.removeTestContainer(c5)
-	err = s.storage.Apps().Insert(app1, app2, app3)
+	err = s.conn.Apps().Insert(app1, app2, app3)
 	c.Assert(err, check.IsNil)
 	mainDockerProvisioner = &p
 	err = MigrateImages()
@@ -76,7 +76,7 @@ func (s *S) TestMigrateImagesWithoutImageInStorage(c *check.C) {
 	p.cluster, _ = cluster.New(nil, &cluster.MapStorage{}, "",
 		cluster.Node{Address: server.URL()})
 	app1 := app.App{Name: "app1"}
-	err = s.storage.Apps().Insert(app1)
+	err = s.conn.Apps().Insert(app1)
 	c.Assert(err, check.IsNil)
 	mainDockerProvisioner = &p
 	err = MigrateImages()
@@ -104,7 +104,7 @@ func (s *S) TestMigrateImagesWithRegistry(c *check.C) {
 		cluster.Node{Address: server.URL()})
 	app1 := app.App{Name: "app1"}
 	app2 := app.App{Name: "app2"}
-	err = s.storage.Apps().Insert(app1, app2)
+	err = s.conn.Apps().Insert(app1, app2)
 	c.Assert(err, check.IsNil)
 	err = newFakeImage(&p, "localhost:3030/tsuru/app1", nil)
 	c.Assert(err, check.IsNil)

--- a/provision/docker/nodecontainer/suite_test.go
+++ b/provision/docker/nodecontainer/suite_test.go
@@ -28,6 +28,7 @@ type S struct {
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "docker_provision_docker_nodecontainer_tests")
 	config.Set("docker:cluster:mongo-url", "127.0.0.1:27017")

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -34,7 +34,7 @@ func (s *S) TestSchedulerSchedule(c *check.C) {
 	cont1 := container.Container{Container: types.Container{ID: "1", Name: "impius1", AppName: a1.Name}}
 	cont2 := container.Container{Container: types.Container{ID: "2", Name: "mirror1", AppName: a2.Name}}
 	cont3 := container.Container{Container: types.Container{ID: "3", Name: "dedication1", AppName: a3.Name}}
-	err := s.storage.Apps().Insert(a1, a2, a3)
+	err := s.conn.Apps().Insert(a1, a2, a3)
 	c.Assert(err, check.IsNil)
 	p := pool.Pool{Name: "pool1"}
 	o := pool.AddPoolOptions{Name: p.Name}
@@ -89,7 +89,7 @@ func (s *S) TestSchedulerScheduleNoName(c *check.C) {
 	cont1 := container.Container{Container: types.Container{ID: "1", Name: "impius1", AppName: a1.Name}}
 	cont2 := container.Container{Container: types.Container{ID: "2", Name: "mirror1", AppName: a2.Name}}
 	cont3 := container.Container{Container: types.Container{ID: "3", Name: "dedication1", AppName: a3.Name}}
-	err := s.storage.Apps().Insert(a1, a2, a3)
+	err := s.conn.Apps().Insert(a1, a2, a3)
 	c.Assert(err, check.IsNil)
 	p := pool.Pool{Name: "pool1"}
 	o := pool.AddPoolOptions{Name: p.Name}
@@ -138,7 +138,7 @@ func (s *S) TestSchedulerScheduleNoName(c *check.C) {
 
 func (s *S) TestSchedulerNoNodes(c *check.C) {
 	app := app.App{Name: "bill", Pool: "mypool"}
-	err := s.storage.Apps().Insert(app)
+	err := s.conn.Apps().Insert(app)
 	c.Assert(err, check.IsNil)
 	scheduler := segregatedScheduler{provisioner: s.p}
 	clusterInstance, err := cluster.New(&scheduler, &cluster.MapStorage{}, "")
@@ -162,10 +162,10 @@ func (s *S) TestSchedulerScheduleWithMemoryAwareness(c *check.C) {
 	log.SetLogger(log.NewWriterLogger(logBuf, false))
 	defer log.SetLogger(nil)
 	app1 := app.App{Name: "skyrim", Plan: appTypes.Plan{Memory: 60000}, Pool: "mypool"}
-	err := s.storage.Apps().Insert(app1)
+	err := s.conn.Apps().Insert(app1)
 	c.Assert(err, check.IsNil)
 	app2 := app.App{Name: "oblivion", Plan: appTypes.Plan{Memory: 20000}, Pool: "mypool"}
-	err = s.storage.Apps().Insert(app2)
+	err = s.conn.Apps().Insert(app2)
 	c.Assert(err, check.IsNil)
 	segSched := segregatedScheduler{
 		maxMemoryRatio:      0.8,
@@ -253,10 +253,10 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
 	log.SetLogger(log.NewWriterLogger(logBuf, false))
 	defer log.SetLogger(nil)
 	app1 := app.App{Name: "skyrim", Plan: appTypes.Plan{Memory: 60000}, Pool: "mypool"}
-	err = s.storage.Apps().Insert(app1)
+	err = s.conn.Apps().Insert(app1)
 	c.Assert(err, check.IsNil)
 	app2 := app.App{Name: "oblivion", Plan: appTypes.Plan{Memory: 20000}, Pool: "mypool"}
-	err = s.storage.Apps().Insert(app2)
+	err = s.conn.Apps().Insert(app2)
 	c.Assert(err, check.IsNil)
 	segSched := segregatedScheduler{
 		maxMemoryRatio:      0.8,
@@ -342,10 +342,10 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScaleDisabledForPool
 	log.SetLogger(log.NewWriterLogger(logBuf, false))
 	defer log.SetLogger(nil)
 	app1 := app.App{Name: "skyrim", Plan: appTypes.Plan{Memory: 60000}, Pool: "mypool"}
-	err = s.storage.Apps().Insert(app1)
+	err = s.conn.Apps().Insert(app1)
 	c.Assert(err, check.IsNil)
 	app2 := app.App{Name: "oblivion", Plan: appTypes.Plan{Memory: 20000}, Pool: "mypool"}
-	err = s.storage.Apps().Insert(app2)
+	err = s.conn.Apps().Insert(app2)
 	c.Assert(err, check.IsNil)
 	segSched := segregatedScheduler{
 		maxMemoryRatio:      0.8,
@@ -758,9 +758,9 @@ func (s *S) TestGetRemovableContainer(c *check.C) {
 	a2 := app.App{Name: "notimpius", Teams: []string{"tsuruteam", "nodockerforme"}, Pool: "pool1"}
 	cont3 := container.Container{Container: types.Container{ID: "3", Name: "dedication1", AppName: a2.Name, ProcessName: "web"}}
 	cont4 := container.Container{Container: types.Container{ID: "4", Name: "dedication2", AppName: a2.Name, ProcessName: "worker"}}
-	err := s.storage.Apps().Insert(a1)
+	err := s.conn.Apps().Insert(a1)
 	c.Assert(err, check.IsNil)
-	err = s.storage.Apps().Insert(a2)
+	err = s.conn.Apps().Insert(a2)
 	c.Assert(err, check.IsNil)
 	p := pool.Pool{Name: "pool1"}
 	o := pool.AddPoolOptions{Name: p.Name}

--- a/provision/docker/suite_test.go
+++ b/provision/docker/suite_test.go
@@ -56,7 +56,7 @@ type S struct {
 	sshUser       string
 	server        *dtesting.DockerServer
 	extraServer   *dtesting.DockerServer
-	storage       *db.Storage
+	conn          *db.Storage
 	p             *dockerProvisioner
 	user          *auth.User
 	token         auth.Token
@@ -75,6 +75,7 @@ func (s *S) SetUpSuite(c *check.C) {
 	s.sshUser = "root"
 	s.port = "8888"
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "docker_provision_tests_s")
 	config.Set("docker:repository-namespace", s.repoNamespace)
@@ -98,12 +99,12 @@ func (s *S) SetUpSuite(c *check.C) {
 	s.runArgs = "/etc/circus/circus.ini"
 	os.Setenv("TSURU_TARGET", "http://localhost")
 	var err error
-	s.storage, err = db.Conn()
+	s.conn, err = db.Conn()
 	c.Assert(err, check.IsNil)
 	clusterDbURL, _ := config.GetString("docker:cluster:mongo-url")
 	s.clusterSess, err = mgo.Dial(clusterDbURL)
 	c.Assert(err, check.IsNil)
-	err = dbtest.ClearAllCollections(s.storage.Apps().Database)
+	err = dbtest.ClearAllCollections(s.conn.Apps().Database)
 	c.Assert(err, check.IsNil)
 	repositorytest.Reset()
 	s.user = &auth.User{Email: "myadmin@arrakis.com", Password: "123456", Quota: quota.Unlimited}
@@ -135,7 +136,7 @@ func (s *S) SetUpTest(c *check.C) {
 	)
 	c.Assert(err, check.IsNil)
 	mainDockerProvisioner = s.p
-	err = dbtest.ClearAllCollectionsExcept(s.storage.Apps().Database, []string{"users", "tokens"})
+	err = dbtest.ClearAllCollectionsExcept(s.conn.Apps().Database, []string{"users", "tokens"})
 	c.Assert(err, check.IsNil)
 	err = clearClusterStorage(s.clusterSess)
 	c.Assert(err, check.IsNil)
@@ -143,7 +144,7 @@ func (s *S) SetUpTest(c *check.C) {
 	opts := pool.AddPoolOptions{Name: "test-default", Default: true}
 	err = pool.AddPool(opts)
 	c.Assert(err, check.IsNil)
-	s.storage.Tokens().Remove(bson.M{"appname": bson.M{"$ne": ""}})
+	s.conn.Tokens().Remove(bson.M{"appname": bson.M{"$ne": ""}})
 	s.logBuf = safe.NewBuffer(nil)
 	log.SetLogger(log.NewWriterLogger(s.logBuf, true))
 	s.team = &authTypes.Team{Name: "admin"}
@@ -162,7 +163,7 @@ func (s *S) TearDownTest(c *check.C) {
 
 func (s *S) TearDownSuite(c *check.C) {
 	defer s.clusterSess.Close()
-	defer s.storage.Close()
+	defer s.conn.Close()
 	os.Unsetenv("TSURU_TARGET")
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)
@@ -219,7 +220,7 @@ func (s *S) addServiceInstance(c *check.C, appName string, unitsIDs []string, fn
 		BoundUnits:  units,
 		Apps:        []string{appName},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	return ret
 }

--- a/provision/dockercommon/commands_test.go
+++ b/provision/dockercommon/commands_test.go
@@ -30,6 +30,7 @@ func Test(t *testing.T) {
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_dockercommon_tests_s")
 	config.Set("docker:registry", "my.registry")

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -81,6 +81,7 @@ func Test(t *testing.T) {
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
 	config.Set("auth:hash-cost", bcrypt.MinCost)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_kubernetes_tests_s")
 	config.Set("routers:fake:type", "fake")

--- a/provision/limiter_test.go
+++ b/provision/limiter_test.go
@@ -32,6 +32,7 @@ func init() {
 func (s *LimiterSuite) SetUpTest(c *check.C) {
 	s.limiter = s.makeLimiter()
 	c.Logf("Test with s.limiter: %T", s.limiter)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_limiter_tests_s")
 	conn, err := db.Conn()

--- a/provision/nodecontainer/suite_test.go
+++ b/provision/nodecontainer/suite_test.go
@@ -24,6 +24,7 @@ type S struct{}
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "docker_provision_nodecontainer_tests")
 	config.Set("docker:cluster:mongo-url", "127.0.0.1:27017")

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -32,6 +32,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "pool_tests_s")
 	var err error

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -35,6 +35,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "fake_provision_tests_s")
 }

--- a/provision/servicecommon/actions_test.go
+++ b/provision/servicecommon/actions_test.go
@@ -29,6 +29,7 @@ func Test(t *testing.T) {
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "servicecommon_tests_s")
 	config.Set("routers:fake:type", "fake")

--- a/provision/suite_test.go
+++ b/provision/suite_test.go
@@ -16,6 +16,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_tests_s")
 	var err error

--- a/provision/swarm/suite_test.go
+++ b/provision/swarm/suite_test.go
@@ -51,6 +51,7 @@ func Test(t *testing.T) {
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("log:disable-syslog", true)
 	config.Set("auth:hash-cost", bcrypt.MinCost)
+	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "provision_swarm_tests_s")
 	config.Set("routers:fake:type", "fake")

--- a/service/actions.go
+++ b/service/actions.go
@@ -18,14 +18,14 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// createServiceInstance is an action that calls the service endpoint
+// notifyCreateServiceInstance is an action that calls the service endpoint
 // to create a service instance.
 //
 // The first argument in the context must be a Service.
 // The second argument in the context must be a ServiceInstance.
 // The third argument in the context must be a request ID.
-var createServiceInstance = action.Action{
-	Name: "create-service-instance",
+var notifyCreateServiceInstance = action.Action{
+	Name: "notify-create-service-instance",
 	Forward: func(ctx action.FWContext) (action.Result, error) {
 		service, ok := ctx.Params[0].(Service)
 		if !ok {
@@ -75,11 +75,11 @@ var createServiceInstance = action.Action{
 	MinParams: 3,
 }
 
-// insertServiceInstance is an action that inserts an instance in the database.
+// createServiceInstance is an action that inserts an instance in the database.
 //
 // The second argument in the context must be a Service Instance.
-var insertServiceInstance = action.Action{
-	Name: "insert-service-instance",
+var createServiceInstance = action.Action{
+	Name: "create-service-instance",
 	Forward: func(ctx action.FWContext) (action.Result, error) {
 		instance, ok := ctx.Params[1].(ServiceInstance)
 		if !ok {

--- a/service/actions.go
+++ b/service/actions.go
@@ -106,6 +106,40 @@ var insertServiceInstance = action.Action{
 	MinParams: 2,
 }
 
+// notifyUpdateServiceInstance is an action that calls the service endpoint
+// to update a service instance.
+//
+// The first argument in the context must be a Service.
+// The second argument in the context must be a ServiceInstance.
+var notifyUpdateServiceInstance = action.Action{
+	Name: "notify-update-service-instance",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		service, ok := ctx.Params[0].(Service)
+		if !ok {
+			return nil, errors.New("First parameter must be a Service.")
+		}
+		endpoint, err := service.getClient("production")
+		if err != nil {
+			return nil, err
+		}
+		instance, ok := ctx.Params[1].(ServiceInstance)
+		if !ok {
+			return nil, errors.New("Second parameter must be a ServiceInstance.")
+		}
+		requestID, ok := ctx.Params[2].(string)
+		if !ok {
+			return nil, errors.New("RequestID should be a string")
+		}
+		err = endpoint.Update(&instance, requestID)
+		if err != nil {
+			return nil, err
+		}
+		return instance, nil
+	},
+	Backward:  func(ctx action.BWContext) {},
+	MinParams: 2,
+}
+
 // updateServiceInstance is an action that updates an instance in the database.
 //
 // The first argument in the context must be a Service Instance.

--- a/service/actions_test.go
+++ b/service/actions_test.go
@@ -241,7 +241,7 @@ func (s *S) TestBindAppEndpointActionForwardReturnsEnvVars(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	defer s.conn.ServiceInstances().RemoveId(si.Name)
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
@@ -272,7 +272,7 @@ func (s *S) TestBindAppEndpointActionBackward(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	defer s.conn.ServiceInstances().RemoveId(si.Name)
 	a := provisiontest.NewFakeApp("myapp", "static", 1)

--- a/service/actions_test.go
+++ b/service/actions_test.go
@@ -19,15 +19,15 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-func (s *S) TestCreateServiceInstanceMinParams(c *check.C) {
-	c.Assert(createServiceInstance.MinParams, check.Equals, 3)
+func (s *S) TestNotifyCreateServiceInstanceMinParams(c *check.C) {
+	c.Assert(notifyCreateServiceInstance.MinParams, check.Equals, 3)
 }
 
-func (s *S) TestCreateServiceInstanceName(c *check.C) {
-	c.Assert(createServiceInstance.Name, check.Equals, "create-service-instance")
+func (s *S) TestNotifyCreateServiceInstanceName(c *check.C) {
+	c.Assert(notifyCreateServiceInstance.Name, check.Equals, "notify-create-service-instance")
 }
 
-func (s *S) TestCreateServiceInstanceForward(c *check.C) {
+func (s *S) TestNotifyCreateServiceInstanceForward(c *check.C) {
 	var requests int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -41,7 +41,7 @@ func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 	ctx := action.FWContext{
 		Params: []interface{}{srv, instance, "my@user", ""},
 	}
-	r, err := createServiceInstance.Forward(ctx)
+	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	a, ok := r.(ServiceInstance)
 	c.Assert(ok, check.Equals, true)
@@ -49,7 +49,7 @@ func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
 }
 
-func (s *S) TestCreateServiceInstanceForwardInvalidParams(c *check.C) {
+func (s *S) TestNotifyCreateServiceInstanceForwardInvalidParams(c *check.C) {
 	var requests int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -60,21 +60,21 @@ func (s *S) TestCreateServiceInstanceForwardInvalidParams(c *check.C) {
 	err := s.conn.Services().Insert(&srv)
 	c.Assert(err, check.IsNil)
 	ctx := action.FWContext{Params: []interface{}{"", "", ""}}
-	_, err = createServiceInstance.Forward(ctx)
+	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be a Service.")
 	ctx = action.FWContext{Params: []interface{}{srv, "", ""}}
-	_, err = createServiceInstance.Forward(ctx)
+	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
 	instance := ServiceInstance{Name: "mysql"}
 	ctx = action.FWContext{Params: []interface{}{srv, instance, 1}}
-	_, err = createServiceInstance.Forward(ctx)
+	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Third parameter must be a string.")
 }
 
-func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
+func (s *S) TestNotifyCreateServiceInstanceBackward(c *check.C) {
 	var requests int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -86,11 +86,11 @@ func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instance := ServiceInstance{Name: "mysql"}
 	ctx := action.BWContext{Params: []interface{}{srv, instance, "", "test"}}
-	createServiceInstance.Backward(ctx)
+	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
 }
 
-func (s *S) TestCreateServiceInstanceBackwardParams(c *check.C) {
+func (s *S) TestNotifyCreateServiceInstanceBackwardParams(c *check.C) {
 	var requests int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -101,41 +101,41 @@ func (s *S) TestCreateServiceInstanceBackwardParams(c *check.C) {
 	err := s.conn.Services().Insert(&srv)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{Params: []interface{}{srv, ""}}
-	createServiceInstance.Backward(ctx)
+	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(0))
 	ctx = action.BWContext{Params: []interface{}{"", ""}}
-	createServiceInstance.Backward(ctx)
+	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(0))
 }
 
-func (s *S) TestInsertServiceInstanceName(c *check.C) {
-	c.Assert(insertServiceInstance.Name, check.Equals, "insert-service-instance")
+func (s *S) TestCreateServiceInstanceName(c *check.C) {
+	c.Assert(createServiceInstance.Name, check.Equals, "create-service-instance")
 }
 
-func (s *S) TestInsertServiceInstanceMinParams(c *check.C) {
-	c.Assert(insertServiceInstance.MinParams, check.Equals, 2)
+func (s *S) TestCreateServiceInstanceMinParams(c *check.C) {
+	c.Assert(createServiceInstance.MinParams, check.Equals, 2)
 }
 
-func (s *S) TestInsertServiceInstanceForward(c *check.C) {
+func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 	srv := Service{Name: "mongodb"}
 	instance := ServiceInstance{Name: "mysql"}
 	ctx := action.FWContext{
 		Params: []interface{}{srv, instance},
 	}
-	_, err := insertServiceInstance.Forward(ctx)
+	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": instance.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) TestInsertServiceInstanceForwardParams(c *check.C) {
+func (s *S) TestCreateServiceInstanceForwardParams(c *check.C) {
 	ctx := action.FWContext{Params: []interface{}{"", ""}}
-	_, err := insertServiceInstance.Forward(ctx)
+	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
 }
 
-func (s *S) TestInsertServiceInstanceBackward(c *check.C) {
+func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
 	srv := Service{Name: "mongodb"}
 	instance := ServiceInstance{Name: "mysql"}
 	err := s.conn.ServiceInstances().Insert(&instance)
@@ -143,19 +143,19 @@ func (s *S) TestInsertServiceInstanceBackward(c *check.C) {
 	ctx := action.BWContext{
 		Params: []interface{}{srv, instance},
 	}
-	insertServiceInstance.Backward(ctx)
+	createServiceInstance.Backward(ctx)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": instance.Name}).One(&instance)
 	c.Assert(err, check.NotNil)
 }
 
-func (s *S) TestInsertServiceInstanceBackwardParams(c *check.C) {
+func (s *S) TestCreateServiceInstanceBackwardParams(c *check.C) {
 	instance := ServiceInstance{Name: "mysql"}
 	err := s.conn.ServiceInstances().Insert(&instance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
 		Params: []interface{}{"", ""},
 	}
-	insertServiceInstance.Backward(ctx)
+	createServiceInstance.Backward(ctx)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": instance.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
 }
@@ -253,7 +253,7 @@ func (s *S) TestNotifyUpdateServiceInstanceForward(c *check.C) {
 	ctx := action.FWContext{
 		Params: []interface{}{srv, instance, "my@user", ""},
 	}
-	r, err := createServiceInstance.Forward(ctx)
+	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	a, ok := r.(ServiceInstance)
 	c.Assert(ok, check.Equals, true)

--- a/service/bind_test.go
+++ b/service/bind_test.go
@@ -82,7 +82,8 @@ func (s *BindSuite) TestBindUnit(c *check.C) {
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
 	c.Assert(err, check.IsNil)
@@ -100,7 +101,8 @@ func (s *BindSuite) TestBindAppFailsWhenEndpointIsDown(c *check.C) {
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
 	c.Assert(err, check.IsNil)
@@ -119,7 +121,8 @@ func (s *BindSuite) TestBindAddsAppToTheServiceInstance(c *check.C) {
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
 	c.Assert(err, check.IsNil)
@@ -146,7 +149,7 @@ func (s *BindSuite) TestBindAppMultiUnits(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
@@ -182,14 +185,14 @@ func (s *BindSuite) TestBindUnbindAppDuplicatedInstanceNames(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance1.Create()
+	err = s.conn.ServiceInstances().Insert(instance1)
 	c.Assert(err, check.IsNil)
 	instance2 := service.ServiceInstance{
 		Name:        "my-db",
 		ServiceName: "postgres",
 		Teams:       []string{s.team.Name},
 	}
-	err = instance2.Create()
+	err = s.conn.ServiceInstances().Insert(instance2)
 	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
@@ -235,7 +238,7 @@ func (s *BindSuite) TestBindReturnConflictIfTheAppIsAlreadyBound(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"painkiller"},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
@@ -255,7 +258,7 @@ func (s *BindSuite) TestBindAppWithNoUnits(c *check.C) {
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
@@ -299,7 +302,8 @@ func (s *BindSuite) TestUnbindUnit(c *check.C) {
 		Apps:        []string{a.GetName()},
 		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}},
 	}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	units, err = a.GetUnits()
 	c.Assert(err, check.IsNil)
 	err = instance.UnbindUnit(a, units[0])
@@ -341,7 +345,8 @@ func (s *BindSuite) TestUnbindMultiUnits(c *check.C) {
 		Apps:        []string{a.GetName()},
 		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}, {ID: units[1].GetID(), IP: units[1].GetIp()}},
 	}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	err = instance.UnbindApp(a, true, nil)
 	c.Assert(err, check.IsNil)
 	err = tsurutest.WaitCondition(1e9, func() bool {
@@ -366,7 +371,8 @@ func (s *BindSuite) TestUnbindRemovesAppFromServiceInstance(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"painkiller"},
 	}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
 	c.Assert(err, check.IsNil)
@@ -415,7 +421,7 @@ func (s *BindSuite) TestUnbindCallsTheUnbindMethodFromAPI(c *check.C) {
 		Apps:        []string{a.GetName()},
 		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	err = instance.UnbindApp(a, true, nil)
 	c.Assert(err, check.IsNil)
@@ -434,7 +440,8 @@ func (s *BindSuite) TestUnbindReturnsPreconditionFailedIfTheAppIsNotBoundToTheIn
 	err := srvc.Create()
 	c.Assert(err, check.IsNil)
 	instance := service.ServiceInstance{Name: "my-mysql", ServiceName: "mysql", Teams: []string{s.team.Name}}
-	instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
+	c.Assert(err, check.IsNil)
 	a := &app.App{Name: "painkiller", Platform: "python", TeamOwner: s.team.Name}
 	err = app.CreateApp(a, &s.user)
 	c.Assert(err, check.IsNil)

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -145,8 +145,10 @@ func (c *Client) Create(instance *ServiceInstance, user, requestID string) error
 func (c *Client) Update(instance *ServiceInstance, requestID string) error {
 	log.Debugf("Attempting to call update of service instance %q at %q api", instance.Name, instance.ServiceName)
 	params := map[string][]string{
-		"team":      {instance.TeamOwner},
-		"requestID": {requestID},
+		"description": {instance.Description},
+		"team":        {instance.TeamOwner},
+		"tags":        instance.Tags,
+		"requestID":   {requestID},
 	}
 	resp, err := c.issueRequest("/resources/"+instance.GetIdentifier(), "PUT", params)
 	if err == nil {

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -142,6 +142,25 @@ func (c *Client) Create(instance *ServiceInstance, user, requestID string) error
 	return log.WrapError(err)
 }
 
+func (c *Client) Update(instance *ServiceInstance, requestID string) error {
+	log.Debugf("Attempting to call update of service instance %q at %q api", instance.Name, instance.ServiceName)
+	params := map[string][]string{
+		"requestID": {requestID},
+	}
+	resp, err := c.issueRequest("/resources/"+instance.GetIdentifier(), "PUT", params)
+	if err == nil {
+		defer resp.Body.Close()
+		if resp.StatusCode > 299 {
+			if resp.StatusCode == http.StatusNotFound {
+				return ErrInstanceNotFoundInAPI
+			}
+			err = errors.Wrapf(c.buildErrorMessage(err, resp), "Failed to update the instance %s", instance.Name)
+			return log.WrapError(err)
+		}
+	}
+	return err
+}
+
 func (c *Client) Destroy(instance *ServiceInstance, requestID string) error {
 	log.Debugf("Attempting to call destroy of service instance %q at %q api", instance.Name, instance.ServiceName)
 	params := map[string][]string{

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -145,6 +145,7 @@ func (c *Client) Create(instance *ServiceInstance, user, requestID string) error
 func (c *Client) Update(instance *ServiceInstance, requestID string) error {
 	log.Debugf("Attempting to call update of service instance %q at %q api", instance.Name, instance.ServiceName)
 	params := map[string][]string{
+		"team":      {instance.TeamOwner},
 		"requestID": {requestID},
 	}
 	resp, err := c.issueRequest("/resources/"+instance.GetIdentifier(), "PUT", params)
@@ -152,7 +153,7 @@ func (c *Client) Update(instance *ServiceInstance, requestID string) error {
 		defer resp.Body.Close()
 		if resp.StatusCode > 299 {
 			if resp.StatusCode == http.StatusNotFound {
-				return ErrInstanceNotFoundInAPI
+				return nil
 			}
 			err = errors.Wrapf(c.buildErrorMessage(err, resp), "Failed to update the instance %s", instance.Name)
 			return log.WrapError(err)

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -189,11 +189,14 @@ func (s *S) TestUpdateShouldSendAPutRequestToTheResourceURL(c *check.C) {
 	config.Set("request-id-header", requestIDHeader)
 	defer config.Unset("request-id-header")
 	var requests int32
-	instance := ServiceInstance{Name: "his-redis", ServiceName: "redis", TeamOwner: "team-owner"}
+	instance := ServiceInstance{Name: "his-redis", ServiceName: "redis", TeamOwner: "team-owner", Description: "my service", Tags: []string{"tag1", "tag2"}}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requests, 1)
 		c.Check(r.Method, check.Equals, http.MethodPut)
 		c.Check(r.URL.Path, check.Equals, "/resources/"+instance.Name)
+		r.ParseForm()
+		c.Check(r.FormValue("description"), check.Equals, instance.Description)
+		c.Check(r.Form["tags"], check.DeepEquals, instance.Tags)
 		c.Check(r.FormValue("team"), check.Equals, instance.TeamOwner)
 		c.Check(r.Header.Get(requestIDHeader), check.Equals, requestIDValue)
 		c.Assert(r.Header.Get("Authorization"), check.Equals, "Basic dXNlcjphYmNkZQ==")

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -389,7 +389,7 @@ func CreateServiceInstance(instance ServiceInstance, service *Service, user *aut
 	instance.ServiceName = service.Name
 	instance.Teams = []string{instance.TeamOwner}
 	instance.Tags = processTags(instance.Tags)
-	actions := []*action.Action{&createServiceInstance, &insertServiceInstance}
+	actions := []*action.Action{&notifyCreateServiceInstance, &createServiceInstance}
 	pipeline := action.NewPipeline(actions...)
 	return pipeline.Execute(*service, instance, user.Email, requestID)
 }

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -153,17 +153,15 @@ func (si *ServiceInstance) Update(service Service, updateData ServiceInstance, r
 		return err
 	}
 	defer conn.Close()
-	si.Description = updateData.Description
-	si.TeamOwner = updateData.TeamOwner
 	tags := processTags(updateData.Tags)
 	if tags == nil {
-		si.Tags = si.Tags
+		updateData.Tags = si.Tags
 	} else {
-		si.Tags = tags
+		updateData.Tags = tags
 	}
 	actions := []*action.Action{&updateServiceInstance, &notifyUpdateServiceInstance}
 	pipeline := action.NewPipeline(actions...)
-	return pipeline.Execute(service, *si, requestID)
+	return pipeline.Execute(service, *si, updateData, requestID)
 }
 
 func (si *ServiceInstance) updateData(update bson.M) error {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -119,15 +119,6 @@ func (si *ServiceInstance) Info(requestID string) (map[string]string, error) {
 	return info, nil
 }
 
-func (si *ServiceInstance) Create() error {
-	conn, err := db.Conn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	return conn.ServiceInstances().Insert(si)
-}
-
 func (si *ServiceInstance) Service() *Service {
 	conn, err := db.Conn()
 	if err != nil {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -161,7 +161,7 @@ func (si *ServiceInstance) Update(service Service, updateData ServiceInstance, r
 	} else {
 		si.Tags = tags
 	}
-	actions := []*action.Action{&updateServiceInstance}
+	actions := []*action.Action{&updateServiceInstance, &notifyUpdateServiceInstance}
 	pipeline := action.NewPipeline(actions...)
 	return pipeline.Execute(service, *si, requestID)
 }

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -731,7 +731,7 @@ func (s *InstanceSuite) TestUnbindApp(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	err = a.AddInstance(bind.AddInstanceArgs{
 		Envs: []bind.ServiceEnvVar{
@@ -793,7 +793,7 @@ func (s *InstanceSuite) TestUnbindAppFailureInUnbindAppCall(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	err = a.AddInstance(bind.AddInstanceArgs{
 		Envs: []bind.ServiceEnvVar{
@@ -858,7 +858,7 @@ func (s *InstanceSuite) TestUnbindAppFailureInAppEnvSet(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{a.GetName()},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	units, err := a.Units()
 	c.Assert(err, check.IsNil)
@@ -914,7 +914,7 @@ func (s *InstanceSuite) TestBindAppFullPipeline(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	a := provisiontest.NewFakeApp("myapp", "static", 2)
 	var buf bytes.Buffer
@@ -960,7 +960,7 @@ func (s *InstanceSuite) TestBindAppMultipleApps(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	var apps []bind.App
 	var expectedNames []string
@@ -1009,7 +1009,7 @@ func (s *InstanceSuite) TestUnbindAppMultipleApps(c *check.C) {
 		ServiceName: "mysql",
 		Teams:       []string{s.team.Name},
 	}
-	err = si.Create()
+	err = s.conn.ServiceInstances().Insert(si)
 	c.Assert(err, check.IsNil)
 	var apps []bind.App
 	for i := 0; i < 20; i++ {

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -573,7 +573,7 @@ func (s *InstanceSuite) TestUpdateServiceInstance(c *check.C) {
 	si.Description = "desc"
 	si.Tags = []string{"tag2"}
 	si.TeamOwner = newTeam.Name
-	err = instance.Update(si)
+	err = instance.Update(srv, si, "")
 	c.Assert(err, check.IsNil)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": "instance"}).One(&si)
 	c.Assert(err, check.IsNil)
@@ -615,7 +615,7 @@ func (s *InstanceSuite) TestUpdateServiceInstanceRemovesDuplicatedAndEmptyTags(c
 	err = CreateServiceInstance(instance, &srv, s.user, "")
 	c.Assert(err, check.IsNil)
 	instance.Tags = []string{"tag2", " ", " tag2 "}
-	err = instance.Update(instance)
+	err = instance.Update(srv, instance, "")
 	c.Assert(err, check.IsNil)
 	var si ServiceInstance
 	err = s.conn.ServiceInstances().Find(bson.M{"name": "instance"}).One(&si)

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -599,7 +599,7 @@ func (s *InstanceSuite) TestUpdateServiceInstanceValidatesTeamOwner(c *check.C) 
 	err = s.conn.ServiceInstances().Find(bson.M{"name": "instance"}).One(&si)
 	c.Assert(err, check.IsNil)
 	si.TeamOwner = "unknown"
-	err = instance.Update(si)
+	err = instance.Update(srv, si, "")
 	c.Assert(err, check.ErrorMatches, "Team owner doesn't exist")
 }
 

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -93,7 +93,7 @@ func (s *SyncSuite) TestBindSyncer(c *check.C) {
 		Apps:        []string{a.GetName()},
 		BoundUnits:  []service.Unit{{ID: units[0].GetID(), IP: units[0].GetIp()}, {ID: "wrong", IP: "wrong"}},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	instance = &service.ServiceInstance{
 		Name:        "my-mysql",
@@ -102,7 +102,7 @@ func (s *SyncSuite) TestBindSyncer(c *check.C) {
 		Apps:        []string{a.GetName()},
 		BoundUnits:  []service.Unit{},
 	}
-	err = instance.Create()
+	err = s.conn.ServiceInstances().Insert(instance)
 	c.Assert(err, check.IsNil)
 	callCh := make(chan struct{})
 	err = service.InitializeSync(func() ([]bind.App, error) {


### PR DESCRIPTION
Notifies the service endpoint when a service instance is updated.

This endpoint implementation should be optional, that's why 404 errors are being ignored.

Fixes #1581