### PR TITLE
Add Build Endpoint

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -1,0 +1,139 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/auth"
+	tsuruErrors "github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/event"
+	tsuruIo "github.com/tsuru/tsuru/io"
+	"github.com/tsuru/tsuru/permission"
+)
+
+// title: app build
+// path: /apps/{appname}/build
+// method: POST
+// consume: application/x-www-form-urlencoded
+// responses:
+//   200: OK
+//   400: Invalid data
+//   403: Forbidden
+//   404: Not found
+func build(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
+	tag := r.FormValue("tag")
+	if tag == "" {
+		return &tsuruErrors.HTTP{
+			Code:    http.StatusBadRequest,
+			Message: "you must specify the image tag.",
+		}
+	}
+	opts, err := prepareToBuild(r)
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "text")
+	appName := r.URL.Query().Get(":appname")
+	var userName string
+	if t.IsAppToken() {
+		if t.GetAppName() != appName && t.GetAppName() != app.InternalAppName {
+			return &tsuruErrors.HTTP{Code: http.StatusUnauthorized, Message: "invalid app token"}
+		}
+		userName = r.FormValue("user")
+	} else {
+		userName = t.GetUserName()
+	}
+	instance, err := app.GetByName(appName)
+	if err != nil {
+		return &tsuruErrors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
+	}
+	opts.App = instance
+	opts.BuildTag = tag
+	opts.User = userName
+	opts.GetKind()
+	if t.GetAppName() != app.InternalAppName {
+		canBuild := permission.Check(t, permission.PermAppBuild, contextsForApp(instance)...)
+		if !canBuild {
+			return &tsuruErrors.HTTP{Code: http.StatusForbidden, Message: "User does not have permission to do this action in this app"}
+		}
+	}
+	evt, err := event.New(&event.Opts{
+		Target:        appTarget(appName),
+		Kind:          permission.PermAppBuild,
+		RawOwner:      event.Owner{Type: event.OwnerTypeUser, Name: userName},
+		CustomData:    opts,
+		Allowed:       event.Allowed(permission.PermAppReadEvents, contextsForApp(instance)...),
+		AllowedCancel: event.Allowed(permission.PermAppUpdateEvents, contextsForApp(instance)...),
+		Cancelable:    true,
+	})
+	if err != nil {
+		return err
+	}
+	var imageID string
+	defer func() { evt.DoneCustomData(err, map[string]string{"image": imageID}) }()
+	opts.Event = evt
+	writer := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "please wait...")
+	defer writer.Stop()
+	opts.OutputStream = writer
+	imageID, err = app.Build(opts)
+	if err == nil {
+		fmt.Fprintln(w, imageID)
+	}
+	return err
+}
+
+func prepareToBuild(r *http.Request) (opts app.DeployOptions, err error) {
+	var file multipart.File
+	var fileSize int64
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/") {
+		file, _, err = r.FormFile("file")
+		if err != nil {
+			return opts, &tsuruErrors.HTTP{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+		fileSize, err = file.Seek(0, io.SeekEnd)
+		if err != nil {
+			return opts, errors.Wrap(err, "unable to find uploaded file size")
+		}
+		file.Seek(0, io.SeekStart)
+		defer file.Close()
+	}
+	archiveURL := r.FormValue("archive-url")
+	image := r.FormValue("image")
+	if image == "" && archiveURL == "" && file == nil {
+		return opts, &tsuruErrors.HTTP{
+			Code:    http.StatusBadRequest,
+			Message: "you must specify either the archive-url, a image url or upload a file.",
+		}
+	}
+	var build bool
+	buildString := r.FormValue("build")
+	if buildString != "" {
+		build, err = strconv.ParseBool(buildString)
+		if err != nil {
+			return opts, &tsuruErrors.HTTP{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}
+		}
+	}
+	opts.FileSize = fileSize
+	opts.File = file
+	opts.ArchiveURL = archiveURL
+	opts.Image = image
+	opts.Build = build
+	return
+}

--- a/api/build_test.go
+++ b/api/build_test.go
@@ -1,0 +1,229 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/builder"
+	"github.com/tsuru/tsuru/builder/fake"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/event/eventtest"
+	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/pool"
+	"github.com/tsuru/tsuru/provision/provisiontest"
+	"github.com/tsuru/tsuru/repository"
+	"github.com/tsuru/tsuru/repository/repositorytest"
+	"github.com/tsuru/tsuru/router/routertest"
+	_ "github.com/tsuru/tsuru/storage/mongodb"
+	appTypes "github.com/tsuru/tsuru/types/app"
+	authTypes "github.com/tsuru/tsuru/types/auth"
+	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/check.v1"
+)
+
+type BuildSuite struct {
+	conn        *db.Storage
+	logConn     *db.LogStorage
+	token       auth.Token
+	team        *authTypes.Team
+	provisioner *provisiontest.FakeProvisioner
+	builder     *fake.FakeBuilder
+	testServer  http.Handler
+}
+
+var _ = check.Suite(&BuildSuite{})
+
+func (s *BuildSuite) createUserAndTeam(c *check.C) {
+	user := &auth.User{Email: "whydidifall@thewho.com", Password: "123456"}
+	app.AuthScheme = nativeScheme
+	_, err := nativeScheme.Create(user)
+	c.Assert(err, check.IsNil)
+	s.team = &authTypes.Team{Name: "tsuruteam"}
+	err = auth.TeamService().Insert(*s.team)
+	c.Assert(err, check.IsNil)
+	s.token = userWithPermission(c, permission.Permission{
+		Scheme:  permission.PermAppReadDeploy,
+		Context: permission.Context(permission.CtxTeam, s.team.Name),
+	}, permission.Permission{
+		Scheme:  permission.PermAppDeploy,
+		Context: permission.Context(permission.CtxTeam, s.team.Name),
+	}, permission.Permission{
+		Scheme:  permission.PermAppBuild,
+		Context: permission.Context(permission.CtxTeam, s.team.Name),
+	})
+}
+
+func (s *BuildSuite) reset() {
+	s.provisioner.Reset()
+	s.builder.Reset()
+	routertest.FakeRouter.Reset()
+	repositorytest.Reset()
+}
+
+func (s *BuildSuite) SetUpSuite(c *check.C) {
+	err := config.ReadConfigFile("testdata/config.yaml")
+	c.Assert(err, check.IsNil)
+	config.Set("log:disable-syslog", true)
+	config.Set("database:driver", "mongodb")
+	config.Set("database:url", "127.0.0.1:27017")
+	config.Set("database:name", "tsuru_deploy_api_tests")
+	config.Set("auth:hash-cost", bcrypt.MinCost)
+	config.Set("repo-manager", "fake")
+	s.conn, err = db.Conn()
+	c.Assert(err, check.IsNil)
+	s.logConn, err = db.LogConn()
+	c.Assert(err, check.IsNil)
+	s.builder = fake.NewFakeBuilder()
+	builder.Register("fake", s.builder)
+	s.testServer = RunServer(true)
+}
+
+func (s *BuildSuite) TearDownSuite(c *check.C) {
+	config.Unset("docker:router")
+	pool.RemovePool("pool1")
+	s.conn.Apps().Database.DropDatabase()
+	s.logConn.Logs("myapp").Database.DropDatabase()
+	s.conn.Close()
+	s.logConn.Close()
+	s.reset()
+}
+
+func (s *BuildSuite) SetUpTest(c *check.C) {
+	s.provisioner = provisiontest.ProvisionerInstance
+	provision.DefaultProvisioner = "fake"
+	builder.DefaultBuilder = "fake"
+	s.reset()
+	err := dbtest.ClearAllCollections(s.conn.Apps().Database)
+	c.Assert(err, check.IsNil)
+	s.createUserAndTeam(c)
+	app.PlatformService().Insert(appTypes.Platform{Name: "python"})
+	opts := pool.AddPoolOptions{Name: "pool1", Default: true}
+	err = pool.AddPool(opts)
+	c.Assert(err, check.IsNil)
+	user, err := s.token.User()
+	c.Assert(err, check.IsNil)
+	repository.Manager().CreateUser(user.Email)
+	config.Set("docker:router", "fake")
+}
+
+func (s *BuildSuite) TestBuildHandler(c *check.C) {
+	user, _ := s.token.User()
+	a := app.App{
+		Name:      "otherapp",
+		Platform:  "python",
+		Router:    "fake",
+		TeamOwner: s.team.Name,
+	}
+	err := app.CreateApp(&a, user)
+	c.Assert(err, check.IsNil)
+	url := fmt.Sprintf("/apps/%s/build?tag=mytag", a.Name)
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	file, err := writer.CreateFormFile("file", "archive.tar.gz")
+	c.Assert(err, check.IsNil)
+	file.Write([]byte("hello world!"))
+	writer.Close()
+	request, err := http.NewRequest("POST", url, &body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "multipart/form-data; boundary="+writer.Boundary())
+	recorder := httptest.NewRecorder()
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	server := RunServer(true)
+	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "text")
+	c.Assert(recorder.Body.String(), check.Equals, "tsuruteam/app-otherapp:mytag\n")
+	c.Assert(eventtest.EventDesc{
+		Target: appTarget(a.Name),
+		Owner:  s.token.GetUserName(),
+		Kind:   "app.build",
+		StartCustomData: map[string]interface{}{
+			"app.name":   a.Name,
+			"commit":     "",
+			"filesize":   12,
+			"kind":       "upload",
+			"archiveurl": "",
+			"user":       s.token.GetUserName(),
+			"image":      "",
+			"origin":     "",
+			"build":      false,
+			"rollback":   false,
+		},
+		EndCustomData: map[string]interface{}{
+			"image": "tsuruteam/app-otherapp:mytag",
+		},
+	}, eventtest.HasEvent)
+}
+
+func (s *BuildSuite) TestBuildArchiveURL(c *check.C) {
+	user, _ := s.token.User()
+	a := app.App{
+		Name:      "otherapp",
+		Platform:  "python",
+		Router:    "fake",
+		TeamOwner: s.team.Name,
+	}
+	err := app.CreateApp(&a, user)
+	c.Assert(err, check.IsNil)
+	url := fmt.Sprintf("/apps/%s/build", a.Name)
+	request, err := http.NewRequest("POST", url, strings.NewReader("tag=mytag&archive-url=http://something.tar.gz"))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	server := RunServer(true)
+	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "text")
+	c.Assert(recorder.Body.String(), check.Equals, "tsuruteam/app-otherapp:mytag\n")
+	c.Assert(eventtest.EventDesc{
+		Target: appTarget(a.Name),
+		Owner:  s.token.GetUserName(),
+		Kind:   "app.build",
+		StartCustomData: map[string]interface{}{
+			"app.name":   a.Name,
+			"commit":     "",
+			"filesize":   0,
+			"kind":       "archive-url",
+			"archiveurl": "http://something.tar.gz",
+			"user":       s.token.GetUserName(),
+			"image":      "",
+			"origin":     "",
+			"build":      false,
+			"rollback":   false,
+		},
+		EndCustomData: map[string]interface{}{
+			"image": "tsuruteam/app-otherapp:mytag",
+		},
+	}, eventtest.HasEvent)
+}
+
+func (s *BuildSuite) TestBuildWithoutTag(c *check.C) {
+	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
+	user, _ := s.token.User()
+	err := app.CreateApp(&a, user)
+	c.Assert(err, check.IsNil)
+	url := fmt.Sprintf("/apps/%s/build", a.Name)
+	request, err := http.NewRequest("POST", url, strings.NewReader("archive-url=http://something.tar.gz"))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	server := RunServer(true)
+	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+	c.Assert(recorder.Body.String(), check.Equals, "you must specify the image tag.\n")
+}

