### PR TITLE
Forbidding the pool change if the new pool has a different provisioner

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -459,6 +459,19 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 			return permission.ErrUnauthorized
 		}
 	}
+	if updateData.Pool != "" {
+		currentPool, err := pool.GetPoolByName(a.GetPool())
+		if err != nil {
+			return err
+		}
+		newPool, err := pool.GetPoolByName(updateData.Pool)
+		if err != nil {
+			return err
+		}
+		if currentPool.Provisioner != newPool.Provisioner {
+			return &errors.HTTP{Code: http.StatusForbidden, Message: "Moving apps between pools belonging to different provisioners is not alllowed"}
+		}
+	}
 	evt, err := event.New(&event.Opts{
 		Target:     appTarget(appName),
 		Kind:       permission.PermAppUpdate,

--- a/api/app.go
+++ b/api/app.go
@@ -392,7 +392,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 // produce: application/x-json-stream
 // responses:
 //   200: App updated
-//	 400: Invalid new pool
+//   400: Invalid new pool
 //   401: Unauthorized
 //   404: Not found
 func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
@@ -470,7 +470,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 			return err
 		}
 		if currentPool.Provisioner != newPool.Provisioner {
-			return &errors.HTTP{Code: http.StatusBadRequest, Message: "Moving apps between pools belonging to different provisioners is not alllowed"}
+			return &errors.HTTP{Code: http.StatusBadRequest, Message: "Moving apps between pools belonging to different provisioners is not allowed"}
 		}
 	}
 	evt, err := event.New(&event.Opts{

--- a/api/app.go
+++ b/api/app.go
@@ -392,6 +392,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 // produce: application/x-json-stream
 // responses:
 //   200: App updated
+//	 400: Invalid new pool
 //   401: Unauthorized
 //   404: Not found
 func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
@@ -469,7 +470,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 			return err
 		}
 		if currentPool.Provisioner != newPool.Provisioner {
-			return &errors.HTTP{Code: http.StatusForbidden, Message: "Moving apps between pools belonging to different provisioners is not alllowed"}
+			return &errors.HTTP{Code: http.StatusBadRequest, Message: "Moving apps between pools belonging to different provisioners is not alllowed"}
 		}
 	}
 	evt, err := event.New(&event.Opts{

--- a/api/app.go
+++ b/api/app.go
@@ -461,11 +461,12 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 		}
 	}
 	if updateData.Pool != "" {
-		currentPool, err := pool.GetPoolByName(a.GetPool())
+		var currentPool, newPool *pool.Pool
+		currentPool, err = pool.GetPoolByName(a.GetPool())
 		if err != nil {
 			return err
 		}
-		newPool, err := pool.GetPoolByName(updateData.Pool)
+		newPool, err = pool.GetPoolByName(updateData.Pool)
 		if err != nil {
 			return err
 		}

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1649,6 +1649,25 @@ func (s *S) TestUpdateAppPoolWhenAppDoesNotExist(c *check.C) {
 	c.Assert(recorder.Body.String(), check.Matches, "^App not found.\n$")
 }
 
+func (s *S) TestUpdateAppPoolWithDifferentProvisioner(c *check.C) {
+	a := app.App{Name: "myappx", Platform: "zend", TeamOwner: s.team.Name}
+	err := app.CreateApp(&a, s.user)
+	c.Assert(err, check.IsNil)
+	opts := pool.AddPoolOptions{Name: "fakepool", Provisioner: "fakeprovisioner"}
+	err = pool.AddPool(opts)
+	c.Assert(err, check.IsNil)
+	err = pool.AddTeamsToPool("fakepool", []string{s.team.Name})
+	c.Assert(err, check.IsNil)
+	body := strings.NewReader("pool=fakepool&provisioner=fakeprovisioner")
+	request, err := http.NewRequest("PUT", "/apps/myappx", body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusForbidden)
+}
+
 func (s *S) TestUpdateAppPlanOnly(c *check.C) {
 	config.Set("docker:router", "fake")
 	defer config.Unset("docker:router")

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1665,7 +1665,7 @@ func (s *S) TestUpdateAppPoolWithDifferentProvisioner(c *check.C) {
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
-	c.Assert(recorder.Code, check.Equals, http.StatusForbidden)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 
 func (s *S) TestUpdateAppPlanOnly(c *check.C) {


### PR DESCRIPTION
This is the partial fix for #1772  
Could someone please check if I am using the correct HTTP status below?
```go
return &errors.HTTP{Code: http.StatusForbidden, Message: "Moving apps between pools belonging to different provisioners is not alllowed"}
```
I was in doubt between that status and `http.StatusBadRequest`.
I added a test, but I will remove it once I am done with the final solution discussed in #1772 

Should I add the block containing lines 463-473 to the if block in line 437 in `api/app.go`?