### PR TITLE
app/migrate: do not delete TSURU_SERVICES env var during migration

### DIFF
--- a/app/migrate/migrate.go
+++ b/app/migrate/migrate.go
@@ -79,6 +79,10 @@ func MigrateAppTsuruServicesVarToServiceEnvs() error {
 		if err != nil {
 			return err
 		}
+		envsMap := map[bind.ServiceEnvVar]struct{}{}
+		for _, sEnv := range a.ServiceEnvs {
+			envsMap[sEnv] = struct{}{}
+		}
 		var serviceNames []string
 		for serviceName := range data {
 			serviceNames = append(serviceNames, serviceName)
@@ -89,17 +93,19 @@ func MigrateAppTsuruServicesVarToServiceEnvs() error {
 			instances := data[serviceName]
 			for _, instance := range instances {
 				for k, v := range instance.Envs {
-					serviceEnvs = append(serviceEnvs, bind.ServiceEnvVar{
+					toAppendEnv := bind.ServiceEnvVar{
 						ServiceName:  serviceName,
 						InstanceName: instance.InstanceName,
 						EnvVar:       bind.EnvVar{Name: k, Value: v},
-					})
+					}
+					if _, ok := envsMap[toAppendEnv]; !ok {
+						serviceEnvs = append(serviceEnvs, toAppendEnv)
+					}
 				}
 			}
 		}
 		err = conn.Apps().Update(bson.M{"name": a.Name}, bson.M{
-			"$push":  bson.M{"serviceenvs": bson.M{"$each": serviceEnvs, "$position": 0}},
-			"$unset": bson.M{"env." + app.TsuruServicesEnvVar: ""},
+			"$push": bson.M{"serviceenvs": bson.M{"$each": serviceEnvs, "$position": 0}},
 		})
 		if err != nil {
 			return err

--- a/app/migrate/migrate_test.go
+++ b/app/migrate/migrate_test.go
@@ -219,8 +219,6 @@ func (s *S) TestMigrateAppTsuruServicesVarToServiceEnvs(c *check.C) {
 		c.Assert(err, check.IsNil)
 		resultApps = append(resultApps, *dbApp)
 		c.Assert(dbApp.ServiceEnvs, check.DeepEquals, tt.expected)
-		_, hasSpecialEnv := dbApp.Env[app.TsuruServicesEnvVar]
-		c.Assert(hasSpecialEnv, check.Equals, false)
 		allEnvs := dbApp.Envs()
 		if tt.expectedServicesEnv == "" {
 			tt.expectedServicesEnv = tt.app.Env[app.TsuruServicesEnvVar].Value


### PR DESCRIPTION
This makes this migration non-destructive making rolling back to a
previous tsuru version easier.