### PR TITLE
cmd: improve performance of table rendering

### DIFF
--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"os"
 	"sort"
+	"testing"
 
 	"gopkg.in/check.v1"
 )
@@ -463,4 +464,20 @@ jk`})
 	c.Assert(t.rows[2], check.DeepEquals, Row{"3", `1 2↵
 3: ↵
 4`})
+}
+
+func BenchmarkString(b *testing.B) {
+	b.StopTimer()
+	table := NewTable()
+	table.Headers = Row{"row 1", "row 2", "row 3", "row 4"}
+	for i := 0; i < 100; i++ {
+		table.AddRow(Row{"my big string", "other string", "small", `largest string in the whole table
+continuing string
+another line
+yet another big line`})
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		table.String()
+	}
 }

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"sort"
 	"testing"
@@ -72,11 +73,10 @@ func (s *S) TestColumnsSize(c *check.C) {
 
 func (s *S) TestSeparator(c *check.C) {
 	table := NewTable()
-	table.AddRow(Row{"One", "1"})
-	table.AddRow(Row{"Two", "2"})
-	table.AddRow(Row{"Three", "3"})
 	expected := "+-------+---+\n"
-	c.Assert(table.separator(), check.Equals, expected)
+	buf := bytes.NewBuffer(nil)
+	table.separator(buf, []int{5, 1})
+	c.Assert(buf.String(), check.Equals, expected)
 }
 
 func (s *S) TestHeadings(c *check.C) {
@@ -478,6 +478,6 @@ yet another big line`})
 	}
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		table.String()
+		_ = table.String()
 	}
 }


### PR DESCRIPTION
```
name      old time/op    new time/op    delta 
String-4    18.5ms ± 4%    1.5ms ±16%  -92.07%  (p=0.004 n=5+6)

name      old alloc/op   new alloc/op   delta 
String-4    60.2MB ± 0%    0.5MB ± 0%  -99.18%  (p=0.004 n=5+6)

name      old allocs/op  new allocs/op  delta 
String-4     34.9k ± 0%    15.5k ± 0%  -55.67%  (p=0.002 n=6+6)
```