### PR TITLE
provision/kubernetes: enable memory overcommit

### DIFF
--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"math/rand"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,10 +20,11 @@ import (
 )
 
 const (
-	namespaceClusterKey = "namespace"
-	tokenClusterKey     = "token"
-	userClusterKey      = "username"
-	passwordClusterKey  = "password"
+	namespaceClusterKey  = "namespace"
+	tokenClusterKey      = "token"
+	userClusterKey       = "username"
+	passwordClusterKey   = "password"
+	overcommitClusterKey = "overcommit-factor"
 )
 
 var clientForConfig = func(conf *rest.Config) (kubernetes.Interface, error) {
@@ -101,6 +103,14 @@ func (c *clusterClient) Namespace() string {
 		return "default"
 	}
 	return c.CustomData[namespaceClusterKey]
+}
+
+func (c *clusterClient) OvercommitFactor() (int64, error) {
+	if c.CustomData == nil || c.CustomData[overcommitClusterKey] == "" {
+		return 1, nil
+	}
+	overcommit, err := strconv.Atoi(c.CustomData[overcommitClusterKey])
+	return int64(overcommit), err
 }
 
 func clusterForPool(pool string) (*clusterClient, error) {

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -105,12 +105,23 @@ func (c *clusterClient) Namespace() string {
 	return c.CustomData[namespaceClusterKey]
 }
 
-func (c *clusterClient) OvercommitFactor() (int64, error) {
-	if c.CustomData == nil || c.CustomData[overcommitClusterKey] == "" {
+func (c *clusterClient) OvercommitFactor(pool string) (int64, error) {
+	if c.CustomData == nil {
 		return 1, nil
 	}
-	overcommit, err := strconv.Atoi(c.CustomData[overcommitClusterKey])
+	overcommitConf := c.configForPool(pool, overcommitClusterKey)
+	if overcommitConf == "" {
+		return 1, nil
+	}
+	overcommit, err := strconv.Atoi(overcommitConf)
 	return int64(overcommit), err
+}
+
+func (c *clusterClient) configForPool(pool, key string) string {
+	if v, ok := c.CustomData[pool+":"+key]; ok {
+		return v
+	}
+	return c.CustomData[key]
 }
 
 func clusterForPool(pool string) (*clusterClient, error) {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -299,7 +299,7 @@ func createAppDeployment(client *clusterClient, oldDeployment *v1beta2.Deploymen
 	}).ToNodeByPoolSelector()
 	_, uid := dockercommon.UserForContainer()
 	resourceLimits := apiv1.ResourceList{}
-	overcommit, err := client.OvercommitFactor()
+	overcommit, err := client.OvercommitFactor(a.GetPool())
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "misconfigured cluster overcommit factor")
 	}

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -130,7 +130,8 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 								{Name: "PORT", Value: "8888"},
 							},
 							Resources: apiv1.ResourceRequirements{
-								Limits: apiv1.ResourceList{},
+								Limits:   apiv1.ResourceList{},
+								Requests: apiv1.ResourceList{},
 							},
 							Ports: []apiv1.ContainerPort{
 								{ContainerPort: 8888},
@@ -541,7 +542,7 @@ func (s *S) TestServiceManagerDeployServiceWithUID(c *check.C) {
 	})
 }
 
-func (s *S) TestServiceManagerDeployServiceWithLimits(c *check.C) {
+func (s *S) TestServiceManagerDeployServiceWithResourceRequirements(c *check.C) {
 	waitDep := s.deploymentReactions(c)
 	defer waitDep()
 	m := serviceManager{client: s.client.clusterClient}
@@ -565,6 +566,42 @@ func (s *S) TestServiceManagerDeployServiceWithLimits(c *check.C) {
 	c.Assert(dep.Spec.Template.Spec.Containers[0].Resources, check.DeepEquals, apiv1.ResourceRequirements{
 		Limits: apiv1.ResourceList{
 			apiv1.ResourceMemory: *expectedMemory,
+		},
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceMemory: *expectedMemory,
+		},
+	})
+}
+
+func (s *S) TestServiceManagerDeployServiceWithClusterOvercommitFactor(c *check.C) {
+	waitDep := s.deploymentReactions(c)
+	defer waitDep()
+	s.client.clusterClient.CustomData[overcommitClusterKey] = "3"
+	m := serviceManager{client: s.client.clusterClient}
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(a, s.user)
+	c.Assert(err, check.IsNil)
+	a.Plan = appTypes.Plan{Memory: 1024}
+	err = image.SaveImageCustomData("myimg", map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cm1",
+		},
+	})
+	c.Assert(err, check.IsNil)
+	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.AppsV1beta2().Deployments(s.client.Namespace()).Get("myapp-p1", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	expectedMemory := resource.NewQuantity(1024, resource.BinarySI)
+	expectedMemoryRequest := resource.NewQuantity(341, resource.BinarySI)
+	c.Assert(dep.Spec.Template.Spec.Containers[0].Resources, check.DeepEquals, apiv1.ResourceRequirements{
+		Limits: apiv1.ResourceList{
+			apiv1.ResourceMemory: *expectedMemory,
+		},
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceMemory: *expectedMemoryRequest,
 		},
 	})
 }

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -135,6 +135,7 @@ func (s *S) SetUpTest(c *check.C) {
 		Addresses:   []string{"https://clusteraddr"},
 		Default:     true,
 		Provisioner: provisionerName,
+		CustomData:  map[string]string{},
 	}
 	err = clus.Save()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This PR adds memory overcommit to Kubernetes cluster by
requesting a fraction of the application memory limit.

For example, with a cluster/pool configure with
overcommit-factor = 2, the request memory will be half of
the application plan and thus allow a 2x memory overcommit.