### PR TITLE
Update docs

### DIFF
--- a/docs/installing/api.rst
+++ b/docs/installing/api.rst
@@ -77,7 +77,6 @@ configuration is described below, please note that you should replace the values
         deploy-cmd: /var/lib/tsuru/deploy
         bs:
             image: tsuru/bs:v1
-            reporter-interval: 10
             socket: /var/run/docker.sock
         cluster:
             storage: mongodb

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -725,14 +725,9 @@ Database collection name used to store containers information.
 docker:port-allocator
 +++++++++++++++++++++
 
-The choice of port allocator. There are two possible values:
-
- * ``docker``: trust Docker to allocate ports. Meaning that whenever a
-   container restarts, the port might change (usually, it changes).
- * ``tsuru``: leverage port allocation to tsuru, so ports mapped to containers
-   never change.
-
-The default value is "docker".
+Deprecated. Currently, when using Docker as provisioner, tsuru trusts it
+to allocate ports. Meaning thatwhenever a container restarts, the port might
+change (usually, it changes).
 
 docker:registry
 +++++++++++++++

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -201,6 +201,12 @@ database:name
 ``database:name`` is the name of the database that tsuru uses. It is a
 mandatory setting and has no default value. An example of value is "tsuru".
 
+database:driver
++++++++++++++++
+
+``database:driver`` is the name of the database driver that tsuru uses.
+Currently, the only value supported is "mongodb".
+
 .. _config_logdb:
 
 database:logdb-url


### PR DESCRIPTION
Add reference to `database:driver`, add deprecation info to `docker:port-allocator`