### PR TITLE
provision/swarm: use network mode specified in node container

### DIFF
--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -487,6 +487,11 @@ func serviceSpecForNodeContainer(config *nodecontainer.NodeContainerConfig, pool
 			Placement: &swarm.Placement{Constraints: constraints},
 		},
 	}
+	if config.HostConfig.NetworkMode != "" {
+		service.TaskTemplate.Networks = []swarm.NetworkAttachmentConfig{
+			{Target: config.HostConfig.NetworkMode},
+		}
+	}
 	return service, nil
 }
 

--- a/provision/swarm/docker_test.go
+++ b/provision/swarm/docker_test.go
@@ -248,6 +248,13 @@ func (s *S) TestServiceSpecForNodeContainer(c *check.C) {
 	constraints := sort.StringSlice(serviceSpec.TaskTemplate.Placement.Constraints)
 	constraints.Sort()
 	c.Assert([]string(constraints), check.DeepEquals, []string{"node.labels.tsuru.pool != p1", "node.labels.tsuru.pool != p2"})
+	loadedC1.HostConfig.NetworkMode = "host"
+	serviceSpec, err = serviceSpecForNodeContainer(loadedC1, "", servicecommon.PoolFilter{})
+	c.Assert(err, check.IsNil)
+	c.Assert(serviceSpec.TaskTemplate.Networks, check.DeepEquals, []swarm.NetworkAttachmentConfig{
+		{Target: "host"},
+	})
+
 }
 
 func tmpFileWith(c *check.C, contents []byte) string {


### PR DESCRIPTION
This prevented BS container from working correctly with swarm.