### PR TITLE
Only remove pool metadata after creating machine in iaas

### DIFF
--- a/api/iaas_test.go
+++ b/api/iaas_test.go
@@ -31,6 +31,9 @@ func (TestIaaS) CreateMachine(params map[string]string) (*iaas.Machine, error) {
 		Status:  "running",
 		Address: params["id"] + ".somewhere.com",
 	}
+	if params["pool"] != "" {
+		m.Id += "-" + params["pool"]
+	}
 	return &m, nil
 }
 

--- a/api/node.go
+++ b/api/node.go
@@ -64,6 +64,7 @@ func addNodeForParams(p provision.NodeProvisioner, params provision.AddNodeOptio
 		params.ClientKey = m.ClientKey
 		params.IaaSID = m.Id
 	}
+	delete(params.Metadata, provision.PoolMetadataName)
 	prov, _, err := provision.FindNode(address)
 	if err != provision.ErrNodeNotFound {
 		if err == nil {
@@ -109,7 +110,6 @@ func addNodeHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		}
 	}
 	params.Pool = params.Metadata[provision.PoolMetadataName]
-	delete(params.Metadata, provision.PoolMetadataName)
 	params.IaaSID = params.Metadata[provision.IaaSIDMetadataName]
 	delete(params.Metadata, provision.IaaSIDMetadataName)
 	if params.Pool == "" {

--- a/api/node.go
+++ b/api/node.go
@@ -52,7 +52,7 @@ func addNodeForParams(p provision.NodeProvisioner, params provision.AddNodeOptio
 		address = params.Metadata["address"]
 		delete(params.Metadata, "address")
 	} else {
-		desc, _ := iaas.Describe(params.Metadata["iaas"])
+		desc, _ := iaas.Describe(params.Metadata[provision.IaaSMetadataName])
 		response["description"] = desc
 		m, err := iaas.CreateMachine(params.Metadata)
 		if err != nil {

--- a/api/node_test.go
+++ b/api/node_test.go
@@ -145,11 +145,11 @@ func (s *S) TestAddNodeHandlerCreatingAnIaasMachine(c *check.C) {
 	c.Assert(nodes, check.HasLen, 1)
 	c.Assert(nodes[0].Address(), check.Equals, "http://test1.somewhere.com:2375")
 	c.Assert(nodes[0].Pool(), check.Equals, "pool1")
-	c.Assert(nodes[0].IaaSID(), check.Equals, "test1")
+	c.Assert(nodes[0].IaaSID(), check.Equals, "test1-pool1")
 	c.Assert(nodes[0].Metadata(), check.DeepEquals, map[string]string{
 		"id":      "test1",
 		"iaas":    "test-iaas",
-		"iaas-id": "test1",
+		"iaas-id": "test1-pool1",
 	})
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: event.TargetTypeNode, Value: "http://test1.somewhere.com:2375"},

--- a/autoscale/autoscale.go
+++ b/autoscale/autoscale.go
@@ -360,11 +360,11 @@ func (a *Config) addNode(evt *event.Event, prov provision.NodeProvisioner, pool 
 	if err != nil {
 		return nil, err
 	}
-	_, hasIaas := metadata["iaas"]
+	_, hasIaas := metadata[provision.IaaSMetadataName]
 	if !hasIaas {
 		return nil, errors.Errorf("no IaaS information in nodes metadata: %#v", metadata)
 	}
-	machine, err := iaas.CreateMachineForIaaS(metadata["iaas"], metadata)
+	machine, err := iaas.CreateMachineForIaaS(metadata[provision.IaaSMetadataName], metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create machine")
 	}
@@ -396,7 +396,7 @@ func (a *Config) removeMultipleNodes(evt *event.Event, prov provision.NodeProvis
 	nodeAddrs := make([]string, len(chosenNodes))
 	nodeHosts := make([]string, len(chosenNodes))
 	for i, node := range chosenNodes {
-		_, hasIaas := node.Metadata["iaas"]
+		_, hasIaas := node.Metadata[provision.IaaSMetadataName]
 		if !hasIaas {
 			return errors.Errorf("no IaaS information in node (%s) metadata: %#v", node.Address, node.Metadata)
 		}

--- a/healer/healer_node.go
+++ b/healer/healer_node.go
@@ -107,7 +107,7 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 	if isHealthNode {
 		failures = healthNode.FailureCount()
 	}
-	machine, err := iaas.CreateMachineForIaaS(newNodeMetadata["iaas"], newNodeMetadata)
+	machine, err := iaas.CreateMachineForIaaS(newNodeMetadata[provision.IaaSMetadataName], newNodeMetadata)
 	if err != nil {
 		if isHealthNode {
 			healthNode.ResetFailures()
@@ -179,7 +179,7 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 }
 
 func (h *NodeHealer) tryHealingNode(node provision.Node, reason string, lastCheck *NodeChecks) error {
-	_, hasIaas := node.MetadataNoPrefix()["iaas"]
+	_, hasIaas := node.MetadataNoPrefix()[provision.IaaSMetadataName]
 	if !hasIaas {
 		log.Debugf("node %q doesn't have IaaS information, healing (%s) won't run on it.", node.Address(), reason)
 		return nil

--- a/provision/node.go
+++ b/provision/node.go
@@ -15,6 +15,7 @@ import (
 const (
 	PoolMetadataName   = "pool"
 	IaaSIDMetadataName = "iaas-id"
+	IaaSMetadataName   = "iaas"
 )
 
 type MetaWithFrequency struct {


### PR DESCRIPTION
This fixes machines being created without the `<pool>-` prefix.