### PR TITLE
api,provision: prevent check for node existence in chosen provisioner

### DIFF
--- a/api/node.go
+++ b/api/node.go
@@ -65,7 +65,7 @@ func addNodeForParams(p provision.NodeProvisioner, params provision.AddNodeOptio
 		params.IaaSID = m.Id
 	}
 	delete(params.Metadata, provision.PoolMetadataName)
-	prov, _, err := provision.FindNode(address)
+	prov, _, err := provision.FindNodeSkipProvisioner(address, p.GetName())
 	if err != provision.ErrNodeNotFound {
 		if err == nil {
 			return "", nil, errors.Errorf("node with address %q already exists in provisioner %q", address, prov.GetName())

--- a/provision/node.go
+++ b/provision/node.go
@@ -56,13 +56,16 @@ func FindNodeByAddrs(p NodeProvisioner, addrs []string) (Node, error) {
 	return node, nil
 }
 
-func FindNode(address string) (Provisioner, Node, error) {
+func FindNodeSkipProvisioner(address string, skipProv string) (Provisioner, Node, error) {
 	provisioners, err := Registry()
 	if err != nil {
 		return nil, nil, err
 	}
 	provErrors := tsuruErrors.NewMultiError()
 	for _, prov := range provisioners {
+		if skipProv != "" && prov.GetName() == skipProv {
+			continue
+		}
 		nodeProv, ok := prov.(NodeProvisioner)
 		if !ok {
 			continue
@@ -81,6 +84,10 @@ func FindNode(address string) (Provisioner, Node, error) {
 		return nil, nil, provErrors
 	}
 	return nil, nil, ErrNodeNotFound
+}
+
+func FindNode(address string) (Provisioner, Node, error) {
+	return FindNodeSkipProvisioner(address, "")
 }
 
 func metadataNoIaasID(n Node) map[string]string {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -465,6 +465,9 @@ func (p *FakeProvisioner) AddNode(opts provision.AddNodeOptions) error {
 	if metadata == nil {
 		metadata = map[string]string{}
 	}
+	if _, ok := p.nodes[opts.Address]; ok {
+		return errors.New("fake node already exists")
+	}
 	p.nodes[opts.Address] = FakeNode{
 		ID:       opts.IaaSID,
 		Addr:     opts.Address,


### PR DESCRIPTION
We don't need to check the chosen provisioner because it's expected that
the Provisioner.AddNode call will already handle duplicated cases and
handler then accordingly.