### PR TITLE
cache app routers addrs for app list

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -121,10 +121,6 @@ func minifyApp(app app.App) (miniApp, error) {
 	if err != nil {
 		errorStr = fmt.Sprintf("unable to list app units: %+v", err)
 	}
-	routers, err := app.GetRoutersWithAddr()
-	if err != nil {
-		errorStr = fmt.Sprintf("unable to get app addresses: %+v", err)
-	}
 	ma := miniApp{
 		Name:      app.Name,
 		Pool:      app.Pool,
@@ -132,7 +128,7 @@ func minifyApp(app app.App) (miniApp, error) {
 		TeamOwner: app.TeamOwner,
 		Units:     units,
 		CName:     app.CName,
-		Routers:   routers,
+		Routers:   app.Routers,
 		Lock:      &app.Lock,
 		Tags:      app.Tags,
 		Error:     errorStr,

--- a/router/routertest/router.go
+++ b/router/routertest/router.go
@@ -297,6 +297,9 @@ func (r *fakeRouter) SetBackendAddr(name, addr string) {
 }
 
 func (r *fakeRouter) Addr(name string) (string, error) {
+	if r.failuresByIp[r.GetName()+name] || r.failuresByIp[name] {
+		return "", ErrForcedFailure
+	}
 	backendName, err := router.Retrieve(name)
 	if err != nil {
 		return "", err

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -11,12 +11,14 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 )
 
 type DbDriver struct {
 	TeamService     auth.TeamService
 	PlatformService app.PlatformService
 	PlanService     app.PlanService
+	CacheService    cache.CacheService
 }
 
 var (

--- a/storage/mongodb/cache.go
+++ b/storage/mongodb/cache.go
@@ -1,0 +1,76 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"time"
+
+	"github.com/tsuru/tsuru/db"
+	dbStorage "github.com/tsuru/tsuru/db/storage"
+	"github.com/tsuru/tsuru/types/cache"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type cacheService struct{}
+
+type mongoCacheEntry struct {
+	Key      string `bson:"_id"`
+	Value    string
+	ExpireAt time.Time `bson:",omitempty"`
+}
+
+func cacheCollection(conn *db.Storage) *dbStorage.Collection {
+	c := conn.Collection("cache")
+	// Ideally ExpireAfter would be 0, but due to mgo bug this needs to be at
+	// least a second.
+	c.EnsureIndex(mgo.Index{Key: []string{"expireat"}, ExpireAfter: time.Second})
+	return c
+}
+
+func (s *cacheService) GetAll(keys ...string) ([]cache.CacheEntry, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	var dbEntries []mongoCacheEntry
+	err = cacheCollection(conn).Find(bson.M{"_id": bson.M{"$in": keys}}).All(&dbEntries)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]cache.CacheEntry, len(dbEntries))
+	for i := range dbEntries {
+		entries[i] = cache.CacheEntry(dbEntries[i])
+	}
+	return entries, nil
+}
+
+func (s *cacheService) Get(key string) (cache.CacheEntry, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return cache.CacheEntry{}, err
+	}
+	defer conn.Close()
+	var dbEntry mongoCacheEntry
+	err = cacheCollection(conn).FindId(key).One(&dbEntry)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return cache.CacheEntry{}, cache.ErrEntryNotFound
+		}
+		return cache.CacheEntry{}, err
+	}
+	return cache.CacheEntry(dbEntry), nil
+}
+
+func (s *cacheService) Put(entry cache.CacheEntry) error {
+	conn, err := db.Conn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = cacheCollection(conn).UpsertId(entry.Key, mongoCacheEntry(entry))
+	return err
+}

