### PR TITLE
healer,provision: rotate slices with resources for healing

### DIFF
--- a/healer/healer_node.go
+++ b/healer/healer_node.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/globalsign/mgo"
@@ -441,6 +442,8 @@ func (h *NodeHealer) shouldHealNode(node provision.Node) (bool, error) {
 	return count > 0, nil
 }
 
+var localSkip uint64
+
 func (h *NodeHealer) findNodesForHealing() ([]NodeStatusData, map[string]provision.Node, error) {
 	nodes, err := allNodes()
 	if err != nil {
@@ -500,6 +503,12 @@ func (h *NodeHealer) findNodesForHealing() ([]NodeStatusData, map[string]provisi
 	err = coll.Find(bson.M{"$or": query}).All(&nodesStatus)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "unable to find nodes to heal")
+	}
+	if len(nodesStatus) > 0 {
+		pivot := atomic.AddUint64(&localSkip, 1) % uint64(len(nodesStatus))
+		// Rotate the queried slice on pivot index to avoid the same node to always
+		// be selected.
+		nodesStatus = append(nodesStatus[pivot:], nodesStatus[:pivot]...)
 	}
 	return nodesStatus, nodesAddrMap, nil
 }

--- a/healer/healer_node_test.go
+++ b/healer/healer_node_test.go
@@ -874,6 +874,41 @@ func (s *S) TestFindNodesForHealingLastUpdateWithRecentStarted(c *check.C) {
 	})
 }
 
+func (s *S) TestFindNodesForHealingRotateResults(c *check.C) {
+	conf := healerConfig()
+	err := conf.SaveBase(NodeHealerConfig{Enabled: boolPtr(true), MaxUnresponsiveTime: intPtr(1)})
+	c.Assert(err, check.IsNil)
+	p := provisiontest.ProvisionerInstance
+	err = p.AddNode(provision.AddNodeOptions{
+		Address: "http://addr1:1",
+	})
+	c.Assert(err, check.IsNil)
+	err = p.AddNode(provision.AddNodeOptions{
+		Address: "http://addr2:1",
+	})
+	c.Assert(err, check.IsNil)
+	node1, err := p.GetNode("http://addr1:1")
+	c.Assert(err, check.IsNil)
+	node2, err := p.GetNode("http://addr2:1")
+	c.Assert(err, check.IsNil)
+	healer := newNodeHealer(nodeHealerArgs{})
+	healer.Shutdown(context.Background())
+	healer.started = time.Now().Add(-3 * time.Second)
+	err = healer.UpdateNodeData(node1, []provision.NodeCheckResult{})
+	c.Assert(err, check.IsNil)
+	err = healer.UpdateNodeData(node2, []provision.NodeCheckResult{})
+	c.Assert(err, check.IsNil)
+	time.Sleep(1200 * time.Millisecond)
+	nodesResult1, _, err := healer.findNodesForHealing()
+	c.Assert(err, check.IsNil)
+	c.Assert(nodesResult1, check.HasLen, 2)
+	nodesResult2, _, err := healer.findNodesForHealing()
+	c.Assert(err, check.IsNil)
+	c.Assert(nodesResult2, check.HasLen, 2)
+	c.Assert(nodesResult1[0], check.DeepEquals, nodesResult2[1])
+	c.Assert(nodesResult1[1], check.DeepEquals, nodesResult2[0])
+}
+
 func (s *S) TestCheckActiveHealing(c *check.C) {
 	conf := healerConfig()
 	err := conf.SaveBase(NodeHealerConfig{Enabled: boolPtr(true), MaxUnresponsiveTime: intPtr(1)})


### PR DESCRIPTION
This prevents a single set of nodes or containers from starving other
resources waiting to be healed. Today this can happen due to events rate
limiting only allowing a fixed number of healing events to run
concurrently. If the chosen resources fail to heal the healer process
would select them again as the first they would still be the first
elements in the collection.