### PR TITLE
event,api: uses a global targetType for rebalance events without pool filter

### DIFF
--- a/api/node.go
+++ b/api/node.go
@@ -597,16 +597,18 @@ func rebalanceNodesHandler(w http.ResponseWriter, r *http.Request, t auth.Token)
 	params.Force = true
 	var permContexts []permission.PermissionContext
 	var ok bool
+	evtTarget := event.Target{Type: event.TargetTypeGlobal}
 	params.Pool, ok = params.MetadataFilter[provision.PoolMetadataName]
 	if ok {
 		delete(params.MetadataFilter, provision.PoolMetadataName)
 		permContexts = append(permContexts, permission.Context(permission.CtxPool, params.Pool))
+		evtTarget = event.Target{Type: event.TargetTypePool, Value: params.Pool}
 	}
 	if !permission.Check(t, permission.PermNodeUpdateRebalance, permContexts...) {
 		return permission.ErrUnauthorized
 	}
 	evt, err := event.New(&event.Opts{
-		Target:      event.Target{Type: event.TargetTypePool, Value: params.Pool},
+		Target:      evtTarget,
 		Kind:        permission.PermNodeUpdateRebalance,
 		Owner:       t,
 		CustomData:  event.FormToCustomData(r.Form),

--- a/event/event.go
+++ b/event/event.go
@@ -224,6 +224,8 @@ type TargetType string
 
 func GetTargetType(t string) (TargetType, error) {
 	switch t {
+	case "global":
+		return TargetTypeGlobal, nil
 	case "app":
 		return TargetTypeApp, nil
 	case "node":

--- a/event/event.go
+++ b/event/event.go
@@ -85,6 +85,7 @@ var (
 	KindTypePermission = kindType("permission")
 	KindTypeInternal   = kindType("internal")
 
+	TargetTypeGlobal          = TargetType("global")
 	TargetTypeApp             = TargetType("app")
 	TargetTypeNode            = TargetType("node")
 	TargetTypeContainer       = TargetType("container")


### PR DESCRIPTION
Fixes #1761 