### PR TITLE
.travis: remove unnecessary before scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,23 +21,6 @@ jobs:
     - go: master
   include:
     - stage: test
-      before_script:
-        - rsyslogd &
-        - sleep 1
-      before_install:
-        - git fetch --unshallow || true
-        - sleep 15
-        - sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
-        - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
-        - sudo ifconfig
-        - sudo sysctl -a | grep ipv6.conf
-        - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-        - echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
-        - sudo apt-get -qq update
-        - sudo apt-get install -y mongodb-org
-        - sudo service mongod start || true
-        - service mongod status
-        - go env && pwd
       script: make test
     - stage: lint
       script:


### PR DESCRIPTION
This was causing errors trying to use a different mongodb version