### PR TITLE
Add information about router info and status to api returns

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -39,7 +39,7 @@ contexts:
 			teams = append(teams, c.Value)
 		}
 	}
-	routers, err := router.List()
+	routers, err := router.ListWithInfo()
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -2103,11 +2103,22 @@ func (app *App) GetRoutersWithAddr() ([]appTypes.AppRouter, error) {
 			multi.Add(err)
 			continue
 		}
+		if statusRouter, ok := r.(router.StatusRouter); ok {
+			status, detail, stErr := statusRouter.GetBackendStatus(app.Name)
+			if stErr != nil {
+				multi.Add(err)
+				continue
+			}
+			routers[i].Status = string(status)
+			routers[i].StatusDetail = detail
+		}
 		cacheService().Put(cache.CacheEntry{
 			Key:   appRouterAddrKey(app.Name, routerName),
 			Value: addr,
 		})
 		routers[i].Address = addr
+		rType, _, _ := router.Type(routerName)
+		routers[i].Type = rType
 	}
 	return routers, multi.ToError()
 }

--- a/router/router.go
+++ b/router/router.go
@@ -52,6 +52,10 @@ func Register(name string, r routerFactory) {
 	routers[name] = r
 }
 
+func Unregister(name string) {
+	delete(routers, name)
+}
+
 func Type(name string) (string, string, error) {
 	prefix := "routers:" + name
 	routerType, err := config.GetString(prefix + ":type")

--- a/router/routertest/router.go
+++ b/router/routertest/router.go
@@ -28,6 +28,11 @@ var InfoRouter = infoRouter{
 	Info:       make(map[string]string),
 }
 
+var StatusRouter = statusRouter{
+	fakeRouter: newFakeRouter(),
+	Status:     router.BackendStatusReady,
+}
+
 var TLSRouter = tlsRouter{
 	fakeRouter: newFakeRouter(),
 	Certs:      make(map[string]string),
@@ -42,6 +47,7 @@ func init() {
 	router.Register("fake-tls", createTLSRouter)
 	router.Register("fake-opts", createOptsRouter)
 	router.Register("fake-info", createInfoRouter)
+	router.Register("fake-status", createStatusRouter)
 }
 
 func createRouter(name, prefix string) (router.Router, error) {
@@ -62,6 +68,10 @@ func createOptsRouter(name, prefix string) (router.Router, error) {
 
 func createInfoRouter(name, prefix string) (router.Router, error) {
 	return &InfoRouter, nil
+}
+
+func createStatusRouter(name, prefix string) (router.Router, error) {
+	return &StatusRouter, nil
 }
 
 func newFakeRouter() fakeRouter {
@@ -458,4 +468,22 @@ func (r *infoRouter) GetInfo() (map[string]string, error) {
 func (r *infoRouter) Reset() {
 	r.fakeRouter.Reset()
 	r.Info = make(map[string]string)
+}
+
+type statusRouter struct {
+	fakeRouter
+	Status       router.BackendStatus
+	StatusDetail string
+}
+
+var _ router.StatusRouter = &statusRouter{}
+
+func (r *statusRouter) GetBackendStatus(name string) (router.BackendStatus, string, error) {
+	return r.Status, r.StatusDetail, nil
+}
+
+func (r *statusRouter) Reset() {
+	r.fakeRouter.Reset()
+	r.Status = router.BackendStatusReady
+	r.StatusDetail = ""
 }

--- a/router/routertest/router.go
+++ b/router/routertest/router.go
@@ -23,6 +23,11 @@ var OptsRouter = optsRouter{
 	Opts:       make(map[string]map[string]string),
 }
 
+var InfoRouter = infoRouter{
+	fakeRouter: newFakeRouter(),
+	Info:       make(map[string]string),
+}
+
 var TLSRouter = tlsRouter{
 	fakeRouter: newFakeRouter(),
 	Certs:      make(map[string]string),
@@ -36,6 +41,7 @@ func init() {
 	router.Register("fake-hc", createHCRouter)
 	router.Register("fake-tls", createTLSRouter)
 	router.Register("fake-opts", createOptsRouter)
+	router.Register("fake-info", createInfoRouter)
 }
 
 func createRouter(name, prefix string) (router.Router, error) {
@@ -52,6 +58,10 @@ func createTLSRouter(name, prefix string) (router.Router, error) {
 
 func createOptsRouter(name, prefix string) (router.Router, error) {
 	return &OptsRouter, nil
+}
+
+func createInfoRouter(name, prefix string) (router.Router, error) {
+	return &InfoRouter, nil
 }
 
 func newFakeRouter() fakeRouter {
@@ -432,4 +442,20 @@ func (r *optsRouter) AddBackendOpts(app router.App, opts map[string]string) erro
 func (r *optsRouter) UpdateBackendOpts(app router.App, opts map[string]string) error {
 	r.Opts[app.GetName()] = opts
 	return nil
+}
+
+type infoRouter struct {
+	fakeRouter
+	Info map[string]string
+}
+
+var _ router.InfoRouter = &infoRouter{}
+
+func (r *infoRouter) GetInfo() (map[string]string, error) {
+	return r.Info, nil
+}
+
+func (r *infoRouter) Reset() {
+	r.fakeRouter.Reset()
+	r.Info = make(map[string]string)
 }

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -5,7 +5,10 @@
 package app
 
 type AppRouter struct {
-	Name    string            `json:"name"`
-	Opts    map[string]string `json:"opts"`
-	Address string            `json:"address" bson:"-"`
+	Name         string            `json:"name"`
+	Opts         map[string]string `json:"opts"`
+	Address      string            `json:"address" bson:"-"`
+	Type         string            `json:"type" bson:"-"`
+	Status       string            `json:"status,omitempty" bson:"-"`
+	StatusDetail string            `json:"status-detail,omitempty" bson:"-"`
 }


### PR DESCRIPTION
This adds router info to /routers (tsuru router-list) calls, and status information to /apps/{} and /apps/{}/routers (app-info, app-router-list).