### PR TITLE
iaas/dockermachine: ensure machine name is valid hostname

### DIFF
--- a/iaas/dockermachine/iaas.go
+++ b/iaas/dockermachine/iaas.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,7 @@ import (
 )
 
 var errDriverNotSet = errors.Errorf("driver is mandatory")
+var invalidHostnameChars = regexp.MustCompile(`[^a-z0-9-]`)
 
 func init() {
 	iaas.RegisterIaasProvider("dockermachine", newDockerMachineIaaS)
@@ -189,6 +191,7 @@ func generateMachineName(prefix string) (string, error) {
 	r := strings.NewReplacer("_", "-", " ", "-")
 	prefix = r.Replace(prefix)
 	prefix = strings.TrimPrefix(prefix, "-")
+	prefix = invalidHostnameChars.ReplaceAllString(prefix, "")
 	name, err := generateRandomID()
 	if err != nil {
 		return "", err

--- a/iaas/dockermachine/iaas_test.go
+++ b/iaas/dockermachine/iaas_test.go
@@ -172,11 +172,12 @@ func (s *S) TestGenerateMachineName(c *check.C) {
 		expectedPrefix string
 		expectedLength int
 	}{
-		{"-abc", "abc", 29},
-		{"a b c", "a-b-c", 31},
-		{"a_b_c", "a-b-c", 31},
-		{"a_b c", "a-b-c", 31},
-		{"-a b_c", "a-b-c", 31},
+		{"-abc", "^abc", 29},
+		{"a b c", "^a-b-c", 31},
+		{"a_b_c", "^a-b-c", 31},
+		{"a_b c", "^a-b-c", 31},
+		{"-a b_c", "^a-b-c", 31},
+		{"-a b_c@d e_f", "^a-b-cd-e-f", 36},
 		{strings.Repeat("a", 80), strings.Repeat("a", 63), 63},
 		{"", "[a-z][a-z0-9]{24}", 25},
 	}


### PR DESCRIPTION
Since the iaas implementation derives the machine name from the pool
and tsuru doesn't ensure that the pool is a valid hostname, the
implementation must strip any invalid character from the pool name
before generating the machine name.