### PR TITLE
Improve app-list performance

### DIFF
--- a/api/pool_test.go
+++ b/api/pool_test.go
@@ -630,36 +630,6 @@ func (s *S) TestPoolUpdateNotOverwriteDefaultPoolHandler(c *check.C) {
 	c.Assert(recorder.Body.String(), check.Equals, pool.ErrDefaultPoolAlreadyExists.Error()+"\n")
 }
 
-func (s *S) TestPoolUpdateProvisioner(c *check.C) {
-	pool.RemovePool("test1")
-	opts := pool.AddPoolOptions{Name: "pool1", Public: true, Default: true}
-	err := pool.AddPool(opts)
-	c.Assert(err, check.IsNil)
-	b := bytes.NewBufferString("provisioner=myprov&default=false")
-	req, err := http.NewRequest("PUT", "/pools/pool1", b)
-	c.Assert(err, check.IsNil)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	rec := httptest.NewRecorder()
-	s.testServer.ServeHTTP(rec, req)
-	c.Assert(rec.Code, check.Equals, http.StatusOK)
-	c.Assert(err, check.IsNil)
-	p, err := pool.GetPoolByName("pool1")
-	c.Assert(err, check.IsNil)
-	c.Assert(p.Provisioner, check.Equals, "myprov")
-	c.Assert(p.Default, check.Equals, false)
-	c.Assert(eventtest.EventDesc{
-		Target: event.Target{Type: event.TargetTypePool, Value: "pool1"},
-		Owner:  s.token.GetUserName(),
-		Kind:   "pool.update",
-		StartCustomData: []map[string]interface{}{
-			{"name": ":name", "value": "pool1"},
-			{"name": "default", "value": "false"},
-			{"name": "provisioner", "value": "myprov"},
-		},
-	}, eventtest.HasEvent)
-}
-
 func (s *S) TestPoolUpdateNotFound(c *check.C) {
 	b := bytes.NewBufferString("public=true")
 	request, err := http.NewRequest("PUT", "/pools/not-found", b)

--- a/app/app.go
+++ b/app/app.go
@@ -170,20 +170,14 @@ func (app *App) getBuilder() (builder.Builder, error) {
 }
 
 func (app *App) getProvisioner() (provision.Provisioner, error) {
+	var err error
 	if app.provisioner == nil {
 		if app.Pool == "" {
 			return provision.GetDefault()
 		}
-		p, err := pool.GetPoolByName(app.Pool)
-		if err != nil {
-			return nil, err
-		}
-		app.provisioner, err = p.GetProvisioner()
-		if err != nil {
-			return nil, err
-		}
+		app.provisioner, err = pool.GetProvisionerForPool(app.Pool)
 	}
-	return app.provisioner, nil
+	return app.provisioner, err
 }
 
 // Units returns the list of units.

--- a/app/suite_test.go
+++ b/app/suite_test.go
@@ -134,6 +134,7 @@ func (s *S) SetUpTest(c *check.C) {
 	routertest.HCRouter.Reset()
 	routertest.TLSRouter.Reset()
 	routertest.OptsRouter.Reset()
+	pool.ResetCache()
 	err := rebuild.RegisterTask(func(appName string) (rebuild.RebuildApp, error) {
 		a, err := GetByName(appName)
 		if err == ErrAppNotFound {

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -773,14 +773,20 @@ func (p *dockerProvisioner) GetAppFromUnitID(unitID string) (provision.App, erro
 	return a, nil
 }
 
-func (p *dockerProvisioner) Units(app provision.App) ([]provision.Unit, error) {
-	containers, err := p.listContainersByApp(app.GetName())
+func (p *dockerProvisioner) Units(apps ...provision.App) ([]provision.Unit, error) {
+	appNames := make([]string, len(apps))
+	appNameMap := map[string]provision.App{}
+	for i, a := range apps {
+		appNames[i] = a.GetName()
+		appNameMap[a.GetName()] = a
+	}
+	containers, err := p.listContainersByAppAndHost(appNames, nil)
 	if err != nil {
 		return nil, err
 	}
 	units := make([]provision.Unit, len(containers))
 	for i, container := range containers {
-		units[i] = container.AsUnit(app)
+		units[i] = container.AsUnit(appNameMap[container.AppName])
 	}
 	return units, nil
 }

--- a/provision/docker/suite_test.go
+++ b/provision/docker/suite_test.go
@@ -119,6 +119,7 @@ func (s *S) SetUpSuite(c *check.C) {
 }
 
 func (s *S) SetUpTest(c *check.C) {
+	pool.ResetCache()
 	config.Set("docker:api-timeout", 2)
 	iaas.ResetAll()
 	repositorytest.Reset()

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -295,7 +295,19 @@ func (p *kubernetesProvisioner) podsToUnits(client *clusterClient, pods []apiv1.
 	return units, nil
 }
 
-func (p *kubernetesProvisioner) Units(a provision.App) ([]provision.Unit, error) {
+func (p *kubernetesProvisioner) Units(apps ...provision.App) ([]provision.Unit, error) {
+	var units []provision.Unit
+	for _, a := range apps {
+		appUnits, err := p.units(a)
+		if err != nil {
+			return nil, err
+		}
+		units = append(units, appUnits...)
+	}
+	return units, nil
+}
+
+func (p *kubernetesProvisioner) units(a provision.App) ([]provision.Unit, error) {
 	client, err := clusterForPool(a.GetPool())
 	if err != nil {
 		return nil, err

--- a/provision/pool/constraint.go
+++ b/provision/pool/constraint.go
@@ -1,3 +1,7 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package pool
 
 import (

--- a/provision/pool/constraint_test.go
+++ b/provision/pool/constraint_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package pool
 
 import (

--- a/provision/pool/provcache.go
+++ b/provision/pool/provcache.go
@@ -1,0 +1,42 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pool
+
+import (
+	"sync"
+
+	"github.com/tsuru/tsuru/provision"
+)
+
+type poolProvCache struct {
+	sync.RWMutex
+	entries map[string]provision.Provisioner
+}
+
+var poolCache poolProvCache
+
+func ResetCache() {
+	poolCache.Lock()
+	defer poolCache.Unlock()
+	poolCache.entries = nil
+}
+
+func (c *poolProvCache) Get(name string) provision.Provisioner {
+	c.RLock()
+	defer c.RUnlock()
+	if c.entries == nil {
+		return nil
+	}
+	return c.entries[name]
+}
+
+func (c *poolProvCache) Set(name string, prov provision.Provisioner) {
+	c.Lock()
+	defer c.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[string]provision.Provisioner)
+	}
+	c.entries[name] = prov
+}

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -350,7 +350,7 @@ type Provisioner interface {
 	Stop(App, string) error
 
 	// Units returns information about units by App.
-	Units(App) ([]Unit, error)
+	Units(...App) ([]Unit, error)
 
 	// RoutableAddresses returns the addresses used to access an application.
 	RoutableAddresses(App) ([]url.URL, error)

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1210,13 +1210,17 @@ func (p *FakeProvisioner) AddUnit(app provision.App, unit provision.Unit) {
 	p.apps[app.GetName()] = a
 }
 
-func (p *FakeProvisioner) Units(app provision.App) ([]provision.Unit, error) {
+func (p *FakeProvisioner) Units(apps ...provision.App) ([]provision.Unit, error) {
 	if err := p.getError("Units"); err != nil {
 		return nil, err
 	}
 	p.mut.Lock()
 	defer p.mut.Unlock()
-	return p.apps[app.GetName()].units, nil
+	var allUnits []provision.Unit
+	for _, a := range apps {
+		allUnits = append(allUnits, p.apps[a.GetName()].units...)
+	}
+	return allUnits, nil
 }
 
 func (p *FakeProvisioner) RoutableAddresses(app provision.App) ([]url.URL, error) {

--- a/provision/swarm/provisioner.go
+++ b/provision/swarm/provisioner.go
@@ -257,7 +257,19 @@ func tasksToUnits(client *clusterClient, tasks []swarm.Task) ([]provision.Unit, 
 	return units, nil
 }
 
-func (p *swarmProvisioner) Units(a provision.App) ([]provision.Unit, error) {
+func (p *swarmProvisioner) Units(apps ...provision.App) ([]provision.Unit, error) {
+	var units []provision.Unit
+	for _, a := range apps {
+		appUnits, err := p.units(a)
+		if err != nil {
+			return nil, err
+		}
+		units = append(units, appUnits...)
+	}
+	return units, nil
+}
+
+func (p *swarmProvisioner) units(a provision.App) ([]provision.Unit, error) {
 	client, err := clusterForPool(a.GetPool())
 	if err != nil {
 		if errors.Cause(err) == cluster.ErrNoCluster {


### PR DESCRIPTION
The performance degradation comes mainly from querying each provisioner for units of each individual application.

The first part of this PR caches the Provisioner value for each Pool in memory as this value cannot be changed for an existing pool.

The second part involves changing the Provisioner.Units interface method to allow querying units from multiple apps in a single call.