--- a/api/server.go
+++ b/api/server.go
@@ -192,6 +192,7 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.0", "Post", "/apps/{appname}/deploy", AuthorizationRequiredHandler(deploy))
 	diffDeployHandler := AuthorizationRequiredHandler(diffDeploy)
 	m.Add("1.0", "Post", "/apps/{appname}/diff", diffDeployHandler)
+	m.Add("1.4", "Post", "/apps/{appname}/build", AuthorizationRequiredHandler(build))
 
 	// Shell also doesn't use {app} on purpose. Middlewares don't play well
 	// with websocket.

--- a/api/server.go
+++ b/api/server.go
@@ -192,7 +192,7 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.0", "Post", "/apps/{appname}/deploy", AuthorizationRequiredHandler(deploy))
 	diffDeployHandler := AuthorizationRequiredHandler(diffDeploy)
 	m.Add("1.0", "Post", "/apps/{appname}/diff", diffDeployHandler)
-	m.Add("1.4", "Post", "/apps/{appname}/build", AuthorizationRequiredHandler(build))
+	m.Add("1.5", "Post", "/apps/{appname}/build", AuthorizationRequiredHandler(build))
 
 	// Shell also doesn't use {app} on purpose. Middlewares don't play well
 	// with websocket.

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -152,6 +152,7 @@ func eventToDeployData(evt *event.Event, validImages set.Set, full bool) *Deploy
 type DeployOptions struct {
 	App          *App
 	Commit       string
+	BuildTag     string
 	ArchiveURL   string
 	FileSize     int64
 	File         io.ReadCloser `bson:"-"`
@@ -196,6 +197,35 @@ func (o *DeployOptions) GetKind() (kind DeployKind) {
 		return DeployGit
 	}
 	return DeployArchiveURL
+}
+
+func Build(opts DeployOptions) (string, error) {
+	if opts.Event == nil {
+		return "", errors.Errorf("missing event in build opts")
+	}
+	logWriter := LogWriter{App: opts.App}
+	logWriter.Async()
+	defer logWriter.Close()
+	opts.Event.SetLogWriter(io.MultiWriter(&tsuruIo.NoErrorWriter{Writer: opts.OutputStream}, &logWriter))
+	prov, err := opts.App.getProvisioner()
+	if err != nil {
+		return "", err
+	}
+	if opts.App.GetPlatform() == "" {
+		return "", errors.Errorf("can't build app without platform")
+	}
+	builder, ok := prov.(provision.BuilderDeploy)
+	if !ok {
+		return "", errors.Errorf("provisioner don't implement builder interface")
+	}
+	imageID, err := builderDeploy(builder, &opts, opts.Event)
+	if err != nil {
+		return "", err
+	}
+	if opts.App.UpdatePlatform {
+		opts.App.SetUpdatePlatform(false)
+	}
+	return imageID, nil
 }
 
 // Deploy runs a deployment of an application. It will first try to run an
