### PR TITLE
builder/docker: fix race condition in tests

### DIFF
--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/docker/docker/pkg/stdcopy"
 	docker "github.com/fsouza/go-dockerclient"
@@ -232,7 +233,7 @@ func (s *S) TestBuilderImageIDWithProcfile(c *check.C) {
 	imageName := fmt.Sprintf("%s/%s", u.Host, "customimage")
 	config.Set("docker:registry", u.Host)
 	defer config.Unset("docker:registry")
-	attachCounter := 0
+	var attachCounter int32
 	s.server.CustomHandler("/containers/.*/attach", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hijacker, ok := w.(http.Hijacker)
 		if !ok {
@@ -247,8 +248,7 @@ func (s *S) TestBuilderImageIDWithProcfile(c *check.C) {
 			return
 		}
 		outStream := stdcopy.NewStdWriter(conn, stdcopy.Stdout)
-		attachCounter++
-		if attachCounter == 1 {
+		if atomic.AddInt32(&attachCounter, 1) == 1 {
 			fmt.Fprintf(outStream, "web: test.sh\n")
 		} else {
 			fmt.Fprintf(outStream, "")
@@ -342,7 +342,7 @@ func (s *S) TestBuilderImageIDWithTsuruYaml(c *check.C) {
 	imageName := fmt.Sprintf("%s/%s", u.Host, "customimage")
 	config.Set("docker:registry", u.Host)
 	defer config.Unset("docker:registry")
-	attachCounter := 0
+	var attachCounter int32
 	s.server.CustomHandler("/containers/.*/attach", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hijacker, ok := w.(http.Hijacker)
 		if !ok {
@@ -357,8 +357,7 @@ func (s *S) TestBuilderImageIDWithTsuruYaml(c *check.C) {
 			return
 		}
 		outStream := stdcopy.NewStdWriter(conn, stdcopy.Stdout)
-		attachCounter++
-		if attachCounter == 2 {
+		if atomic.AddInt32(&attachCounter, 1) == 2 {
 			yamlData := `healthcheck:
   path: /status
   method: GET


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c42042a090 by goroutine 9:
  github.com/tsuru/tsuru/builder/docker.(*S).TestBuilderImageIDWithTsuruYaml.func1()
      /home/travis/gopath/src/github.com/tsuru/tsuru/builder/docker/builder_test.go:360 +0x205
  net/http.HandlerFunc.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:1918 +0x51
  github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).ServeHTTP()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:336 +0x1ff
  net/http.serverHandler.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2619 +0xbc
  net/http.(*conn).serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:1801 +0x83b
Previous write at 0x00c42042a090 by goroutine 23:
  github.com/tsuru/tsuru/builder/docker.(*S).TestBuilderImageIDWithTsuruYaml.func1()
      /home/travis/gopath/src/github.com/tsuru/tsuru/builder/docker/builder_test.go:360 +0x221
  net/http.HandlerFunc.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:1918 +0x51
  github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing.(*DockerServer).ServeHTTP()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/github.com/fsouza/go-dockerclient/testing/server.go:336 +0x1ff
  net/http.serverHandler.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2619 +0xbc
  net/http.(*conn).serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:1801 +0x83b
Goroutine 9 (running) created at:
  net/http.(*Server).Serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2720 +0x37c
  net/http.Serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2323 +0xe2
Goroutine 23 (finished) created at:
  net/http.(*Server).Serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2720 +0x37c
  net/http.Serve()
      /home/travis/.gimme/versions/go1.9.linux.amd64/src/net/http/server.go:2323 +0xe2
==================
```