### PR TITLE
provision/kubernetes: remove in progress taint from node on add/update

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -31,9 +31,10 @@ import (
 )
 
 const (
-	tsuruLabelPrefix   = "tsuru.io/"
-	replicaDepRevision = "deployment.kubernetes.io/revision"
-	kubeKindReplicaSet = "ReplicaSet"
+	tsuruLabelPrefix     = "tsuru.io/"
+	tsuruInProgressTaint = tsuruLabelPrefix + "inprogress"
+	replicaDepRevision   = "deployment.kubernetes.io/revision"
+	kubeKindReplicaSet   = "ReplicaSet"
 )
 
 var kubeNameRegex = regexp.MustCompile(`(?i)[^a-z0-9.-]`)

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -598,6 +598,15 @@ func (p *kubernetesProvisioner) UpdateNode(opts provision.UpdateNodeOptions) err
 	} else if opts.Enable {
 		node.Spec.Unschedulable = false
 	}
+	taints := node.Spec.Taints
+	for i := 0; i < len(taints); i++ {
+		if taints[i].Key == tsuruInProgressTaint {
+			taints[i] = taints[len(taints)-1]
+			taints = taints[:len(taints)-1]
+			i--
+		}
+	}
+	node.Spec.Taints = taints
 	setNodeMetadata(node, opts.Pool, opts.Metadata)
 	_, err = client.Core().Nodes().Update(node)
 	if err == nil {


### PR DESCRIPTION
This allow us to permit Kubelet to register the node while preventing it
from being used by setting a tsuru.io/inprogress NoSchedule taint.

Once the node is registered in tsuru we ensure this taint is removed.