### PR TITLE
Allow events with multiple targets

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/event/eventtest"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/permission/permissiontest"
@@ -5139,18 +5140,11 @@ func (s *S) TestSwap(c *check.C) {
 	c.Assert(dbApp.Lock, check.Equals, app.AppLock{})
 	c.Assert(eventtest.EventDesc{
 		Target: appTarget(app1.Name),
-		Owner:  s.token.GetUserName(),
-		Kind:   "app.update.swap",
-		StartCustomData: []map[string]interface{}{
-			{"name": "app1", "value": app1.Name},
-			{"name": "app2", "value": app2.Name},
-			{"name": "cnameOnly", "value": "false"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: app2.Name}, Lock: true},
 		},
-	}, eventtest.HasEvent)
-	c.Assert(eventtest.EventDesc{
-		Target: appTarget(app2.Name),
-		Owner:  s.token.GetUserName(),
-		Kind:   "app.update.swap",
+		Owner: s.token.GetUserName(),
+		Kind:  "app.update.swap",
 		StartCustomData: []map[string]interface{}{
 			{"name": "app1", "value": app1.Name},
 			{"name": "app2", "value": app2.Name},
@@ -5183,18 +5177,11 @@ func (s *S) TestSwapCnameOnly(c *check.C) {
 	c.Assert(dbApp.Lock, check.Equals, app.AppLock{})
 	c.Assert(eventtest.EventDesc{
 		Target: appTarget(app1.Name),
-		Owner:  s.token.GetUserName(),
-		Kind:   "app.update.swap",
-		StartCustomData: []map[string]interface{}{
-			{"name": "app1", "value": app1.Name},
-			{"name": "app2", "value": app2.Name},
-			{"name": "cnameOnly", "value": "true"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: app2.Name}, Lock: true},
 		},
-	}, eventtest.HasEvent)
-	c.Assert(eventtest.EventDesc{
-		Target: appTarget(app2.Name),
-		Owner:  s.token.GetUserName(),
-		Kind:   "app.update.swap",
+		Owner: s.token.GetUserName(),
+		Kind:  "app.update.swap",
 		StartCustomData: []map[string]interface{}{
 			{"name": "app1", "value": app1.Name},
 			{"name": "app2", "value": app2.Name},
@@ -5264,18 +5251,10 @@ func (s *S) TestSwapIncompatiblePlatforms(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusPreconditionFailed)
 	c.Assert(recorder.Body.String(), check.Equals, "platforms don't match\n")
 	c.Assert(eventtest.EventDesc{
-		Target:       appTarget(app1.Name),
-		Owner:        s.token.GetUserName(),
-		Kind:         "app.update.swap",
-		ErrorMatches: "platforms don't match",
-		StartCustomData: []map[string]interface{}{
-			{"name": "app1", "value": app1.Name},
-			{"name": "app2", "value": app2.Name},
-			{"name": "cnameOnly", "value": "false"},
+		Target: appTarget(app1.Name),
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: app2.Name}, Lock: true},
 		},
-	}, eventtest.HasEvent)
-	c.Assert(eventtest.EventDesc{
-		Target:       appTarget(app2.Name),
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.swap",
 		ErrorMatches: "platforms don't match",

--- a/db/storage.go
+++ b/db/storage.go
@@ -205,6 +205,7 @@ func (s *Storage) Limiter() *storage.Collection {
 func (s *Storage) Events() *storage.Collection {
 	ownerIndex := mgo.Index{Key: []string{"owner.name"}}
 	targetIndex := mgo.Index{Key: []string{"target.value"}}
+	extraTargetIndex := mgo.Index{Key: []string{"extratargets.target.value"}}
 	kindIndex := mgo.Index{Key: []string{"kind.name"}}
 	startTimeIndex := mgo.Index{Key: []string{"-starttime"}}
 	uniqueIdIndex := mgo.Index{Key: []string{"uniqueid"}}
@@ -212,6 +213,7 @@ func (s *Storage) Events() *storage.Collection {
 	c := s.Collection("events")
 	c.EnsureIndex(ownerIndex)
 	c.EnsureIndex(targetIndex)
+	c.EnsureIndex(extraTargetIndex)
 	c.EnsureIndex(kindIndex)
 	c.EnsureIndex(startTimeIndex)
 	c.EnsureIndex(uniqueIdIndex)

--- a/db/storage.go
+++ b/db/storage.go
@@ -208,12 +208,14 @@ func (s *Storage) Events() *storage.Collection {
 	kindIndex := mgo.Index{Key: []string{"kind.name"}}
 	startTimeIndex := mgo.Index{Key: []string{"-starttime"}}
 	uniqueIdIndex := mgo.Index{Key: []string{"uniqueid"}}
+	runningIndex := mgo.Index{Key: []string{"running"}}
 	c := s.Collection("events")
 	c.EnsureIndex(ownerIndex)
 	c.EnsureIndex(targetIndex)
 	c.EnsureIndex(kindIndex)
 	c.EnsureIndex(startTimeIndex)
 	c.EnsureIndex(uniqueIdIndex)
+	c.EnsureIndex(runningIndex)
 	return c
 }
 

--- a/event/eventlist_test.go
+++ b/event/eventlist_test.go
@@ -62,7 +62,11 @@ func (s *S) TestListFilterMany(c *check.C) {
 		c.Assert(evts, eventtest.EvtEquals, expected)
 	}
 	create(&event.Opts{
-		Target:  event.Target{Type: "app", Value: "myapp"},
+		Target: event.Target{Type: "app", Value: "myapp"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "xapp1"}},
+			{Target: event.Target{Type: "app", Value: "xapp2"}},
+		},
 		Kind:    permission.PermAppUpdateEnvSet,
 		Owner:   s.token,
 		Allowed: event.Allowed(permission.PermAppReadEvents, permission.Context(permission.CtxApp, "myapp")),
@@ -110,6 +114,8 @@ func (s *S) TestListFilterMany(c *check.C) {
 	checkFilters(&event.Filter{ErrorOnly: true, Sort: "_id"}, allEvts[len(allEvts)-3])
 	checkFilters(&event.Filter{Target: event.Target{Type: "app"}, Sort: "_id"}, []*event.Event{allEvts[0], allEvts[1]})
 	checkFilters(&event.Filter{Target: event.Target{Type: "app", Value: "myapp"}}, allEvts[0])
+	checkFilters(&event.Filter{Target: event.Target{Type: "app", Value: "xapp1"}}, allEvts[0])
+	checkFilters(&event.Filter{Target: event.Target{Type: "app", Value: "xapp2"}}, allEvts[0])
 	checkFilters(&event.Filter{KindType: event.KindTypeInternal, Sort: "_id"}, allEvts[3:len(allEvts)-1])
 	checkFilters(&event.Filter{KindType: event.KindTypePermission, Sort: "_id"}, allEvts[:3])
 	checkFilters(&event.Filter{KindType: event.KindTypePermission, KindNames: []string{"kind"}}, nil)
@@ -138,6 +144,12 @@ func (s *S) TestListFilterMany(c *check.C) {
 		{Type: "app", Values: []string{"myapp"}},
 		{Type: "node", Values: []string{"http://10.0.1.2"}},
 	}, Sort: "_id"}, []*event.Event{allEvts[0], allEvts[4]})
+	checkFilters(&event.Filter{AllowedTargets: []event.TargetFilter{
+		{Type: "app", Values: []string{"xapp1", "myapp2"}},
+	}, Sort: "_id"}, allEvts[:2])
+	checkFilters(&event.Filter{AllowedTargets: []event.TargetFilter{
+		{Type: "app", Values: []string{"xapp2"}},
+	}, Sort: "_id"}, allEvts[0])
 	checkFilters(&event.Filter{Permissions: []permission.Permission{
 		{Scheme: permission.PermAll, Context: permission.Context(permission.CtxGlobal, "")},
 	}, Sort: "_id"}, allEvts[:len(allEvts)-1])

--- a/event/eventtest/checker.go
+++ b/event/eventtest/checker.go
@@ -17,6 +17,7 @@ import (
 
 type EventDesc struct {
 	Target          event.Target
+	ExtraTargets    []event.ExtraTarget
 	Kind            string
 	Owner           string
 	StartCustomData interface{}
@@ -84,6 +85,15 @@ func (hasEventChecker) Check(params []interface{}, names []string) (bool, string
 		"kind.name":  evt.Kind,
 		"owner.name": evt.Owner,
 		"running":    false,
+	}
+	if len(evt.ExtraTargets) > 0 {
+		var andBlock []bson.M
+		for _, t := range evt.ExtraTargets {
+			andBlock = append(andBlock, bson.M{
+				"extratargets": t,
+			})
+		}
+		query["$and"] = andBlock
 	}
 	queryPartCustom(query, "startcustomdata", evt.StartCustomData)
 	queryPartCustom(query, "endcustomdata", evt.EndCustomData)

--- a/healer/healer_node_test.go
+++ b/healer/healer_node_test.go
@@ -431,6 +431,7 @@ func (s *S) TestHealerHandleError(c *check.C) {
 		Address:  "http://addr1:1",
 		Metadata: map[string]string{"iaas": "my-healer-iaas"},
 		IaaSID:   m.Id,
+		Pool:     "p1",
 	})
 	c.Assert(err, check.IsNil)
 	node, err := p.GetNode("http://addr1:1")
@@ -474,7 +475,11 @@ func (s *S) TestHealerHandleError(c *check.C) {
 	c.Assert(machines[0].Address, check.Equals, "addr2")
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "node", Value: "http://addr1:1"},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "node", Value: "http://addr2:2"}},
+			{Target: event.Target{Type: "pool", Value: "p1"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"reason":   "2 consecutive failures",
 			"node._id": "http://addr1:1",
@@ -500,6 +505,7 @@ func (s *S) TestHealerHandleErrorFailureEvent(c *check.C) {
 		Address:  "http://addr1:1",
 		Metadata: map[string]string{"iaas": "my-healer-iaas"},
 		IaaSID:   m.Id,
+		Pool:     "p1",
 	})
 	c.Assert(err, check.IsNil)
 	node, err := p.GetNode("http://addr1:1")
@@ -545,7 +551,10 @@ func (s *S) TestHealerHandleErrorFailureEvent(c *check.C) {
 
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "node", Value: "http://addr1:1"},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "pool", Value: "p1"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"reason":   "2 consecutive failures",
 			"node._id": "http://addr1:1",
@@ -884,6 +893,7 @@ func (s *S) TestCheckActiveHealing(c *check.C) {
 		Address:  "http://addr1:1",
 		Metadata: map[string]string{"iaas": "my-healer-iaas"},
 		IaaSID:   m.Id,
+		Pool:     "p1",
 	})
 	c.Assert(err, check.IsNil)
 	node, err := p.GetNode("http://addr1:1")
@@ -923,7 +933,11 @@ func (s *S) TestCheckActiveHealing(c *check.C) {
 
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "node", Value: "http://addr1:1"},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "node", Value: "http://addr2:2"}},
+			{Target: event.Target{Type: "pool", Value: "p1"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"reason":         bson.M{"$regex": `last update \d+\.\d*?s ago, last success \d+\.\d*?s ago`},
 			"lastcheck.time": bson.M{"$exists": true},
@@ -952,6 +966,7 @@ func (s *S) TestTryHealingNodeConcurrent(c *check.C) {
 		Address:  "http://addr1:1",
 		Metadata: map[string]string{"iaas": "my-healer-iaas"},
 		IaaSID:   m.Id,
+		Pool:     "p1",
 	})
 	c.Assert(err, check.IsNil)
 	node, err := p.GetNode("http://addr1:1")
@@ -995,7 +1010,11 @@ func (s *S) TestTryHealingNodeConcurrent(c *check.C) {
 	c.Assert(machines[0].Address, check.Equals, "addr2")
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "node", Value: "http://addr1:1"},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "node", Value: "http://addr2:2"}},
+			{Target: event.Target{Type: "pool", Value: "p1"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"reason":   "something",
 			"node._id": "http://addr1:1",

--- a/provision/docker/healer/healer_container_test.go
+++ b/provision/docker/healer/healer_container_test.go
@@ -124,7 +124,11 @@ func (s *S) TestRunContainerHealer(c *check.C) {
 	}})
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -173,7 +177,11 @@ func (s *S) TestRunContainerHealerCreatedContainer(c *check.C) {
 	c.Assert(movings, check.DeepEquals, expected)
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -224,7 +232,11 @@ func (s *S) TestRunContainerHealerStoppedContainer(c *check.C) {
 	c.Assert(movings, check.DeepEquals, expected)
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -359,7 +371,11 @@ func (s *S) TestRunContainerHealerShutdown(c *check.C) {
 	c.Assert(movings, check.DeepEquals, []dockertest.ContainerMoving{expected})
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -421,7 +437,11 @@ func (s *S) TestRunContainerHealerConcurrency(c *check.C) {
 
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -472,7 +492,11 @@ func (s *S) TestRunContainerHealerAlreadyHealed(c *check.C) {
 	c.Assert(movings, check.DeepEquals, []dockertest.ContainerMoving{expected})
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+			{Target: event.Target{Type: "container", Value: toMoveCont.ID + "-recreated"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,
@@ -620,7 +644,10 @@ func (s *S) TestRunContainerHealerWithError(c *check.C) {
 
 	c.Assert(eventtest.EventDesc{
 		Target: event.Target{Type: "container", Value: toMoveCont.ID},
-		Kind:   "healer",
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "myapp"}},
+		},
+		Kind: "healer",
 		StartCustomData: map[string]interface{}{
 			"hostaddr": "127.0.0.1",
 			"id":       toMoveCont.ID,


### PR DESCRIPTION
Now the following events have multiple targets:

app.swap -> target: app1, extra-targets: app2
container healer -> target: failing container, extra-targets: new-container, app
node healer -> target: failing node, extra-targets: new-node, pool
