### PR TITLE
iaas/cloudstack: fix race condition by waiting for queue to finish

### DIFF
--- a/iaas/cloudstack/iaas_test.go
+++ b/iaas/cloudstack/iaas_test.go
@@ -104,6 +104,7 @@ func (s *cloudstackSuite) TestCreateMachine(c *check.C) {
 	}
 	vm, err := cs.CreateMachine(params)
 	c.Assert(err, check.IsNil)
+	queue.ResetQueue()
 	c.Assert(vm, check.NotNil)
 	c.Assert(vm.Address, check.Equals, "10.24.16.241")
 	c.Assert(vm.Id, check.Equals, "0366ae09-0a77-4e2b-8595-3b749764a107")
@@ -137,6 +138,7 @@ func (s *cloudstackSuite) TestCreateMachineAsyncFailure(c *check.C) {
 	}
 	_, err = cs.CreateMachine(params)
 	c.Assert(err, check.ErrorMatches, ".*my weird error.*")
+	queue.ResetQueue()
 	c.Assert(calls[:2], check.DeepEquals, []string{"deployVirtualMachine", "queryAsyncJobResult"})
 }
 
@@ -207,6 +209,7 @@ func (s *cloudstackSuite) TestCreateMachineWithTags(c *check.C) {
 	}
 	vm, err := cs.CreateMachine(params)
 	c.Assert(err, check.IsNil)
+	queue.ResetQueue()
 	c.Assert(vm, check.NotNil)
 	c.Assert(vm.Address, check.Equals, "10.24.16.241")
 	c.Assert(vm.Id, check.Equals, "0366ae09-0a77-4e2b-8595-3b749764a107")
@@ -247,6 +250,7 @@ func (s *cloudstackSuite) TestDeleteMachineWithoutProjectID(c *check.C) {
 	machine := iaas.Machine{Id: "myMachineId", CreationParams: map[string]string{}}
 	err = cs.DeleteMachine(&machine)
 	c.Assert(err, check.IsNil)
+	queue.ResetQueue()
 	c.Assert(calls, check.DeepEquals, []string{
 		"listVolumes",
 		"destroyVirtualMachine",
@@ -291,6 +295,7 @@ func (s *cloudstackSuite) TestDeleteMachine(c *check.C) {
 	machine := iaas.Machine{Id: "myMachineId", CreationParams: map[string]string{"projectid": "projid"}}
 	err = cs.DeleteMachine(&machine)
 	c.Assert(err, check.IsNil)
+	queue.ResetQueue()
 	c.Assert(calls, check.DeepEquals, []string{
 		"listVolumes",
 		"destroyVirtualMachine",
@@ -328,6 +333,7 @@ func (s *cloudstackSuite) TestDeleteMachineAsyncFail(c *check.C) {
 	machine := iaas.Machine{Id: "myMachineId", CreationParams: map[string]string{"projectid": "projid"}}
 	err = cs.DeleteMachine(&machine)
 	c.Assert(err, check.ErrorMatches, ".*my awesome err.*")
+	queue.ResetQueue()
 	c.Assert(calls, check.DeepEquals, []string{
 		"listVolumes",
 		"destroyVirtualMachine",


### PR DESCRIPTION
Example of a race caught by the race detector:

```
==================
WARNING: DATA RACE
Read at 0x00c42021dd40 by goroutine 67:
  github.com/tsuru/tsuru/iaas/cloudstack.(*cloudstackSuite).TestCreateMachineAsyncFailure()
      /home/travis/gopath/src/github.com/tsuru/tsuru/iaas/cloudstack/iaas_test.go:140 +0x5dc
  runtime.call32()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/runtime/asm_amd64.s:509 +0x3a
  reflect.Value.Call()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/reflect/value.go:302 +0xc0
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:772 +0x9ab
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:666 +0x89
Previous write at 0x00c42021dd40 by goroutine 17:
  github.com/tsuru/tsuru/iaas/cloudstack.(*cloudstackSuite).TestCreateMachineAsyncFailure.func1()
      /home/travis/gopath/src/github.com/tsuru/tsuru/iaas/cloudstack/iaas_test.go:117 +0x157
  net/http.HandlerFunc.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/net/http/server.go:1918 +0x51
  net/http.serverHandler.ServeHTTP()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/net/http/server.go:2619 +0xbc
  net/http.(*conn).serve()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/net/http/server.go:1801 +0x83b
Goroutine 67 (running) created at:
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkCall()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:663 +0x430
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).forkTest()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:754 +0x131
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).runTest()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:809 +0x42
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.(*suiteRunner).run()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/check.go:615 +0x1fa
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.Run()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/run.go:92 +0x5a
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.RunAll()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/run.go:84 +0x136
  github.com/tsuru/tsuru/vendor/gopkg.in/check%2ev1.TestingT()
      /home/travis/gopath/src/github.com/tsuru/tsuru/vendor/gopkg.in/check.v1/run.go:72 +0x680
  github.com/tsuru/tsuru/iaas/cloudstack.Test()
      /home/travis/gopath/src/github.com/tsuru/tsuru/iaas/cloudstack/iaas_test.go:21 +0x38
  testing.tRunner()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/testing/testing.go:746 +0x16c
Goroutine 17 (running) created at:
  net/http.(*Server).Serve()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/net/http/server.go:2720 +0x37c
  net/http/httptest.(*Server).goServe.func1()
      /home/travis/.gimme/versions/go1.9.2.linux.amd64/src/net/http/httptest/server.go:280 +0xa2
==================
```