### PR TITLE
kubernetes: add taint on node disable

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -31,10 +31,11 @@ import (
 )
 
 const (
-	tsuruLabelPrefix     = "tsuru.io/"
-	tsuruInProgressTaint = tsuruLabelPrefix + "inprogress"
-	replicaDepRevision   = "deployment.kubernetes.io/revision"
-	kubeKindReplicaSet   = "ReplicaSet"
+	tsuruLabelPrefix       = "tsuru.io/"
+	tsuruInProgressTaint   = tsuruLabelPrefix + "inprogress"
+	tsuruNodeDisabledTaint = tsuruLabelPrefix + "disabled"
+	replicaDepRevision     = "deployment.kubernetes.io/revision"
+	kubeKindReplicaSet     = "ReplicaSet"
 )
 
 var kubeNameRegex = regexp.MustCompile(`(?i)[^a-z0-9.-]`)

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -189,6 +189,12 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *clusterClie
 							SecurityContext: secCtx,
 						},
 					},
+					Tolerations: []apiv1.Toleration{
+						{
+							Key:      tsuruNodeDisabledTaint,
+							Operator: apiv1.TolerationOpExists,
+						},
+					},
 				},
 			},
 		},

--- a/provision/kubernetes/nodecontainer_test.go
+++ b/provision/kubernetes/nodecontainer_test.go
@@ -127,6 +127,12 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 							},
 						},
 					},
+					Tolerations: []apiv1.Toleration{
+						{
+							Key:      "tsuru.io/disabled",
+							Operator: apiv1.TolerationOpExists,
+						},
+					},
 				},
 			},
 		},

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -428,6 +428,48 @@ func (s *S) TestUpdateNodeRemoveInProgressTaint(c *check.C) {
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Spec.Taints, check.DeepEquals, []apiv1.Taint{})
 }
 
+func (s *S) TestUpdateNodeToggleDisableTaint(c *check.C) {
+	err := s.p.AddNode(provision.AddNodeOptions{
+		Address: "my-node-addr",
+		Pool:    "p1",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.p.UpdateNode(provision.UpdateNodeOptions{
+		Address: "my-node-addr",
+		Disable: true,
+	})
+	c.Assert(err, check.IsNil)
+	nodes, err := s.p.ListNodes(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(nodes, check.HasLen, 1)
+	c.Assert(nodes[0].Address(), check.Equals, "my-node-addr")
+	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Spec.Taints, check.DeepEquals, []apiv1.Taint{
+		{Key: "tsuru.io/disabled", Effect: apiv1.TaintEffectNoSchedule},
+	})
+	err = s.p.UpdateNode(provision.UpdateNodeOptions{
+		Address: "my-node-addr",
+		Disable: true,
+	})
+	c.Assert(err, check.IsNil)
+	nodes, err = s.p.ListNodes(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(nodes, check.HasLen, 1)
+	c.Assert(nodes[0].Address(), check.Equals, "my-node-addr")
+	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Spec.Taints, check.DeepEquals, []apiv1.Taint{
+		{Key: "tsuru.io/disabled", Effect: apiv1.TaintEffectNoSchedule},
+	})
+	err = s.p.UpdateNode(provision.UpdateNodeOptions{
+		Address: "my-node-addr",
+		Enable:  true,
+	})
+	c.Assert(err, check.IsNil)
+	nodes, err = s.p.ListNodes(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(nodes, check.HasLen, 1)
+	c.Assert(nodes[0].Address(), check.Equals, "my-node-addr")
+	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Spec.Taints, check.DeepEquals, []apiv1.Taint{})
+}
+
 func (s *S) TestUnits(c *check.C) {
 	a, wait, rollback := s.defaultReactions(c)
 	defer rollback()


### PR DESCRIPTION
Instead of setting the node to NoSchedulable we add a taint to the node
to prevent new nodes from being scheduled to the node. Setting the
NoSchedulable flag to the node spec has the undesirable effect of
removing that node from the list of nodes used by LoadBalancers.