### PR TITLE
Improvements to node autoscale routines

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -257,6 +258,14 @@ type Applog struct {
 	Unit    string
 }
 
+type ErrAppNotLocked struct {
+	App string
+}
+
+func (e ErrAppNotLocked) Error() string {
+	return fmt.Sprintf("unable to lock app %q", e.App)
+}
+
 // AcquireApplicationLock acquires an application lock by setting the lock
 // field in the database.  This method is already called by a connection
 // middleware on requests with :app or :appname params that have side-effects.
@@ -292,6 +301,45 @@ func AcquireApplicationLockWait(appName string, owner string, reason string, tim
 			return false, nil
 		case <-time.After(300 * time.Millisecond):
 		}
+	}
+}
+
+func AcquireApplicationLockWaitMany(appNames []string, owner string, reason string, timeout time.Duration) error {
+	lockedApps := make(chan string, len(appNames))
+	errCh := make(chan error, len(appNames))
+	wg := sync.WaitGroup{}
+	for _, appName := range appNames {
+		wg.Add(1)
+		go func(appName string) {
+			defer wg.Done()
+			locked, err := AcquireApplicationLockWait(appName, owner, reason, timeout)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if !locked {
+				errCh <- ErrAppNotLocked{App: appName}
+				return
+			}
+			lockedApps <- appName
+		}(appName)
+	}
+	wg.Wait()
+	close(lockedApps)
+	close(errCh)
+	err := <-errCh
+	if err != nil {
+		for appName := range lockedApps {
+			ReleaseApplicationLock(appName)
+		}
+		return err
+	}
+	return nil
+}
+
+func ReleaseApplicationLockMany(appNames []string) {
+	for _, appName := range appNames {
+		ReleaseApplicationLock(appName)
 	}
 }
 

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -238,27 +238,21 @@ func (a *Config) runScalerInNodes(prov provision.NodeProvisioner, pool string, n
 	}
 	evt.SetLogWriter(a.writer)
 	var retErr error
