### PR TITLE
action: handle panics as errors during pipelines

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -145,7 +145,7 @@ func (p *Pipeline) Execute(params ...interface{}) (err error) {
 	var a *Action
 	defer func() {
 		if r := recover(); r != nil {
-			log.Debugf("[pipeline] PANIC running the Forward for the %s action - %v", a.Name, r)
+			log.Errorf("[pipeline] PANIC running the Forward for the %s action - %v", a.Name, r)
 			err = fmt.Errorf("panic running the Forward for the %s action: %v", a.Name, r)
 			if a.OnError != nil {
 				a.OnError(fwCtx, err)
@@ -167,7 +167,7 @@ func (p *Pipeline) Execute(params ...interface{}) (err error) {
 			fwCtx.Previous = r
 		}
 		if err != nil {
-			log.Debugf("[pipeline] error running the Forward for the %s action - %s", a.Name, err)
+			log.Errorf("[pipeline] error running the Forward for the %s action - %s", a.Name, err)
 			if a.OnError != nil {
 				a.OnError(fwCtx, err)
 			}

--- a/action/stubs_test.go
+++ b/action/stubs_test.go
@@ -23,6 +23,14 @@ var errorAction = Action{
 	Backward: func(ctx BWContext) {},
 }
 
+var panicAction = Action{
+	Name: "panic",
+	Forward: func(ctx FWContext) (Result, error) {
+		panic("action panicked")
+	},
+	Backward: func(ctx BWContext) {},
+}
+
 var unrollbackableAction = Action{
 	Name: "unrollbackable",
 	Forward: func(ctx FWContext) (Result, error) {


### PR DESCRIPTION
Ideally, one action should never panic but this change makes sure we
handle it gracefully (calling the backwards function as when an error occurs)
to minimize the chance of inconsistences.