### PR TITLE
Service instance update plan

### DIFF
--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -136,6 +136,7 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	instanceName := r.URL.Query().Get(":instance")
 	description := r.FormValue("description")
 	teamOwner := r.FormValue("teamowner")
+	plan := r.FormValue("plan")
 	tags := r.Form["tag"]
 	srv, err := getService(serviceName)
 	if err != nil {
@@ -155,10 +156,13 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	if tags != nil {
 		wantedPerms = append(wantedPerms, permission.PermServiceInstanceUpdateTags)
 	}
+	if plan != "" {
+		wantedPerms = append(wantedPerms, permission.PermServiceInstanceUpdatePlan)
+	}
 	if len(wantedPerms) == 0 {
 		return &tsuruErrors.HTTP{
 			Code:    http.StatusBadRequest,
-			Message: "Neither the description, team owner or tags were set. You must define at least one.",
+			Message: "Neither the description, team owner, tags or plan were set. You must define at least one.",
 		}
 	}
 	for _, perm := range wantedPerms {

--- a/docs/services/api.rst
+++ b/docs/services/api.rst
@@ -137,23 +137,23 @@ user updates properties of a service instance via command line tool:
 
 ::
 
-    $ tsuru service-instance-update mysql mysql_instance --description "new-description" --tag "tag1" --tag "tag2" --team-owner "new-team-owner"
+    $ tsuru service-instance-update mysql mysql_instance --description "new-description" --tag "tag1" --tag "tag2" --team-owner "new-team-owner" --plan "new-plan"
 
 tsuru calls the service API to inform the instance update via PUT on ``/resources``
 (please notice that tsuru does not include a trailing slash) with the new, updated
-fields (description, tags and team owner). Example of request:
+fields (description, tags, team owner and plan). Example of request:
 
 ::
 
     PUT /resources/mysql_instance HTTP/1.1
     Host: myserviceapi.com
-    Content-Length: 56
+    Content-Length: 79
     User-Agent: Go 1.1 package http
     Accept: application/json
     Authorization: Basic dXNlcjpwYXNzd29yZA==
     Content-Type: application/x-www-form-urlencoded
 
-    description=new-description&tag=tag1&tag=tag2&team=new-team-owner
+    description=new-description&tag=tag1&tag=tag2&team=new-team-owner&plan=new-plan
 
 The API should return the following HTTP response codes with the respective
 response body:

--- a/docs/services/build.rst
+++ b/docs/services/build.rst
@@ -176,6 +176,7 @@ Here's an example implementation for this endpoint:
         description = request.form.get("description")
         tags = request.form.get("tag")
         team = request.form.get("team")
+        plan = request.form.get("plan")
         # use the given parameters to update the instance "name"
         return "", 200
 

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -171,6 +171,7 @@ var (
 	PermServiceInstanceUpdateBind        = PermissionRegistry.get("service-instance.update.bind")        // [global service-instance team]
 	PermServiceInstanceUpdateDescription = PermissionRegistry.get("service-instance.update.description") // [global service-instance team]
 	PermServiceInstanceUpdateGrant       = PermissionRegistry.get("service-instance.update.grant")       // [global service-instance team]
+	PermServiceInstanceUpdatePlan        = PermissionRegistry.get("service-instance.update.plan")        // [global service-instance team]
 	PermServiceInstanceUpdateProxy       = PermissionRegistry.get("service-instance.update.proxy")       // [global service-instance team]
 	PermServiceInstanceUpdateRevoke      = PermissionRegistry.get("service-instance.update.revoke")      // [global service-instance team]
 	PermServiceInstanceUpdateTags        = PermissionRegistry.get("service-instance.update.tags")        // [global service-instance team]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -140,6 +140,7 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"service-instance.update.description",
 	"service-instance.update.tags",
 	"service-instance.update.teamowner",
+	"service-instance.update.plan",
 ).add(
 	"role.create",
 	"role.delete",

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -148,6 +148,7 @@ func (c *Client) Update(instance *ServiceInstance, requestID string) error {
 		"description": {instance.Description},
 		"team":        {instance.TeamOwner},
 		"tags":        instance.Tags,
+		"plan":        {instance.PlanName},
 		"requestID":   {requestID},
 	}
 	resp, err := c.issueRequest("/resources/"+instance.GetIdentifier(), "PUT", params)

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -194,7 +194,7 @@ func (s *S) TestUpdateShouldSendAPutRequestToTheResourceURL(c *check.C) {
 	config.Set("request-id-header", requestIDHeader)
 	defer config.Unset("request-id-header")
 	var requests int32
-	instance := ServiceInstance{Name: "his-redis", ServiceName: "redis", TeamOwner: "team-owner", Description: "my service", Tags: []string{"tag1", "tag2"}}
+	instance := ServiceInstance{Name: "his-redis", ServiceName: "redis", TeamOwner: "team-owner", Description: "my service", Tags: []string{"tag1", "tag2"}, PlanName: "small"}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&requests, 1)
 		c.Check(r.Method, check.Equals, http.MethodPut)
@@ -203,6 +203,7 @@ func (s *S) TestUpdateShouldSendAPutRequestToTheResourceURL(c *check.C) {
 		c.Check(r.FormValue("description"), check.Equals, instance.Description)
 		c.Check(r.Form["tags"], check.DeepEquals, instance.Tags)
 		c.Check(r.FormValue("team"), check.Equals, instance.TeamOwner)
+		c.Check(r.FormValue("plan"), check.Equals, instance.PlanName)
 		c.Check(r.Header.Get(requestIDHeader), check.Equals, requestIDValue)
 		c.Assert(r.Header.Get("Authorization"), check.Equals, "Basic dXNlcjphYmNkZQ==")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Add a `plan` parameter to service instance update route. As this field isn't persisted in the DB, it's only for notifying the change to the service API