### PR TITLE
all: replace golang.org/x/net/context imports with context

### DIFF
--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tsuru/config"
@@ -18,7 +20,6 @@ import (
 	"github.com/tsuru/tsuru/auth/native"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/log"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/integration/gce.go
+++ b/integration/gce.go
@@ -12,7 +12,8 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/option"
 )

--- a/integration/gce_client.go
+++ b/integration/gce_client.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sort"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/option"

--- a/provision/dockercommon/docker.go
+++ b/provision/dockercommon/docker.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"time"
 
+	"context"
+
 	"github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
@@ -18,7 +20,6 @@ import (
 	tsuruNet "github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/safe"
-	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
Since Go 1.7, context is available as a standard library