### PR TITLE
update container name in scheduler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -437,7 +437,7 @@
   branch = "master"
   name = "github.com/tsuru/docker-cluster"
   packages = ["cluster","log","storage","storage/mongodb"]
-  revision = "6c22fc6de974a37745976f8806ebfcf659e2fed7"
+  revision = "9f4ce1fd6f06810a8b19826b859426311898261d"
 
 [[projects]]
   name = "github.com/tsuru/gandalf"

--- a/provision/docker/actions.go
+++ b/provision/docker/actions.go
@@ -132,6 +132,10 @@ func checkCanceled(evt *event.Event) error {
 	return nil
 }
 
+func generateContainerName(appName string) string {
+	return appName + "-" + randomString()
+}
+
 var insertEmptyContainerInDB = action.Action{
 	Name: "insert-empty-container",
 	Forward: func(ctx action.FWContext) (action.Result, error) {
@@ -143,13 +147,13 @@ var insertEmptyContainerInDB = action.Action{
 		if args.isDeploy {
 			initialStatus = provision.StatusBuilding
 		}
-		contName := args.app.GetName() + "-" + randomString()
 		cont := container.Container{
 			Container: types.Container{
+				MongoID:       bson.NewObjectId(),
 				AppName:       args.app.GetName(),
 				ProcessName:   args.processName,
 				Type:          args.app.GetPlatform(),
-				Name:          contName,
+				Name:          generateContainerName(args.app.GetName()),
 				Status:        initialStatus.String(),
 				Image:         args.imageID,
 				BuildingImage: args.buildingImage,
@@ -169,7 +173,7 @@ var insertEmptyContainerInDB = action.Action{
 		args := ctx.Params[0].(runContainerActionsArgs)
 		coll := args.provisioner.Collection()
 		defer coll.Close()
-		coll.Remove(bson.M{"name": c.Name})
+		coll.RemoveId(c.MongoID)
 	},
 }
 

--- a/provision/docker/actions_test.go
+++ b/provision/docker/actions_test.go
@@ -93,6 +93,7 @@ func (s *S) TestInsertEmptyContainerInDBForward(c *check.C) {
 	c.Assert(cont.Status, check.Equals, "created")
 	c.Assert(cont.Image, check.Equals, "image-id")
 	c.Assert(cont.BuildingImage, check.Equals, "next-image")
+	c.Assert(string(cont.MongoID), check.Not(check.Equals), "")
 	coll := s.p.Collection()
 	defer coll.Close()
 	defer coll.Remove(bson.M{"name": cont.Name})
@@ -124,6 +125,7 @@ func (s *S) TestInsertEmptyContainerInDBForDeployForward(c *check.C) {
 	c.Assert(cont.Status, check.Equals, "building")
 	c.Assert(cont.Image, check.Equals, "image-id")
 	c.Assert(cont.BuildingImage, check.Equals, "next-image")
+	c.Assert(string(cont.MongoID), check.Not(check.Equals), "")
 	coll := s.p.Collection()
 	defer coll.Close()
 	defer coll.Remove(bson.M{"name": cont.Name})
@@ -134,7 +136,7 @@ func (s *S) TestInsertEmptyContainerInDBForDeployForward(c *check.C) {
 }
 
 func (s *S) TestInsertEmptyContainerInDBBackward(c *check.C) {
-	cont := container.Container{Container: types.Container{Name: "myName"}}
+	cont := container.Container{Container: types.Container{MongoID: bson.NewObjectId()}}
 	coll := s.p.Collection()
 	defer coll.Close()
 	err := coll.Insert(&cont)

--- a/provision/docker/container/container.go
+++ b/provision/docker/container/container.go
@@ -41,6 +41,7 @@ type DockerProvisioner interface {
 type SchedulerOpts struct {
 	AppName       string
 	ProcessName   string
+	UpdateName    bool
 	ActionLimiter provision.ActionLimiter
 	LimiterDone   func()
 }
@@ -142,6 +143,7 @@ func (c *Container) Create(args *CreateArgs) error {
 	schedulerOpts := &SchedulerOpts{
 		AppName:       args.App.GetName(),
 		ProcessName:   args.ProcessName,
+		UpdateName:    true,
 		ActionLimiter: args.Provisioner.ActionLimiter(),
 	}
 	addr, cont, err := args.Provisioner.Cluster().CreateContainerSchedulerOpts(opts, schedulerOpts, net.StreamInactivityTimeout, nodeList...)
@@ -153,6 +155,7 @@ func (c *Container) Create(args *CreateArgs) error {
 		log.Errorf("error on creating container in docker %s - %s", c.AppName, err)
 		return err
 	}
+	c.Name = cont.Name
 	c.ID = cont.ID
 	c.HostAddr = hostAddr
 	return nil

--- a/provision/docker/docker_test.go
+++ b/provision/docker/docker_test.go
@@ -491,13 +491,13 @@ func (s *S) TestGetDockerClientWithoutApp(c *check.C) {
 		c.Assert(err, check.IsNil)
 	}
 	opts := docker.CreateContainerOptions{Name: cont1.Name}
-	_, err = scheduler.Schedule(s.p.cluster, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont1.ProcessName})
+	_, err = scheduler.Schedule(s.p.cluster, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont1.ProcessName})
 	c.Assert(err, check.IsNil)
 	client, err := s.p.GetDockerClient(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(client.(*dbAwareClient).Endpoint(), check.Equals, nodes[1].Address)
 	opts = docker.CreateContainerOptions{Name: cont2.Name}
-	_, err = scheduler.Schedule(s.p.cluster, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont2.ProcessName})
+	_, err = scheduler.Schedule(s.p.cluster, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont2.ProcessName})
 	c.Assert(err, check.IsNil)
 	client, err = s.p.GetDockerClient(nil)
 	c.Assert(err, check.IsNil)

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -1311,7 +1311,7 @@ func (s *S) TestProvisionerRemoveUnitsEmptyProcess(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{Name: cont1.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	papp := provisiontest.NewFakeApp(a1.Name, "python", 0)
 	s.p.Provision(papp)
@@ -1410,7 +1410,7 @@ func (s *S) TestProvisionerRemoveUnitsInvalidProcess(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{Name: cont1.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	customData := map[string]interface{}{
 		"processes": map[string]interface{}{

--- a/provision/docker/scheduler_test.go
+++ b/provision/docker/scheduler_test.go
@@ -73,13 +73,47 @@ func (s *S) TestSchedulerSchedule(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{Name: cont1.Name}
-	node, err := scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
+	node, err := scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	c.Check(node.Address, check.Equals, server1.URL())
 	opts = docker.CreateContainerOptions{Name: cont2.Name}
-	node, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: "web"})
+	node, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	c.Check(node.Address, check.Equals, localURL)
+}
+
+func (s *S) TestSchedulerScheduleChangesContainerName(c *check.C) {
+	a1 := app.App{Name: "impius", Teams: []string{"tsuruteam", "nodockerforme"}, Pool: "test-default"}
+	cont1 := container.Container{Container: types.Container{ID: "1", Name: "impius1", AppName: a1.Name}}
+	err := s.conn.Apps().Insert(a1)
+	c.Assert(err, check.IsNil)
+	contColl := s.p.Collection()
+	defer contColl.Close()
+	err = contColl.Insert(cont1)
+	c.Assert(err, check.IsNil)
+	scheduler := segregatedScheduler{provisioner: s.p}
+	clusterInstance, err := cluster.New(&scheduler, &cluster.MapStorage{}, "")
+	s.p.cluster = clusterInstance
+	c.Assert(err, check.IsNil)
+	server1, err := testing.NewServer("127.0.0.1:0", nil, nil)
+	c.Assert(err, check.IsNil)
+	defer server1.Stop()
+	err = clusterInstance.Register(cluster.Node{
+		Address:  server1.URL(),
+		Metadata: map[string]string{"pool": "test-default"},
+	})
+	c.Assert(err, check.IsNil)
+	opts := docker.CreateContainerOptions{Name: cont1.Name}
+	node, err := scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web", UpdateName: true})
+	c.Assert(err, check.IsNil)
+	c.Assert(opts.Name, check.Not(check.Equals), cont1.Name)
+	c.Assert(node.Address, check.Equals, server1.URL())
+	var dbConts []container.Container
+	err = contColl.Find(nil).All(&dbConts)
+	c.Assert(err, check.IsNil)
+	c.Assert(dbConts, check.HasLen, 1)
+	c.Assert(dbConts[0].Name, check.Equals, opts.Name)
+	c.Assert(dbConts[0].HostAddr, check.Equals, "127.0.0.1")
 }
 
 func (s *S) TestSchedulerScheduleNoName(c *check.C) {
@@ -128,7 +162,7 @@ func (s *S) TestSchedulerScheduleNoName(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{}
-	node, err := scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
+	node, err := scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	c.Check(node.Address, check.Equals, server1.URL())
 	container, err := s.p.GetContainer(cont1.ID)
@@ -151,7 +185,7 @@ func (s *S) TestSchedulerNoNodes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{}
 	schedOpts := &container.SchedulerOpts{AppName: app.Name, ProcessName: "web"}
-	node, err := scheduler.Schedule(clusterInstance, opts, schedOpts)
+	node, err := scheduler.Schedule(clusterInstance, &opts, schedOpts)
 	c.Assert(node.Address, check.Equals, "")
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, "error in scheduler: No nodes found with one of the following metadata: pool=mypool")
@@ -206,7 +240,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwareness(c *check.C) {
 		opts := docker.CreateContainerOptions{
 			Name: cont.Name,
 		}
-		node, schedErr := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+		node, schedErr := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 		c.Assert(schedErr, check.IsNil)
 		c.Assert(node, check.NotNil)
 	}
@@ -228,7 +262,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwareness(c *check.C) {
 	opts := docker.CreateContainerOptions{
 		Name: cont.Name,
 	}
-	node, err := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+	node, err := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 	c.Assert(err, check.ErrorMatches, `.*no nodes found with enough memory for container of "oblivion": 0.0191MB.*`)
 	c.Assert(node, check.DeepEquals, cluster.Node{})
 }
@@ -297,7 +331,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
 		opts := docker.CreateContainerOptions{
 			Name: cont.Name,
 		}
-		node, schedErr := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+		node, schedErr := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 		c.Assert(schedErr, check.IsNil)
 		c.Assert(node, check.NotNil)
 	}
@@ -319,7 +353,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScale(c *check.C) {
 	opts := docker.CreateContainerOptions{
 		Name: cont.Name,
 	}
-	node, err := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+	node, err := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 	c.Assert(err, check.IsNil)
 	c.Assert(node, check.NotNil)
 	c.Assert(logBuf.String(), check.Matches, `(?s).*WARNING: no nodes found with enough memory for container of "oblivion": 0.0191MB.*`)
@@ -386,7 +420,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScaleDisabledForPool
 		opts := docker.CreateContainerOptions{
 			Name: cont.Name,
 		}
-		node, schedErr := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+		node, schedErr := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 		c.Assert(schedErr, check.IsNil)
 		c.Assert(node, check.NotNil)
 	}
@@ -408,7 +442,7 @@ func (s *S) TestSchedulerScheduleWithMemoryAwarenessWithAutoScaleDisabledForPool
 	opts := docker.CreateContainerOptions{
 		Name: cont.Name,
 	}
-	node, err := segSched.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
+	node, err := segSched.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: cont.AppName, ProcessName: "web"})
 	c.Assert(err, check.ErrorMatches, `.*no nodes found with enough memory for container of "oblivion": 0.0191MB.*`)
 	c.Assert(node, check.DeepEquals, cluster.Node{})
 }
@@ -800,16 +834,16 @@ func (s *S) TestGetRemovableContainer(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	opts := docker.CreateContainerOptions{Name: cont1.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont1.ProcessName})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont1.ProcessName})
 	c.Assert(err, check.IsNil)
 	opts = docker.CreateContainerOptions{Name: cont2.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont2.ProcessName})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a1.Name, ProcessName: cont2.ProcessName})
 	c.Assert(err, check.IsNil)
 	opts = docker.CreateContainerOptions{Name: cont3.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: cont3.ProcessName})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: cont3.ProcessName})
 	c.Assert(err, check.IsNil)
 	opts = docker.CreateContainerOptions{Name: cont4.Name}
