### PR TITLE
provision/docker: mitigate race when a node is removed and added again

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -487,7 +487,7 @@
   branch = "master"
   name = "github.com/tsuru/docker-cluster"
   packages = ["cluster","log","storage","storage/mongodb"]
-  revision = "6310615948a8b4d6b3ac61d0a18c345344db9eba"
+  revision = "9ff8a48c7af77a1d6fbbe49c07a1c9a658ea73ca"
 
 [[projects]]
   name = "github.com/tsuru/gandalf"


### PR DESCRIPTION
The race condition can still happen, however it won't corrupt node pool
metadata information nor the creation status.