### PR TITLE
event,provision/docker: fix race updating writer for existing event

### DIFF
--- a/event/event_test.go
+++ b/event/event_test.go
@@ -80,6 +80,7 @@ func (s *S) TestNewDone(c *check.C) {
 		LockUpdateTime: evt.LockUpdateTime,
 		Allowed:        Allowed(permission.PermAppReadEvents),
 	}}
+	expected.Init()
 	c.Assert(evt, check.DeepEquals, expected)
 	evts, err := All()
 	c.Assert(err, check.IsNil)
@@ -133,6 +134,7 @@ func (s *S) TestNewCustomDataDone(c *check.C) {
 		StartCustomData: evt.StartCustomData,
 		Allowed:         Allowed(permission.PermAppReadEvents),
 	}}
+	expected.Init()
 	c.Assert(evt, check.DeepEquals, expected)
 	customData = struct{ A string }{A: "other"}
 	err = evt.DoneCustomData(nil, customData)
@@ -197,6 +199,7 @@ func (s *S) TestNewDoneDisableLock(c *check.C) {
 		LockUpdateTime: evt.LockUpdateTime,
 		Allowed:        Allowed(permission.PermAppReadEvents),
 	}}
+	expected.Init()
 	c.Assert(evt, check.DeepEquals, expected)
 	evts, err := All()
 	c.Assert(err, check.IsNil)
@@ -358,6 +361,7 @@ func (s *S) TestEventDoneError(c *check.C) {
 		Error:          "myerr",
 		Allowed:        Allowed(permission.PermAppReadEvents),
 	}}
+	expected.Init()
 	c.Assert(&evts[0], check.DeepEquals, expected)
 }
 
@@ -1001,6 +1005,7 @@ func (s *S) TestEventRawInsert(c *check.C) {
 		Error:     "err x",
 		Log:       "my log",
 	}}
+	evt.Init()
 	err := evt.RawInsert(nil, nil, nil)
 	c.Assert(err, check.IsNil)
 	evts, err := All()
@@ -1033,6 +1038,7 @@ func (s *S) TestNewWithPermission(c *check.C) {
 			Contexts: []permission.PermissionContext{permission.Context(permission.CtxApp, "myapp"), permission.Context(permission.CtxTeam, "myteam")},
 		},
 	}}
+	expected.Init()
 	c.Assert(evt, check.DeepEquals, expected)
 	evts, err := All()
 	c.Assert(err, check.IsNil)
@@ -1101,6 +1107,7 @@ func (s *S) TestNewCustomDataPtr(c *check.C) {
 		StartCustomData: evt.StartCustomData,
 		Allowed:         Allowed(permission.PermAppReadEvents),
 	}}
+	expected.Init()
 	c.Assert(evt, check.DeepEquals, expected)
 }
 

--- a/event/migrate/migrate_test.go
+++ b/event/migrate/migrate_test.go
@@ -67,6 +67,7 @@ func (s *S) TestMigrateRCEventsNoApp(c *check.C) {
 	now := time.Unix(time.Now().Unix(), 0)
 	id := bson.NewObjectId()
 	var expected event.Event
+	expected.Init()
 	expected.UniqueID = id
 	expected.Target = event.Target{Type: event.TargetTypeApp, Value: "a1"}
 	expected.Owner = event.Owner{Type: event.OwnerTypeUser, Name: "u1"}
@@ -86,6 +87,7 @@ func (s *S) TestMigrateRCEventsWithApp(c *check.C) {
 	now := time.Unix(time.Now().Unix(), 0)
 	id := bson.NewObjectId()
 	var expected event.Event
+	expected.Init()
 	expected.UniqueID = id
 	expected.Target = event.Target{Type: event.TargetTypeApp, Value: "a1"}
 	expected.Owner = event.Owner{Type: event.OwnerTypeUser, Name: "u1"}
@@ -107,6 +109,7 @@ func (s *S) TestMigrateRCEventsInvalidTarget(c *check.C) {
 	now := time.Unix(time.Now().Unix(), 0)
 	id := bson.NewObjectId()
 	var expected event.Event
+	expected.Init()
 	expected.UniqueID = id
 	expected.Target = event.Target{Type: "some-invalid-target", Value: "a1"}
 	expected.Owner = event.Owner{Type: event.OwnerTypeUser, Name: "u1"}

--- a/provision/docker/containers.go
+++ b/provision/docker/containers.go
@@ -194,18 +194,14 @@ func (p *dockerProvisioner) MoveOneContainer(c container.Container, toHost strin
 		fmt.Fprintf(writer, "Moving unit %s for %q from %s%s...\n", c.ID, c.AppName, c.HostAddr, suffix)
 	}
 	toAdd := map[string]*containersToAdd{c.ProcessName: {Quantity: 1, Status: c.ExpectedStatus()}}
-	var oldWriter io.Writer
 	var pipeWriter io.Writer
 	evt, _ := writer.(*event.Event)
 	if evt != nil {
-		oldWriter = evt.GetLogWriter()
-		evt.SetLogWriter(ioutil.Discard)
-		pipeWriter = evt
+		evtClone := *evt
+		evtClone.SetLogWriter(ioutil.Discard)
+		pipeWriter = &evtClone
 	}
 	addedContainers, err := p.runReplaceUnitsPipeline(pipeWriter, a, toAdd, []container.Container{c}, imageID, destHosts...)
-	if evt != nil {
-		evt.SetLogWriter(oldWriter)
-	}
 	if err != nil {
 		errCh <- &tsuruErrors.CompositeError{
 			Base:    err,


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c4221ecda0 by goroutine 320:
  github.com/tsuru/tsuru/event.(*Event).Write()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/event/event.go:941 +0x4b
  fmt.Fprintf()
      /usr/local/go/src/fmt/print.go:182 +0xc7
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).MoveOneContainer()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:194 +0x12b5

Previous write at 0x00c4221ecda0 by goroutine 395:
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).MoveOneContainer()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:202 +0xf8c

Goroutine 320 (running) created at:
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).moveContainerList()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:244 +0x26b
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).rebalanceContainersByFilter()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:304 +0x2ca
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).RebalanceNodes()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/provisioner.go:1210 +0x724
  github.com/tsuru/tsuru/provision/docker.(*S).TestRebalanceNodes()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/provisioner_test.go:3181 +0x103e
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:302 +0xc0
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:772 +0xa71
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89

Goroutine 395 (running) created at:
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).moveContainerList()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:244 +0x26b
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).rebalanceContainersByFilter()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/containers.go:304 +0x2ca
  github.com/tsuru/tsuru/provision/docker.(*dockerProvisioner).RebalanceNodes()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/provisioner.go:1210 +0x724
  github.com/tsuru/tsuru/provision/docker.(*S).TestRebalanceNodes()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/provision/docker/provisioner_test.go:3181 +0x103e
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:514 +0x47
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:302 +0xc0
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:772 +0xa71
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /tmp/gopath/tsuru/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89
==================
```