### PR TITLE
Refactor runtime.GOMAXPROCS calls

### DIFF
--- a/app/quota_test.go
+++ b/app/quota_test.go
@@ -70,7 +70,8 @@ func (s *S) TestReserveUnitsUnlimitedQuota(c *check.C) {
 
 func (s *S) TestReserveUnitsIsAtomic(c *check.C) {
 	ncpu := runtime.NumCPU()
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(ncpu))
+	originalMaxProcs := runtime.GOMAXPROCS(ncpu)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	app := &App{
 		Name:   "together",
 		Quota:  quota.Quota{Limit: 40},
@@ -122,7 +123,8 @@ func (s *S) TestReleaseUnreservedUnits(c *check.C) {
 
 func (s *S) TestReleaseUnitsIsAtomic(c *check.C) {
 	ncpu := runtime.NumCPU()
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(ncpu))
+	originalMaxProcs := runtime.GOMAXPROCS(ncpu)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	app := &App{
 		Name:   "together",
 		Quota:  quota.Quota{Limit: 40, InUse: 40},

--- a/auth/quota_test.go
+++ b/auth/quota_test.go
@@ -79,7 +79,8 @@ func (s *S) TestReserveAppQuotaExceeded(c *check.C) {
 }
 
 func (s *S) TestReserveAppIsSafe(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(runtime.NumCPU()))
+	originalMaxProcs := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	email := "seven@corp.globo.com"
 	user := &User{
 		Email: email, Password: "123456",
@@ -176,7 +177,8 @@ func (s *S) TestReleaseAppNonReserved(c *check.C) {
 }
 
 func (s *S) TestReleaseAppIsSafe(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(runtime.NumCPU()))
+	originalMaxProcs := runtime.GOMAXPROCS(runtime.NumCPU())
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	email := "seven@corp.globo.com"
 	user := &User{
 		Email: email, Password: "123456",

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -1019,7 +1019,8 @@ func (s *S) TestNewWithPermission(c *check.C) {
 }
 
 func (s *S) TestNewLockRetryRace(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(100))
+	originalMaxProcs := runtime.GOMAXPROCS(100)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	wg := sync.WaitGroup{}
 	var countOK int32
 	for i := 0; i < 150; i++ {

--- a/healer/healer_node_test.go
+++ b/healer/healer_node_test.go
@@ -774,7 +774,8 @@ func (s *S) TestCheckActiveHealing(c *check.C) {
 }
 
 func (s *S) TestTryHealingNodeConcurrent(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	factory, iaasInst := iaasTesting.NewHealerIaaSConstructorWithInst("addr1")
 	iaas.RegisterIaasProvider("my-healer-iaas", factory)
 	_, err := iaas.CreateMachineForIaaS("my-healer-iaas", map[string]string{})

--- a/iaas/iaas_test.go
+++ b/iaas/iaas_test.go
@@ -246,7 +246,8 @@ func (s *S) TestGetDefaultIaaSEc2MultipleConfigured(c *check.C) {
 }
 
 func (s *S) TestStressConcurrentGet(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1000))
+	originalMaxProcs := runtime.GOMAXPROCS(1000)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	RegisterIaasProvider("customable-iaas", newTestCustomizableIaaS)
 	config.Set("iaas:custom:abc:provider", "customable-iaas")
 	defer config.Unset("iaas:custom:abc:provider")

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -537,7 +537,8 @@ func (s *S) TestDeployCanceledEvent(c *check.C) {
 }
 
 func (s *S) TestDeployRegisterRace(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	var p dockerProvisioner
 	var registerCount int64
 	server, err := testing.NewServer("127.0.0.1:0", nil, func(r *http.Request) {

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -414,7 +414,8 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScaleDisabledForPool
 }
 
 func (s *S) TestChooseNodeDistributesNodesEqually(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	nodes := []cluster.Node{
 		{Address: "http://server1:1234"},
 		{Address: "http://server2:1234"},

--- a/provision/limiter_test.go
+++ b/provision/limiter_test.go
@@ -81,7 +81,8 @@ func (s *LimiterSuite) TestLimiterAddDone(c *check.C) {
 }
 
 func (s *LimiterSuite) TestLimiterAddDoneRace(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	l := s.limiter
 	l.Initialize(100)
 	wg := sync.WaitGroup{}
@@ -108,7 +109,8 @@ func (s *LimiterSuite) TestLimiterAddDoneRace(c *check.C) {
 }
 
 func (s *LimiterSuite) TestLimiterAddDoneRace2(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	l := s.limiter
 	l.Initialize(100)
 	wg := sync.WaitGroup{}

--- a/provision/nodecontainer/bs_test.go
+++ b/provision/nodecontainer/bs_test.go
@@ -51,7 +51,8 @@ func (s *S) TestInitializeBS(c *check.C) {
 }
 
 func (s *S) TestInitializeBSStress(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	nativeScheme := auth.ManagedScheme(native.NativeScheme{})
 	nTimes := 100
 	initializedCh := make(chan bool, nTimes)

--- a/router/routertest/race_test.go
+++ b/router/routertest/race_test.go
@@ -18,7 +18,8 @@ import (
 func (s *S) TestAddRouteAndRemoteRouteAreSafe(c *check.C) {
 	var wg sync.WaitGroup
 	fake := newFakeRouter()
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	originalMaxProcs := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	for i := 1; i < 256; i++ {
 		wg.Add(5)
 		name := fmt.Sprintf("route-%d", i)

--- a/safe/counter_test.go
+++ b/safe/counter_test.go
@@ -23,7 +23,8 @@ func (s *S) TestCounterVal(c *check.C) {
 }
 
 func (s *S) TestIncrement(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(16))
+	originalMaxProcs := runtime.GOMAXPROCS(16)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	n := 50
 	var wg sync.WaitGroup
 	var ct Counter
@@ -41,7 +42,8 @@ func (s *S) TestIncrement(c *check.C) {
 }
 
 func (s *S) TestDecrement(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(16))
+	originalMaxProcs := runtime.GOMAXPROCS(16)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	n := 50
 	var wg sync.WaitGroup
 	ct := NewCounter(int64(n * n))

--- a/scopedconfig/scopedconfig_test.go
+++ b/scopedconfig/scopedconfig_test.go
@@ -507,7 +507,8 @@ func (s *S) TestScopedConfigSaveMerge(c *check.C) {
 }
 
 func (s *S) TestScopedConfigSetFieldAtomic(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(10))
+	originalMaxProcs := runtime.GOMAXPROCS(10)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	nRoutines := 50
 	values := make([]bool, nRoutines)
 	var wg sync.WaitGroup

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -991,7 +991,8 @@ func (s *InstanceSuite) TestBindAppMultipleApps(c *check.C) {
 }
 
 func (s *InstanceSuite) TestUnbindAppMultipleApps(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(4))
+	originalMaxProcs := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	var reqs []*http.Request
 	var mut sync.Mutex
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tsurutest/recorder_test.go
+++ b/tsurutest/recorder_test.go
@@ -27,7 +27,8 @@ func (s *S) TestSafeResponseRecorderWriteHeader(c *check.C) {
 }
 
 func (s *S) TestSafeResponseRecorderWriteIsSafe(c *check.C) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(8))
+	originalMaxProcs := runtime.GOMAXPROCS(8)
+	defer runtime.GOMAXPROCS(originalMaxProcs)
 	recorder := NewSafeResponseRecorder()
 	var wg sync.WaitGroup
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
A small change in how we set `runtime.GOMAXPROCS` in tests, to make the code clearer.