-	var sResult *ScalerResult
-	var evtNodes []provision.NodeSpec
-	var rule *Rule
+	customData := EventCustomData{}
 	defer func() {
 		if retErr != nil {
 			evt.Logf(retErr.Error())
 		}
-		if (sResult == nil && retErr == nil) || (sResult != nil && sResult.NoAction()) {
+		if (customData.Result == nil && retErr == nil) || (customData.Result != nil && customData.Result.NoAction()) {
 			evt.Logf("nothing to do for %q: %q", provision.PoolMetadataName, pool)
 			evt.Abort()
 		} else {
-			evt.DoneCustomData(retErr, EventCustomData{
-				Result: sResult,
-				Nodes:  evtNodes,
-				Rule:   rule,
-			})
+			evt.DoneCustomData(retErr, customData)
 		}
 	}()
-	rule, err = AutoScaleRuleForMetadata(pool)
+	customData.Rule, err = AutoScaleRuleForMetadata(pool)
 	if err == mgo.ErrNotFound {
-		rule, err = AutoScaleRuleForMetadata("")
+		customData.Rule, err = AutoScaleRuleForMetadata("")
 	}
 	if err != nil {
 		if err != mgo.ErrNotFound {
@@ -268,17 +262,17 @@ func (a *Config) runScalerInNodes(prov provision.NodeProvisioner, pool string, n
 		evt.Logf("no auto scale rule for %s", pool)
 		return
 	}
-	if !rule.Enabled {
+	if !customData.Rule.Enabled {
 		evt.Logf("auto scale rule disabled for %s", pool)
 		return
 	}
-	scaler, err := a.scalerForRule(rule)
+	scaler, err := a.scalerForRule(customData.Rule)
 	if err != nil {
 		retErr = errors.Wrapf(err, "error getting scaler for %s", pool)
 		return
 	}
 	evt.Logf("running scaler %T for %q: %q", scaler, provision.PoolMetadataName, pool)
-	sResult, err = scaler.scale(pool, nodes)
+	customData.Result, err = scaler.scale(pool, nodes)
 	if err != nil {
 		if _, ok := err.(errAppNotLocked); ok {
 			evt.Logf("aborting scaler for now, gonna retry later: %s", err)
@@ -287,29 +281,28 @@ func (a *Config) runScalerInNodes(prov provision.NodeProvisioner, pool string, n
 		retErr = errors.Wrapf(err, "error scaling group %s", pool)
 		return
 	}
-	if sResult.ToAdd > 0 {
-		evt.Logf("running event \"add\" for %q: %#v", pool, sResult)
-		evtNodes, err = a.addMultipleNodes(evt, prov, pool, nodes, sResult.ToAdd)
+	if customData.Result.ToAdd > 0 {
+		evt.Logf("running event \"add\" for %q: %#v", pool, customData.Result)
+		customData.Nodes, err = a.addMultipleNodes(evt, prov, pool, nodes, customData.Result.ToAdd)
 		if err != nil {
-			if len(evtNodes) == 0 {
+			if len(customData.Nodes) == 0 {
 				retErr = err
-				return
 			}
 			evt.Logf("not all required nodes were created: %s", err)
 		}
-	} else if len(sResult.ToRemove) > 0 {
-		evt.Logf("running event \"remove\" for %q: %#v", pool, sResult)
-		evtNodes = sResult.ToRemove
-		err = a.removeMultipleNodes(evt, prov, sResult.ToRemove)
+	} else if len(customData.Result.ToRemove) > 0 {
+		evt.Logf("running event \"remove\" for %q: %#v", pool, customData.Result)
+		customData.Nodes = customData.Result.ToRemove
+		err = a.removeMultipleNodes(evt, prov, customData.Result.ToRemove)
 		if err != nil {
 			retErr = err
 			return
 		}
 	}
-	if !rule.PreventRebalance {
-		err := a.rebalanceIfNeeded(evt, prov, pool, nodes, sResult)
+	if !customData.Rule.PreventRebalance {
+		err := a.rebalanceIfNeeded(evt, prov, pool, nodes, &customData)
 		if err != nil {
-			if sResult.IsRebalanceOnly() {
+			if customData.Result.IsRebalanceOnly() {
 				retErr = err
 			} else {
 				evt.Logf("unable to rebalance: %s", err.Error())
@@ -318,8 +311,8 @@ func (a *Config) runScalerInNodes(prov provision.NodeProvisioner, pool string, n
 	}
 }
 
-func (a *Config) rebalanceIfNeeded(evt *event.Event, prov provision.NodeProvisioner, pool string, nodes []provision.Node, sResult *ScalerResult) error {
-	if len(sResult.ToRemove) > 0 {
+func (a *Config) rebalanceIfNeeded(evt *event.Event, prov provision.NodeProvisioner, pool string, nodes []provision.Node, customData *EventCustomData) error {
+	if len(customData.Result.ToRemove) > 0 {
 		return nil
 	}
 	rebalanceProv, ok := prov.(provision.NodeRebalanceProvisioner)
@@ -329,11 +322,11 @@ func (a *Config) rebalanceIfNeeded(evt *event.Event, prov provision.NodeProvisio
 	buf := safe.NewBuffer(nil)
 	writer := io.MultiWriter(buf, evt)
 	shouldRebalance, err := rebalanceProv.RebalanceNodes(provision.RebalanceNodesOptions{
-		Force:  sResult.ToAdd > 0,
+		Force:  len(customData.Nodes) > 0,
 		Pool:   pool,
 		Writer: writer,
 	})
-	sResult.ToRebalance = shouldRebalance
+	customData.Result.ToRebalance = shouldRebalance
 	if err != nil {
 		return errors.Wrapf(err, "unable to rebalance containers. log: %s", buf.String())
 	}

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -327,7 +327,7 @@ func (a *Config) rebalanceIfNeeded(evt *event.Event, prov provision.NodeProvisio
 	buf := safe.NewBuffer(nil)
 	writer := io.MultiWriter(buf, evt)
 	shouldRebalance, err := rebalanceProv.RebalanceNodes(provision.RebalanceNodesOptions{
-		Force:  false,
+		Force:  sResult.ToAdd > 0,
 		Pool:   pool,
 		Writer: writer,
 	})

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -28,6 +28,8 @@ import (
 
 const (
 	EventKind = "autoscale"
+
+	lockWaitTimeout = 10 * time.Second
 )
 
 var globalConfig *Config
@@ -527,7 +529,7 @@ func preciseUnitsByNode(pool string, nodes []provision.Node) (map[string][]provi
 	}
 	for _, a := range appsInPool {
 		var locked bool
-		locked, err = app.AcquireApplicationLock(a.Name, app.InternalAppName, "node auto scale")
+		locked, err = app.AcquireApplicationLockWait(a.Name, app.InternalAppName, "node auto scale", lockWaitTimeout)
 		if err != nil {
 			return nil, err
 		}

--- a/autoscale/autoscale_test.go
+++ b/autoscale/autoscale_test.go
@@ -133,7 +133,7 @@ func (s *S) TestAutoScaleConfigRunOnce(c *check.C) {
 				"_id": "http://n2:2",
 			}},
 		},
-		LogMatches: `(?s).*running scaler.*countScaler.*pool1.*new machine created.*`,
+		LogMatches: `(?s).*running scaler.*countScaler.*pool1.*new machine created.*rebalancing - dry: false, force: true.*`,
 	}, eventtest.HasEvent)
 	err = a.runOnce()
 	c.Assert(err, check.IsNil)
@@ -378,6 +378,7 @@ func (s *S) TestAutoScaleConfigRunRebalanceOnly(c *check.C) {
 			"result.toadd":       0,
 			"result.torebalance": true,
 		},
+		LogMatches: `(?s).*running scaler.*countScaler.*pool1.*rebalancing - dry: false, force: false.*`,
 	}, eventtest.HasEvent)
 	u0, err := nodes[0].Units()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
* Force rebalance if nodes were added as there's no need for the provisioner to check if a rebalance is necessary, with a new empty node it'll always be necessary;
* Wait application lock for a few seconds when calculating units in nodes for autoscale and rebalance, and also when running rebalance;
* When running autoscale checks, try checking if a rebalance is necessary even if new nodes were necessary but adding them failed.

Fixes #1759