### PR TITLE
provision/swarm: return node not found err if no cluster found

### DIFF
--- a/provision/swarm/provisioner.go
+++ b/provision/swarm/provisioner.go
@@ -435,10 +435,9 @@ func (p *swarmProvisioner) GetNode(address string) (provision.Node, error) {
 func (p *swarmProvisioner) NodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, error) {
 	clusters, err := allClusters()
 	if err != nil {
-		if errors.Cause(err) == cluster.ErrNoCluster {
-			return nil, nil
+		if errors.Cause(err) != cluster.ErrNoCluster {
+			return nil, err
 		}
-		return nil, err
 	}
 	for _, client := range clusters {
 		tasks, err := client.ListTasks(docker.ListTasksOptions{})

--- a/provision/swarm/provisioner_test.go
+++ b/provision/swarm/provisioner_test.go
@@ -1560,11 +1560,27 @@ func (s *S) TestNodeForNodeData(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(node.Address(), check.Equals, s.clusterSrv.URL())
 	data = provision.NodeStatusData{
+		Addrs: []string{s.clusterSrv.URL()},
+	}
+	node, err = s.p.NodeForNodeData(data)
+	c.Assert(err, check.IsNil)
+	c.Assert(node.Address(), check.Equals, s.clusterSrv.URL())
+	data = provision.NodeStatusData{
 		Units: []provision.UnitStatusData{
 			{ID: "invalidid"},
 		},
 	}
 	_, err = s.p.NodeForNodeData(data)
+	c.Assert(err, check.Equals, provision.ErrNodeNotFound)
+}
+
+func (s *S) TestNodeForNodeDataNoCluster(c *check.C) {
+	data := provision.NodeStatusData{
+		Units: []provision.UnitStatusData{
+			{ID: "invalidid"},
+		},
+	}
+	_, err := s.p.NodeForNodeData(data)
 	c.Assert(err, check.Equals, provision.ErrNodeNotFound)
 }
 


### PR DESCRIPTION
This could cause tsuru to return 404 errors on /node/status requests if the
first queried provisioner was swarm and no swarm clusters existed.