### PR TITLE
Include public pools in app creation error

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1001,8 +1001,12 @@ func (app *App) getPoolForApp(poolName string) (string, error) {
 			return "", err
 		}
 		if len(pools) > 1 {
+			publicPools, err := pool.ListPublicPools()
+			if err != nil {
+				return "", err
+			}
 			var names []string
-			for _, p := range pools {
+			for _, p := range append(pools, publicPools...) {
 				names = append(names, fmt.Sprintf("%q", p.Name))
 			}
 			return "", errors.Errorf("you have access to %s pools. Please choose one in app creation", strings.Join(names, ","))

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4021,13 +4021,16 @@ func (s *S) TestAppSetPoolManyPools(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = pool.AddTeamsToPool("pool2", []string{"test"})
 	c.Assert(err, check.IsNil)
+	opts = pool.AddPoolOptions{Name: "pool3", Public: true}
+	err = pool.AddPool(opts)
+	c.Assert(err, check.IsNil)
 	app := App{
 		Name:      "test",
 		TeamOwner: "test",
 	}
 	err = app.SetPool()
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "you have access to \"test\",\"pool2\" pools. Please choose one in app creation")
+	c.Assert(err.Error(), check.Equals, "you have access to \"test\",\"pool2\",\"pool1\",\"pool3\" pools. Please choose one in app creation")
 }
 
 func (s *S) TestAppSetPoolNoDefault(c *check.C) {

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -385,6 +385,10 @@ func ListAllPools() ([]Pool, error) {
 	return listPools(nil)
 }
 
+func ListPublicPools() ([]Pool, error) {
+	return getPoolsSatisfyConstraints(true, "team", "*")
+}
+
 func ListPossiblePools(teams []string) ([]Pool, error) {
 	return getPoolsSatisfyConstraints(false, "team", teams...)
 }


### PR DESCRIPTION
I tried to list the public constraints, but in some test, the pool `pool1` are showing with the team's pools. But it is not initialized in the test scope, maybe it has a global behaviour, but I don't know.

Any suggestion?

Ref https://github.com/tsuru/tsuru/issues/1782