### PR TITLE
router/routertest: fix race in router test

### DIFF
--- a/router/routertest/router.go
+++ b/router/routertest/router.go
@@ -300,6 +300,8 @@ func (r *fakeRouter) SetBackendAddr(name, addr string) {
 }
 
 func (r *fakeRouter) Addr(name string) (string, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	if r.failuresByIp[r.GetName()+name] || r.failuresByIp[name] {
 		return "", ErrForcedFailure
 	}
@@ -307,8 +309,6 @@ func (r *fakeRouter) Addr(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
 	if _, ok := r.backends[backendName]; ok {
 		if r.backendAddrs != nil && r.backendAddrs[backendName] != "" {
 			return r.backendAddrs[backendName], nil


### PR DESCRIPTION
==================
WARNING: DATA RACE
Write at 0x000001467538 by goroutine 199:
  github.com/tsuru/tsuru/router/routertest.(*fakeRouter).Reset()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/router/routertest/router.go:326 +0x193
  github.com/tsuru/tsuru/app.(*S).SetUpTest()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/app/suite_test.go:128 +0x4f
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:302 +0xc0
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:721 +0x184
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89

Previous read at 0x000001467538 by goroutine 73:
  github.com/tsuru/tsuru/router/routertest.(*fakeRouter).Addr()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/router/routertest/router.go:303 +0xe3
  github.com/tsuru/tsuru/app.(*App).GetRoutersWithAddr()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/app/app.go:2036 +0x4d7

Goroutine 199 (running) created at:
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:667 +0x42a
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFunc()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:673 +0x7e
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFixture()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:722 +0x7e
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).runFixtureWithPanic()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:735 +0xaa
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:760 +0x1a1
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89

Goroutine 73 (running) created at:
  github.com/tsuru/tsuru/app.loadCachedAddrsInApps()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/app/app.go:1787 +0xe6c
  github.com/tsuru/tsuru/app.List()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/app/app.go:1748 +0xb19
  github.com/tsuru/tsuru/app.(*S).TestListFilteringByNameExact()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/app/app_test.go:3129 +0x664
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:302 +0xc0
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:772 +0xa71
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89
==================