### PR TITLE
Makefile: disable gotype linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TSR_PKGS = $$(go list ./... | grep -v /vendor/)
 LINTER_ARGS_SLOW = \
 	-j 4 --enable-gc -s vendor -e '.*/vendor/.*' --vendor --enable=misspell --enable=gofmt --enable=goimports --enable=unused \
 	--disable=dupl --disable=gocyclo --disable=errcheck --disable=golint --disable=interfacer --disable=gas \
-	--disable=structcheck --deadline=60m --tests
+	--disable=structcheck --disable=gotype --deadline=60m --tests
 
 LINTER_ARGS = \
 	$(LINTER_ARGS_SLOW) --disable=staticcheck --disable=unused --disable=gosimple


### PR DESCRIPTION
As reported in alecthomas/gometalinter#355, gotype is throwing false positives
for _test pkgs and for function redefinition in different build tags. Examples:

```
cmd/open_darwin.go:9:6:error: open redeclared in this block (gotype)
cmd/open.go:11:6:error: other declaration of open (gotype)
service/bind_test.go:5:1:error: package service_test; expected service (gotype)
```