### PR TITLE
event: ensure updates to lockUpdater internal set are atomic and synced

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -889,7 +889,7 @@ func newEvt(opts *Opts) (evt *Event, err error) {
 				evt.Done(err)
 				return nil, err
 			}
-			updater.addCh <- id
+			updater.add(id)
 			return evt, nil
 		}
 		if mgo.IsDup(err) {
@@ -1140,7 +1140,7 @@ func (e *Event) done(evtErr error, customData interface{}, abort bool) (err erro
 			log.Errorf("[events] error marking event as done - %#v: %s", e, err)
 		}
 	}()
-	updater.removeCh <- e.ID
+	updater.remove(e.ID)
 	conn, err := db.Conn()
 	if err != nil {
 		return err

--- a/event/workers.go
+++ b/event/workers.go
@@ -93,12 +93,10 @@ func (l *eventCleaner) spin() {
 }
 
 type lockUpdater struct {
-	addCh    chan eventID
-	removeCh chan eventID
-	stopCh   chan struct{}
-	once     *sync.Once
-	setMu    sync.Mutex
-	set      map[eventID]struct{}
+	stopCh chan struct{}
+	once   *sync.Once
+	setMu  sync.Mutex
+	set    map[eventID]struct{}
 }
 
 func (l *lockUpdater) start() {


### PR DESCRIPTION
Before this commit the added test case would break due to the 10 buffer
in both addCh and removeCh channels. These buffers allowed the
possibility of a removeCh message to arrive before a addCh message for
the same ID, causing the message to never be removed from the internal
ID Set.

Simply removing the buffer could potentially cause performance issues
as every operation on events (New, Done, etc) would require the
lockUpdater goroutine to be running and unblocked. Long mongodb update
operations could delay the processing of seemingly unreleated events for
a long period of time.

This new approach uses a mutex based approach to update an internal
event ID Set and operations to the Set are made on the same goroutine as
the caller. The lockUpdater goroutine simply reads a copy of the
internal Set before updating the entries in the database ensuring
updates do not impact in Set operations.