-	_, err = scheduler.Schedule(clusterInstance, opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: cont4.ProcessName})
+	_, err = scheduler.Schedule(clusterInstance, &opts, &container.SchedulerOpts{AppName: a2.Name, ProcessName: cont4.ProcessName})
 	c.Assert(err, check.IsNil)
 	cont, err := scheduler.GetRemovableContainer(a1.Name, "web")
 	c.Assert(err, check.IsNil)

--- a/vendor/github.com/tsuru/docker-cluster/cluster/cluster_test.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/cluster_test.go
@@ -88,7 +88,7 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := docker.CreateContainerOptions{}
-	node, err = scheduler.Schedule(cluster, opts, nil)
+	node, err = scheduler.Schedule(cluster, &opts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,14 +99,14 @@ func TestRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	node, err = scheduler.Schedule(cluster, opts, nil)
+	node, err = scheduler.Schedule(cluster, &opts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if node.Address != "http://localhost2:4243" {
 		t.Errorf("Register failed. Got wrong ID. Want %q. Got %q.", "http://localhost2:4243", node.Address)
 	}
-	node, err = scheduler.Schedule(cluster, opts, nil)
+	node, err = scheduler.Schedule(cluster, &opts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +340,7 @@ func TestUnregister(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := docker.CreateContainerOptions{}
-	_, err = scheduler.Schedule(cluster, opts, nil)
+	_, err = scheduler.Schedule(cluster, &opts, nil)
 	if err == nil || err.Error() != "No nodes available" {
 		t.Fatal("Expected no nodes available error")
 	}

--- a/vendor/github.com/tsuru/docker-cluster/cluster/container.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/container.go
@@ -42,7 +42,7 @@ func (c *Cluster) CreateContainerSchedulerOpts(opts docker.CreateContainerOption
 	maxTries := 5
 	for ; maxTries > 0; maxTries-- {
 		if useScheduler {
-			node, scheduleErr := c.scheduler.Schedule(c, opts, schedulerOpts)
+			node, scheduleErr := c.scheduler.Schedule(c, &opts, schedulerOpts)
 			if scheduleErr != nil {
 				if err != nil {
 					scheduleErr = fmt.Errorf("Error in scheduler after previous errors (%s) trying to create container: %s", err.Error(), scheduleErr.Error())

--- a/vendor/github.com/tsuru/docker-cluster/cluster/container_test.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/container_test.go
@@ -482,7 +482,7 @@ func TestCreateContainerWithStorage(t *testing.T) {
 
 type firstNodeScheduler struct{}
 
-func (firstNodeScheduler) Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
+func (firstNodeScheduler) Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
 	var node Node
 	nodes, err := c.Nodes()
 	if err != nil {

--- a/vendor/github.com/tsuru/docker-cluster/cluster/race_test.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/race_test.go
@@ -23,13 +23,13 @@ func TestRoundRobinScheduleIsRaceFree(t *testing.T) {
 	}
 	c.Register(Node{Address: "url1"})
 	c.Register(Node{Address: "url2"})
-	opts := docker.CreateContainerOptions{Config: &docker.Config{}}
 	var wg sync.WaitGroup
 	wg.Add(8)
 	for i := 0; i < tasks; i++ {
 		go func() {
 			defer wg.Done()
-			node, err := c.scheduler.Schedule(c, opts, nil)
+			opts := docker.CreateContainerOptions{Config: &docker.Config{}}
+			node, err := c.scheduler.Schedule(c, &opts, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/vendor/github.com/tsuru/docker-cluster/cluster/scheduler.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/scheduler.go
@@ -21,7 +21,7 @@ type SchedulerOptions interface{}
 type Scheduler interface {
 	// Schedule creates a new container, returning the ID of the node where
 	// the container is running, and the container, or an error.
-	Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error)
+	Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error)
 }
 
 type roundRobin struct {
@@ -29,7 +29,7 @@ type roundRobin struct {
 	once     sync.Once
 }
 
-func (s *roundRobin) Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
+func (s *roundRobin) Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
 	nodes, _ := c.Nodes()
 	if len(nodes) == 0 {
 		return Node{}, errors.New("No nodes available")

--- a/vendor/github.com/tsuru/docker-cluster/cluster/scheduler_test.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/scheduler_test.go
@@ -18,18 +18,18 @@ func TestRoundRobinSchedule(t *testing.T) {
 	c.Register(Node{Address: "url1"})
 	c.Register(Node{Address: "url2"})
 	opts := docker.CreateContainerOptions{Config: &docker.Config{}}
-	node, err := c.scheduler.Schedule(c, opts, nil)
+	node, err := c.scheduler.Schedule(c, &opts, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	if node.Address != "url1" {
 		t.Errorf("roundRobin.Schedule(): wrong node ID. Want %q. Got %q.", "url1", node.Address)
 	}
-	node, _ = c.scheduler.Schedule(c, opts, nil)
+	node, _ = c.scheduler.Schedule(c, &opts, nil)
 	if node.Address != "url2" {
 		t.Errorf("roundRobin.Schedule(): wrong node ID. Want %q. Got %q.", "url2", node.Address)
 	}
-	node, _ = c.scheduler.Schedule(c, opts, nil)
+	node, _ = c.scheduler.Schedule(c, &opts, nil)
 	if node.Address != "url1" {
 		t.Errorf("roundRobin.Schedule(): wrong node ID. Want %q. Got %q.", "url1", node.Address)
 	}
@@ -42,7 +42,7 @@ func TestScheduleEmpty(t *testing.T) {
 	}
 	expected := "No nodes available"
 	opts := docker.CreateContainerOptions{Config: &docker.Config{}}
-	_, err = c.scheduler.Schedule(c, opts, nil)
+	_, err = c.scheduler.Schedule(c, &opts, nil)
 	if err == nil || err.Error() != expected {
 		t.Fatalf("Schedule(): wrong error message. Want %q. Got %q.", expected, err)
 	}

--- a/vendor/github.com/tsuru/docker-cluster/cluster/types_test.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/types_test.go
@@ -88,13 +88,13 @@ func (failingStorage) UnlockNode(address string) error {
 
 type fakeScheduler struct{}
 
-func (fakeScheduler) Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
+func (fakeScheduler) Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
 	return Node{}, nil
 }
 
 type failingScheduler struct{}
 
-func (failingScheduler) Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
+func (failingScheduler) Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
 	return Node{}, errors.New("Cannot schedule")
 }
 
@@ -102,7 +102,7 @@ type optsScheduler struct {
 	roundRobin
 }
 
-func (s *optsScheduler) Schedule(c *Cluster, opts docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
+func (s *optsScheduler) Schedule(c *Cluster, opts *docker.CreateContainerOptions, schedulerOpts SchedulerOptions) (Node, error) {
 	optStr := schedulerOpts.(string)
 	if optStr != "myOpt" {
 		return Node{}, fmt.Errorf("Invalid option %s", optStr)


### PR DESCRIPTION
This avoids the possibility of having multiple containers with the same
name in different nodes due to docker cluster retrying container creation.