### PR TITLE
provision/kubernetes: fix node containers with multiple clusters

### DIFF
--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -30,7 +30,7 @@ type nodeContainerManager struct{}
 
 func (m *nodeContainerManager) DeployNodeContainer(config *nodecontainer.NodeContainerConfig, pool string, filter servicecommon.PoolFilter, placementOnly bool) error {
 	err := forEachCluster(func(cluster *clusterClient) error {
-		return m.deployNodeContainerForCluster(cluster, config, pool, filter, placementOnly)
+		return m.deployNodeContainerForCluster(cluster, *config, pool, filter, placementOnly)
 	})
 	if err == cluster.ErrNoCluster {
 		return nil
@@ -38,7 +38,7 @@ func (m *nodeContainerManager) DeployNodeContainer(config *nodecontainer.NodeCon
 	return err
 }
 
-func (m *nodeContainerManager) deployNodeContainerForCluster(client *clusterClient, config *nodecontainer.NodeContainerConfig, pool string, filter servicecommon.PoolFilter, placementOnly bool) error {
+func (m *nodeContainerManager) deployNodeContainerForCluster(client *clusterClient, config nodecontainer.NodeContainerConfig, pool string, filter servicecommon.PoolFilter, placementOnly bool) error {
 	dsName := daemonSetName(config.Name, pool)
 	oldDs, err := client.Extensions().DaemonSets(client.Namespace()).Get(dsName, metav1.GetOptions{})
 	if err != nil {

--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -498,13 +498,13 @@ func serviceSpecForNodeContainer(config *nodecontainer.NodeContainerConfig, pool
 	return service, nil
 }
 
-func upsertService(spec *swarm.ServiceSpec, client *clusterClient, placementOnly bool) (bool, error) {
+func upsertService(spec swarm.ServiceSpec, client *clusterClient, placementOnly bool) (bool, error) {
 	currService, err := client.InspectService(spec.Name)
 	if err != nil {
 		if _, ok := err.(*docker.NoSuchService); !ok {
 			return false, errors.WithStack(err)
 		}
-		opts := docker.CreateServiceOptions{ServiceSpec: *spec}
+		opts := docker.CreateServiceOptions{ServiceSpec: spec}
 		_, errCreate := client.CreateService(opts)
 		if errCreate != nil {
 			return false, errors.WithStack(errCreate)
@@ -513,10 +513,10 @@ func upsertService(spec *swarm.ServiceSpec, client *clusterClient, placementOnly
 	}
 	if placementOnly {
 		currService.Spec.TaskTemplate.Placement = spec.TaskTemplate.Placement
-		spec = &currService.Spec
+		spec = currService.Spec
 	}
 	opts := docker.UpdateServiceOptions{
-		ServiceSpec: *spec,
+		ServiceSpec: spec,
 		Version:     currService.Version.Index,
 	}
 	return false, errors.WithStack(client.UpdateService(currService.ID, opts))

--- a/provision/swarm/provisioner.go
+++ b/provision/swarm/provisioner.go
@@ -797,7 +797,7 @@ func (m *nodeContainerManager) DeployNodeContainer(config *nodecontainer.NodeCon
 		return err
 	}
 	err = forEachCluster(func(client *clusterClient) error {
-		_, upsertErr := upsertService(serviceSpec, client, placementOnly)
+		_, upsertErr := upsertService(*serviceSpec, client, placementOnly)
 		return upsertErr
 	})
 	if err == cluster.ErrNoCluster {


### PR DESCRIPTION
With multiple clusters every bind added to the node container config would
persist on the next cluster since we were modifying a config's pointer.