### PR TITLE
provision/kubernetes: adds iaasID to node.Spec.ProviderID

### DIFF
--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -481,6 +481,7 @@ func setNodeMetadata(node *apiv1.Node, pool, iaasID string, meta map[string]stri
 		delete(node.Annotations, k)
 		node.Labels[k] = v
 	}
+	node.Spec.ProviderID = iaasID
 }
 
 func (p *kubernetesProvisioner) AddNode(opts provision.AddNodeOptions) error {


### PR DESCRIPTION
This makes easier to integrate with cloudproviders.