@@ -250,36 +280,36 @@ func deployToProvisioner(opts *DeployOptions, evt *event.Event) (string, error) 
 	if (opts.App.GetPlatform() == "") && ((opts.Kind != DeployImage) && (opts.Kind != DeployRollback)) {
 		return "", errors.Errorf("can't deploy app without platform, if it's not an image or rollback")
 	}
-	switch opts.Kind {
-	case DeployRollback:
+
+	if opts.Kind != DeployRollback {
+		if deployer, ok := prov.(provision.BuilderDeploy); ok {
+			imageID, err := builderDeploy(deployer, opts, evt)
+			if err != nil {
+				return "", err
+			}
+			return deployer.Deploy(opts.App, imageID, evt)
+		}
+	} else {
 		if deployer, ok := prov.(provision.RollbackableDeployer); ok {
 			return deployer.Rollback(opts.App, opts.Image, evt)
 		}
+	}
+
+	// Fallback if provisioner dont't implement BuilderDeploy
+	switch opts.Kind {
 	case DeployImage:
-		if deployer, ok := prov.(provision.BuilderDeploy); ok {
-			return builderDeploy(deployer, opts, evt, false)
-		}
 		if deployer, ok := prov.(provision.ImageDeployer); ok {
 			return deployer.ImageDeploy(opts.App, opts.Image, evt)
 		}
 	case DeployUpload, DeployUploadBuild:
-		if deployer, ok := prov.(provision.BuilderDeploy); ok {
-			return builderDeploy(deployer, opts, evt, false)
-		}
 		if deployer, ok := prov.(provision.UploadDeployer); ok {
 			return deployer.UploadDeploy(opts.App, opts.File, opts.FileSize, opts.Build, evt)
 		}
 	case DeployRebuild:
-		if deployer, ok := prov.(provision.BuilderDeploy); ok {
-			return builderDeploy(deployer, opts, evt, true)
-		}
 		if deployer, ok := prov.(provision.RebuildableDeployer); ok {
 			return deployer.Rebuild(opts.App, evt)
 		}
 	default:
-		if deployer, ok := prov.(provision.BuilderDeploy); ok {
-			return builderDeploy(deployer, opts, evt, false)
-		}
 		if deployer, ok := prov.(provision.ArchiveDeployer); ok {
 			return deployer.ArchiveDeploy(opts.App, opts.ArchiveURL, evt)
 		}
@@ -287,7 +317,8 @@ func deployToProvisioner(opts *DeployOptions, evt *event.Event) (string, error) 
 	return "", provision.ProvisionerNotSupported{Prov: prov, Action: fmt.Sprintf("%s deploy", opts.Kind)}
 }
 
-func builderDeploy(prov provision.BuilderDeploy, opts *DeployOptions, evt *event.Event, isRebuild bool) (string, error) {
+func builderDeploy(prov provision.BuilderDeploy, opts *DeployOptions, evt *event.Event) (string, error) {
+	isRebuild := opts.Kind == DeployRebuild
 	buildOpts := builder.BuildOpts{
 		BuildFromFile: opts.Build,
 		ArchiveURL:    opts.ArchiveURL,
@@ -295,16 +326,13 @@ func builderDeploy(prov provision.BuilderDeploy, opts *DeployOptions, evt *event
 		ArchiveSize:   opts.FileSize,
 		Rebuild:       isRebuild,
 		ImageID:       opts.Image,
+		Tag:           opts.BuildTag,
 	}
-	build, err := opts.App.getBuilder()
+	builder, err := opts.App.getBuilder()
 	if err != nil {
 		return "", err
 	}
-	imageID, err := build.Build(prov, opts.App, evt, buildOpts)
-	if err != nil {
-		return "", err
-	}
-	return prov.Deploy(opts.App, imageID, evt)
+	return builder.Build(prov, opts.App, evt, buildOpts)
 }
 
 func ValidateOrigin(origin string) bool {

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -369,7 +369,7 @@ func PullAppImageNames(appName string, images []string) error {
 }
 
 func PlatformImageName(platformName string) string {
-	return fmt.Sprintf("%s/%s:latest", basicImageName(), platformName)
+	return fmt.Sprintf("%s/%s:latest", basicImageName("tsuru"), platformName)
 }
 
 func GetProcessesFromProcfile(strProcfile string) map[string][]string {
@@ -383,7 +383,7 @@ func GetProcessesFromProcfile(strProcfile string) map[string][]string {
 	return processes
 }
 
-func AppNewBuilderImageName(appName string) (string, error) {
+func AppNewBuilderImageName(appName, teamOwner string) (string, error) {
 	coll, err := appImagesColl()
 	if err != nil {
 		return "", err
@@ -395,7 +395,7 @@ func AppNewBuilderImageName(appName string) (string, error) {
 		return "", err
 	}
 	version := imgs.Count + 1
-	return fmt.Sprintf("%s:v%d-builder", appBasicImageName(appName), version), nil
+	return fmt.Sprintf("%s:v%d-builder", appBasicBuilderImageName(appName, teamOwner), version), nil
 }
 
 func ListAppBuilderImages(appName string) ([]string, error) {
@@ -449,10 +449,17 @@ func AppCurrentBuilderImageName(appName string) (string, error) {
 }
 
 func appBasicImageName(appName string) string {
-	return fmt.Sprintf("%s/app-%s", basicImageName(), appName)
+	return fmt.Sprintf("%s/app-%s", basicImageName("tsuru"), appName)
 }
 
-func basicImageName() string {
+func appBasicBuilderImageName(appName, teamName string) string {
+	if teamName == "" {
+		teamName = "tsuru"
+	}
+	return fmt.Sprintf("%s/app-%s", basicImageName(teamName), appName)
+}
+
+func basicImageName(repoName string) string {
 	parts := make([]string, 0, 2)
 	registry, _ := config.GetString("docker:registry")
 	if registry != "" {
@@ -460,7 +467,7 @@ func basicImageName() string {
 	}
 	repoNamespace, _ := config.GetString("docker:repository-namespace")
 	if repoNamespace == "" {
-		repoNamespace = "tsuru"
+		repoNamespace = repoName
 	}
 	parts = append(parts, repoNamespace)
 	return strings.Join(parts, "/")

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -26,6 +26,7 @@ type BuildOpts struct {
 	ArchiveTarFile io.ReadCloser
 	ArchiveSize    int64
 	ImageID        string
+	Tag            string
 }
 
 // Builder is the basic interface of this package.

--- a/builder/docker/actions.go
+++ b/builder/docker/actions.go
@@ -33,7 +33,6 @@ type runContainerActionsArgs struct {
 	client           provision.BuilderDockerClient
 	exposedPort      string
 	event            *event.Event
-	tags             []string
 }
 
 func checkCanceled(evt *event.Event) error {

--- a/builder/docker/actions.go
+++ b/builder/docker/actions.go
@@ -33,6 +33,7 @@ type runContainerActionsArgs struct {
 	client           provision.BuilderDockerClient
 	exposedPort      string
 	event            *event.Event
+	tags             []string
 }
 
 func checkCanceled(evt *event.Event) error {

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -99,7 +99,7 @@ func (b *dockerBuilder) Build(p provision.BuilderDeploy, app provision.App, evt 
 	}
 	defer client.RemoveImage(intermediateImageID)
 	cmds := dockercommon.ArchiveBuildCmds(app, fileURI)
-	imageID, err := b.buildPipeline(p, client, app, intermediateImageID, cmds, evt)
+	imageID, err := b.buildPipeline(p, client, app, cmds, evt, intermediateImageID, opts.Tag)
 	if err != nil {
 		return "", err
 	}

--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -52,7 +52,7 @@ func (s *S) TestBuilderArchiveURL(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, bopts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 }
 
 func (s *S) TestBuilderArchiveURLEmptyFile(c *check.C) {
@@ -104,7 +104,7 @@ func (s *S) TestBuilderArchiveFile(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, bopts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 }
 
 func (s *S) TestBuilderImageID(c *check.C) {
@@ -403,7 +403,7 @@ func (s *S) TestBuilderRebuild(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, bopts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 	_, err = image.AppNewImageName(a.Name)
 	c.Assert(err, check.IsNil)
 	bopts = builder.BuildOpts{
@@ -411,7 +411,7 @@ func (s *S) TestBuilderRebuild(c *check.C) {
 	}
 	imgID, err = s.b.Build(s.provisioner, a, evt, bopts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v2-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v2-builder")
 }
 
 func (s *S) TestBuilderErasesOldImages(c *check.C) {
@@ -449,7 +449,7 @@ func (s *S) TestBuilderErasesOldImages(c *check.C) {
 	c.Assert(imgs, check.HasLen, 2)
 	c.Assert(imgs[0].RepoTags, check.HasLen, 1)
 	c.Assert(imgs[1].RepoTags, check.HasLen, 1)
-	expected := []string{"tsuru/app-myapp:v1-builder", "tsuru/python:latest"}
+	expected := []string{s.team.Name + "/app-myapp:v1-builder", "tsuru/python:latest"}
 	got := []string{imgs[0].RepoTags[0], imgs[1].RepoTags[0]}
 	sort.Strings(got)
 	c.Assert(got, check.DeepEquals, expected)
@@ -464,6 +464,6 @@ func (s *S) TestBuilderErasesOldImages(c *check.C) {
 	c.Assert(imgs[2].RepoTags, check.HasLen, 1)
 	got = []string{imgs[1].RepoTags[0], imgs[2].RepoTags[0]}
 	sort.Strings(got)
-	expected = []string{"tsuru/app-myapp:v2-builder", "tsuru/python:latest"}
+	expected = []string{s.team.Name + "/app-myapp:v2-builder", "tsuru/python:latest"}
 	c.Assert(got, check.DeepEquals, expected)
 }

--- a/builder/docker/docker.go
+++ b/builder/docker/docker.go
@@ -28,7 +28,7 @@ func (b *dockerBuilder) buildPipeline(p provision.BuilderDeploy, client provisio
 		&updateAppBuilderImage,
 	}
 	pipeline := action.NewPipeline(actions...)
-	buildingImage, err := image.AppNewBuilderImageName(app.GetName())
+	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner())
 	if err != nil {
 		return "", log.WrapError(errors.Errorf("error getting new image name for app %s", app.GetName()))
 	}

--- a/builder/docker/docker.go
+++ b/builder/docker/docker.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 )
 
-func (b *dockerBuilder) buildPipeline(p provision.BuilderDeploy, client provision.BuilderDockerClient, app provision.App, imageID string, commands []string, evt *event.Event) (string, error) {
+func (b *dockerBuilder) buildPipeline(p provision.BuilderDeploy, client provision.BuilderDockerClient, app provision.App, commands []string, evt *event.Event, imageID, imageTag string) (string, error) {
 	actions := []*action.Action{
 		&createContainer,
 		&startContainer,
@@ -28,7 +28,7 @@ func (b *dockerBuilder) buildPipeline(p provision.BuilderDeploy, client provisio
 		&updateAppBuilderImage,
 	}
 	pipeline := action.NewPipeline(actions...)
-	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner())
+	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner(), imageTag)
 	if err != nil {
 		return "", log.WrapError(errors.Errorf("error getting new image name for app %s", app.GetName()))
 	}

--- a/builder/fake/builder.go
+++ b/builder/fake/builder.go
@@ -54,7 +54,7 @@ func (b *FakeBuilder) Build(p provision.BuilderDeploy, app provision.App, evt *e
 	} else {
 		return "", errors.New("no valid files found")
 	}
-	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner())
+	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner(), opts.Tag)
 	if err != nil {
 		return "", fmt.Errorf("error getting new image name for app %s", app.GetName())
 	}

--- a/builder/fake/builder.go
+++ b/builder/fake/builder.go
@@ -54,7 +54,7 @@ func (b *FakeBuilder) Build(p provision.BuilderDeploy, app provision.App, evt *e
 	} else {
 		return "", errors.New("no valid files found")
 	}
-	buildingImage, err := image.AppNewBuilderImageName(app.GetName())
+	buildingImage, err := image.AppNewBuilderImageName(app.GetName(), app.GetTeamOwner())
 	if err != nil {
 		return "", fmt.Errorf("error getting new image name for app %s", app.GetName())
 	}

--- a/builder/fake/builder_test.go
+++ b/builder/fake/builder_test.go
@@ -32,7 +32,7 @@ func (s *S) TestBuildArchiveURL(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, opts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 	c.Assert(s.b.IsArchiveURLDeploy, check.Equals, true)
 }
 
@@ -54,7 +54,7 @@ func (s *S) TestBuildArchiveUpload(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, opts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 	c.Assert(s.b.IsArchiveFileDeploy, check.Equals, true)
 }
 
@@ -99,7 +99,7 @@ func (s *S) TestBuilderRebuild(c *check.C) {
 	}
 	imgID, err := s.b.Build(s.provisioner, a, evt, opts)
 	c.Assert(err, check.IsNil)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v1-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v1-builder")
 	c.Assert(s.b.IsArchiveFileDeploy, check.Equals, true)
 	_, err = image.AppNewImageName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -109,5 +109,5 @@ func (s *S) TestBuilderRebuild(c *check.C) {
 	imgID, err = s.b.Build(s.provisioner, a, evt, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(s.b.IsRebuildDeploy, check.Equals, true)
-	c.Assert(imgID, check.Equals, "tsuru/app-myapp:v2-builder")
+	c.Assert(imgID, check.Equals, s.team.Name+"/app-myapp:v2-builder")
 }

--- a/cmd/tsurud/checker.go
+++ b/cmd/tsurud/checker.go
@@ -85,7 +85,6 @@ func checkDocker() error {
 // Check default configs to Docker.
 func checkDockerBasicConfig() error {
 	return checkConfigPresent([]string{
-		"docker:repository-namespace",
 		"docker:collection",
 	}, "Config error: you should configure %q")
 }

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -754,7 +754,7 @@ docker:repository-namespace
 
 Docker repository namespace to be used for application and platform images. Images
 will be tagged in docker as <docker:repository-namespace>/<platform-name> and
-<docker:repository-namespace>/<app-name>
+<docker:repository-namespace>/<app-name>. The default value is 'tsuru'.
 
 docker:max-layers
 +++++++++++++++++

--- a/etc/tsuru-compose.conf
+++ b/etc/tsuru-compose.conf
@@ -21,7 +21,6 @@ docker:
     mongo-database: cluster
   collection: docker
   registry: 10.200.10.1:5000
-  repository-namespace: tsuru
   router: hipache
   deploy-cmd: /var/lib/tsuru/deploy
   run-cmd:

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -14,6 +14,7 @@ var (
 	PermAppAdminQuota                    = PermissionRegistry.get("app.admin.quota")                     // [global app team pool]
 	PermAppAdminRoutes                   = PermissionRegistry.get("app.admin.routes")                    // [global app team pool]
 	PermAppAdminUnlock                   = PermissionRegistry.get("app.admin.unlock")                    // [global app team pool]
+	PermAppBuild                         = PermissionRegistry.get("app.build")                           // [global app team pool]
 	PermAppCreate                        = PermissionRegistry.get("app.create")                          // [global team]
 	PermAppDelete                        = PermissionRegistry.get("app.delete")                          // [global app team pool]
 	PermAppDeploy                        = PermissionRegistry.get("app.deploy")                          // [global app team pool]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -64,6 +64,7 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"app.admin.unlock",
 	"app.admin.routes",
 	"app.admin.quota",
+	"app.build",
 ).addWithCtx(
 	"node", []contextType{CtxPool},
 ).add(

--- a/provision/docker/image.go
+++ b/provision/docker/image.go
@@ -22,9 +22,9 @@ func MigrateImages() error {
 	if registry != "" {
 		registry += "/"
 	}
-	repoNamespace, err := config.GetString("docker:repository-namespace")
-	if err != nil {
-		return err
+	repoNamespace, _ := config.GetString("docker:repository-namespace")
+	if repoNamespace == "" {
+		repoNamespace = "tsuru"
 	}
 	apps, err := app.List(nil)
 	if err != nil {

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -257,6 +257,8 @@ func (s *S) stopContainers(endpoint string, n uint) <-chan bool {
 }
 
 func (s *S) TestDeploy(c *check.C) {
+	config.Unset("docker:repository-namespace")
+	defer config.Set("docker:repository-namespace", "tsuru")
 	stopCh := s.stopContainers(s.server.URL(), 1)
 	defer func() { <-stopCh }()
 	err := newFakeImage(s.p, "tsuru/python:latest", nil)
@@ -290,9 +292,9 @@ func (s *S) TestDeploy(c *check.C) {
 	}
 	builderImgID, err := s.b.Build(s.p, &a, evt, buildOpts)
 	c.Assert(err, check.IsNil)
-	c.Assert(builderImgID, check.Equals, "tsuru/app-"+a.Name+":v1-builder")
+	c.Assert(builderImgID, check.Equals, s.team.Name+"/app-"+a.Name+":v1-builder")
 	pullOpts := docker.PullImageOptions{
-		Repository: "tsuru/app-" + a.Name,
+		Repository: s.team.Name + "/app-" + a.Name,
 		Tag:        "v1-builder",
 	}
 	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -222,6 +222,8 @@ type App interface {
 
 	GetPool() string
 
+	GetTeamOwner() string
+
 	SetQuotaInUse(int) error
 }
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -253,6 +253,10 @@ func (a *FakeApp) GetDeploys() uint {
 	return a.Deploys
 }
 
+func (a *FakeApp) GetTeamOwner() string {
+	return a.TeamOwner
+}
+
 func (a *FakeApp) Units() ([]provision.Unit, error) {
 	return a.units, nil
 }

--- a/provision/swarm/suite_test.go
+++ b/provision/swarm/suite_test.go
@@ -58,6 +58,7 @@ func (s *S) SetUpSuite(c *check.C) {
 	config.Set("routers:fake:default", true)
 	config.Set("docker:registry", "registry.tsuru.io")
 	config.Set("host", "http://tsuruhost")
+	config.Set("docker:repository-namespace", "tsuru")
 	var err error
 	s.conn, err = db.Conn()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This PR creates the app-build endpoint, with the purpose of build app images without doing the deploy.

example of use: 
```
$ tsuru app-build -a myapp -t <commit_hash>
registry.domain/myteam/app-myapp:commit_hash
```

This PR is related to #1521 