### PR TITLE
provision/kubernetes: use json unmarshal byte slice already in memory

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -676,7 +676,7 @@ func imageTagAndPush(client *clusterClient, a provision.App, oldImage, newImage 
 		return nil, errors.Wrapf(err, "unable to pull and tag image: %q", buf.String())
 	}
 	var imgs []dockerImageSpec
-	err = json.NewDecoder(buf).Decode(&imgs)
+	err = json.Unmarshal(buf.Bytes(), &imgs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid image inspect response: %q", buf.String())
 	}


### PR DESCRIPTION
This also improves the error messages as the String method will return
the full received data