--- a/storage/mongodb/cache_test.go
+++ b/storage/mongodb/cache_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/storage/storagetest"
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.CacheSuite{
+	CacheService: &cacheService{},
+	CustomSuite: storagetest.CustomSuite{
+		SetUpSuiteFn: func(c *check.C) {
+			config.Set("database:url", "127.0.0.1:27017")
+			config.Set("database:name", "tsuru_storage_mongodb_cache_test")
+		},
+		SetUpTestFn: func(c *check.C) {
+			conn, err := db.Conn()
+			c.Assert(err, check.IsNil)
+			err = dbtest.ClearAllCollections(cacheCollection(conn).Database)
+			c.Assert(err, check.IsNil)
+		},
+		TearDownSuiteFn: func(c *check.C) {
+			conn, err := db.Conn()
+			c.Assert(err, check.IsNil)
+			err = cacheCollection(conn).Database.DropDatabase()
+			c.Assert(err, check.IsNil)
+		},
+	},
+})

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -11,6 +11,7 @@ func init() {
 		TeamService:     &TeamService{},
 		PlatformService: &PlatformService{},
 		PlanService:     &PlanService{},
+		CacheService:    &cacheService{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/suite_test.go
+++ b/storage/mongodb/suite_test.go
@@ -25,7 +25,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("database:url", "127.0.0.1:27017")
-	config.Set("database:name", "tsuru_storage_test")
+	config.Set("database:name", "tsuru_storage_mongodb_test")
 	s.conn, _ = db.Conn()
 	s.TeamService = &TeamService{}
 	s.PlatformService = &PlatformService{}

--- a/storage/storagetest/cache_suite.go
+++ b/storage/storagetest/cache_suite.go
@@ -1,0 +1,94 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"sort"
+	"time"
+
+	"github.com/tsuru/tsuru/types/cache"
+	check "gopkg.in/check.v1"
+)
+
+type CacheSuite struct {
+	CustomSuite
+	CacheService cache.CacheService
+}
+
+func (s *CacheSuite) TestCachePut(c *check.C) {
+	err := s.CacheService.Put(cache.CacheEntry{
+		Key:   "k1",
+		Value: "v1",
+	})
+	c.Assert(err, check.IsNil)
+	entry, err := s.CacheService.Get("k1")
+	c.Assert(err, check.IsNil)
+	c.Assert(entry, check.DeepEquals, cache.CacheEntry{
+		Key:   "k1",
+		Value: "v1",
+	})
+}
+
+func (s *CacheSuite) TestCacheGetNotFound(c *check.C) {
+	entry, err := s.CacheService.Get("k1")
+	c.Assert(err, check.Equals, cache.ErrEntryNotFound)
+	c.Assert(entry, check.DeepEquals, cache.CacheEntry{})
+}
+
+func (s *CacheSuite) TestCacheGetAll(c *check.C) {
+	err := s.CacheService.Put(cache.CacheEntry{
+		Key:   "k1",
+		Value: "v1",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.CacheService.Put(cache.CacheEntry{
+		Key:   "k2",
+		Value: "v2",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.CacheService.Put(cache.CacheEntry{
+		Key:   "k3",
+		Value: "v3",
+	})
+	c.Assert(err, check.IsNil)
+	entries, err := s.CacheService.GetAll("k1", "k3")
+	c.Assert(err, check.IsNil)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Key < entries[j].Key
+	})
+	c.Assert(entries, check.DeepEquals, []cache.CacheEntry{
+		{Key: "k1", Value: "v1"},
+		{Key: "k3", Value: "v3"},
+	})
+	entries, err = s.CacheService.GetAll("kx")
+	c.Assert(err, check.IsNil)
+	c.Assert(entries, check.HasLen, 0)
+}
+
+func (s *CacheSuite) TestCacheExpiration(c *check.C) {
+	err := s.CacheService.Put(cache.CacheEntry{
+		Key:      "k1",
+		Value:    "v1",
+		ExpireAt: time.Now().Add(time.Second),
+	})
+	c.Assert(err, check.IsNil)
+	entry, err := s.CacheService.Get("k1")
+	c.Assert(err, check.IsNil)
+	c.Assert(entry.Value, check.Equals, "v1")
+	timeout := time.After(70 * time.Second)
+	for {
+		_, err = s.CacheService.Get("k1")
+		if err != nil {
+			c.Assert(err, check.Equals, cache.ErrEntryNotFound)
+			break
+		}
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-timeout:
+			c.Fatal("timeout waiting for key to expire")
+		}
+	}
+
+}

--- a/storage/storagetest/custom_suite.go
+++ b/storage/storagetest/custom_suite.go
@@ -1,0 +1,40 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	check "gopkg.in/check.v1"
+)
+
+type CustomSuite struct {
+	SetUpSuiteFn    func(c *check.C)
+	SetUpTestFn     func(c *check.C)
+	TearDownTestFn  func(c *check.C)
+	TearDownSuiteFn func(c *check.C)
+}
+
+func (s *CustomSuite) SetUpSuite(c *check.C) {
+	if s.SetUpSuiteFn != nil {
+		s.SetUpSuiteFn(c)
+	}
+}
+
+func (s *CustomSuite) SetUpTest(c *check.C) {
+	if s.SetUpTestFn != nil {
+		s.SetUpTestFn(c)
+	}
+}
+
+func (s *CustomSuite) TearDownSuite(c *check.C) {
+	if s.TearDownSuiteFn != nil {
+		s.TearDownSuiteFn(c)
+	}
+}
+
+func (s *CustomSuite) TearDownTest(c *check.C) {
+	if s.TearDownTestFn != nil {
+		s.TearDownTestFn(c)
+	}
+}

--- a/types/cache/cache.go
+++ b/types/cache/cache.go
@@ -1,0 +1,27 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cache
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrEntryNotFound = errors.New("cache entry not found")
+)
+
+type CacheEntry struct {
+	Key      string
+	Value    string
+	ExpireAt time.Time
+}
+
+type CacheService interface {
+	GetAll(keys ...string) ([]CacheEntry, error)
+	Get(key string) (CacheEntry, error)
+	Put(entry CacheEntry) error
+}


### PR DESCRIPTION
Cached value is always used in app-list, if not found or empty a cache refresh will be triggered in background.
app-info will always force a new request to the router and update the cache.