### PR TITLE
api,app,service: add user and eventid to all service requests

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -97,8 +97,9 @@ func appDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
+	evt.SetLogWriter(writer)
 	w.Header().Set("Content-Type", "application/x-json-stream")
-	return app.Delete(&a, writer)
+	return app.Delete(&a, evt, requestIDHeader(r))
 }
 
 // miniApp is a minimal representation of the app, created to make appList
@@ -1249,7 +1250,7 @@ func bindServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token) (
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	err = instance.BindApp(a, !noRestart, writer)
+	err = instance.BindApp(a, !noRestart, writer, evt, requestIDHeader(r))
 	if err != nil {
 		return err
 	}
@@ -1311,7 +1312,7 @@ func unbindServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	err = instance.UnbindApp(a, !noRestart, writer)
+	err = instance.UnbindApp(a, !noRestart, writer, evt, requestIDHeader(r))
 	if err != nil {
 		return err
 	}

--- a/api/service.go
+++ b/api/service.go
@@ -235,8 +235,9 @@ func serviceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
+	var evt *event.Event
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		evt, err := event.New(&event.Opts{
+		evt, err = event.New(&event.Opts{
 			Target: serviceTarget(s.Name),
 			Kind:   permission.PermServiceUpdateProxy,
 			Owner:  t,
@@ -252,7 +253,7 @@ func serviceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 		defer func() { evt.Done(err) }()
 	}
 	path := r.URL.Query().Get("callback")
-	return service.Proxy(&s, path, w, r)
+	return service.Proxy(&s, path, evt, requestIDHeader(r), w, r)
 }
 
 // title: grant access to a service

--- a/app/app.go
+++ b/app/app.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 	"sync"
@@ -574,7 +573,7 @@ func processTags(tags []string) []string {
 // unbind takes all service instances that are bound to the app, and unbind
 // them. This method is used by Destroy (before destroying the app, it unbinds
 // all service instances). Refer to Destroy docs for more details.
-func (app *App) unbind() error {
+func (app *App) unbind(evt *event.Event, requestID string) error {
 	instances, err := service.GetServiceInstancesBoundToApp(app.Name)
 	if err != nil {
 		return err
@@ -587,7 +586,7 @@ func (app *App) unbind() error {
 		msg += fmt.Sprintf("- %s (%s)", instanceName, reason.Error())
 	}
 	for _, instance := range instances {
-		err = instance.UnbindApp(app, true, nil)
+		err = instance.UnbindApp(app, true, nil, evt, requestID)
 		if err != nil {
 			addMsg(instance.Name, err)
 		}
@@ -620,7 +619,8 @@ func (app *App) unbindVolumes() error {
 }
 
 // Delete deletes an app.
-func Delete(app *App, w io.Writer) error {
+func Delete(app *App, evt *event.Event, requestID string) error {
+	w := evt
 	isSwapped, swappedWith, err := router.IsSwapped(app.GetName())
 	if err != nil {
 		return errors.Wrap(err, "unable to check if app is swapped")
@@ -629,9 +629,6 @@ func Delete(app *App, w io.Writer) error {
 		return errors.Errorf("application is swapped with %q, cannot remove it", swappedWith)
 	}
 	appName := app.Name
-	if w == nil {
-		w = ioutil.Discard
-	}
 	fmt.Fprintf(w, "---- Removing application %q...\n", appName)
 	var hasErrors bool
 	defer func() {
@@ -681,7 +678,7 @@ func Delete(app *App, w io.Writer) error {
 	if err != nil {
 		log.Errorf("failed to remove image names from storage for app %s: %s", appName, err)
 	}
-	err = app.unbind()
+	err = app.unbind(evt, requestID)
 	if err != nil {
 		logErr("Unable to unbind app", err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/db"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	"github.com/tsuru/tsuru/validation"
@@ -231,12 +232,12 @@ type ServiceModel struct {
 
 // Proxy is a proxy between tsuru and the service.
 // This method allow customized service methods.
-func Proxy(service *Service, path string, w http.ResponseWriter, r *http.Request) error {
+func Proxy(service *Service, path string, evt *event.Event, requestID string, w http.ResponseWriter, r *http.Request) error {
 	endpoint, err := service.getClient("production")
 	if err != nil {
 		return err
 	}
-	return endpoint.Proxy(path, w, r)
+	return endpoint.Proxy(path, evt, requestID, w, r)
 }
 
 func RenameServiceTeam(oldName, newName string) error {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -18,9 +18,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/app/bind"
-	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
@@ -65,13 +65,13 @@ func (bu Unit) GetIp() string {
 }
 
 // DeleteInstance deletes the service instance from the database.
-func DeleteInstance(si *ServiceInstance, requestID string) error {
+func DeleteInstance(si *ServiceInstance, evt *event.Event, requestID string) error {
 	if len(si.Apps) > 0 {
 		return ErrServiceInstanceBound
 	}
 	endpoint, err := si.Service().getClient("production")
 	if err == nil {
-		endpoint.Destroy(si, requestID)
+		endpoint.Destroy(si, evt, requestID)
 	}
 	conn, err := db.Conn()
 	if err != nil {
@@ -147,7 +147,7 @@ func (si *ServiceInstance) FindApp(appName string) int {
 }
 
 // Update changes informations of the service instance.
-func (si *ServiceInstance) Update(service Service, updateData ServiceInstance, requestID string) error {
+func (si *ServiceInstance) Update(service Service, updateData ServiceInstance, evt *event.Event, requestID string) error {
 	err := validateServiceInstanceTeamOwner(updateData)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func (si *ServiceInstance) Update(service Service, updateData ServiceInstance, r
 	}
 	actions := []*action.Action{&updateServiceInstance, &notifyUpdateServiceInstance}
 	pipeline := action.NewPipeline(actions...)
-	return pipeline.Execute(service, *si, updateData, requestID)
+	return pipeline.Execute(service, *si, updateData, evt, requestID)
 }
 
 func (si *ServiceInstance) updateData(update bson.M) error {
@@ -178,12 +178,14 @@ func (si *ServiceInstance) updateData(update bson.M) error {
 }
 
 // BindApp makes the bind between the service instance and an app.
-func (si *ServiceInstance) BindApp(app bind.App, shouldRestart bool, writer io.Writer) error {
+func (si *ServiceInstance) BindApp(app bind.App, shouldRestart bool, writer io.Writer, evt *event.Event, requestID string) error {
 	args := bindPipelineArgs{
 		serviceInstance: si,
 		app:             app,
 		writer:          writer,
 		shouldRestart:   shouldRestart,
+		event:           evt,
+		requestID:       requestID,
 	}
 	actions := []*action.Action{
 		bindAppDBAction,
@@ -243,7 +245,7 @@ func (si *ServiceInstance) BindUnit(app bind.App, unit bind.Unit) error {
 }
 
 // UnbindApp makes the unbind between the service instance and an app.
-func (si *ServiceInstance) UnbindApp(app bind.App, shouldRestart bool, writer io.Writer) error {
+func (si *ServiceInstance) UnbindApp(app bind.App, shouldRestart bool, writer io.Writer, evt *event.Event, requestID string) error {
 	if si.FindApp(app.GetName()) == -1 {
 		return ErrAppNotBound
 	}
@@ -252,6 +254,8 @@ func (si *ServiceInstance) UnbindApp(app bind.App, shouldRestart bool, writer io
 		app:             app,
 		writer:          writer,
 		shouldRestart:   shouldRestart,
+		event:           evt,
+		requestID:       requestID,
 	}
 	actions := []*action.Action{
 		&unbindUnits,
@@ -389,7 +393,7 @@ func validateServiceInstanceTeamOwner(si ServiceInstance) error {
 	return err
 }
 
-func CreateServiceInstance(instance ServiceInstance, service *Service, user *auth.User, requestID string) error {
+func CreateServiceInstance(instance ServiceInstance, service *Service, evt *event.Event, requestID string) error {
 	err := validateServiceInstance(instance, service)
 	if err != nil {
 		return err
@@ -399,7 +403,7 @@ func CreateServiceInstance(instance ServiceInstance, service *Service, user *aut
 	instance.Tags = processTags(instance.Tags)
 	actions := []*action.Action{&notifyCreateServiceInstance, &createServiceInstance}
 	pipeline := action.NewPipeline(actions...)
-	return pipeline.Execute(*service, instance, user.Email, requestID)
+	return pipeline.Execute(*service, instance, evt, requestID)
 }
 
 func GetServiceInstancesByServices(services []Service) ([]ServiceInstance, error) {
@@ -502,7 +506,7 @@ func RenameServiceInstanceTeam(oldName, newName string) error {
 
 // ProxyInstance is a proxy between tsuru and the service instance.
 // This method allow customized service instance methods.
-func ProxyInstance(instance *ServiceInstance, path string, w http.ResponseWriter, r *http.Request) error {
+func ProxyInstance(instance *ServiceInstance, path string, evt *event.Event, requestID string, w http.ResponseWriter, r *http.Request) error {
 	service := instance.Service()
 	endpoint, err := service.getClient("production")
 	if err != nil {
@@ -517,5 +521,5 @@ func ProxyInstance(instance *ServiceInstance, path string, w http.ResponseWriter
 			}
 		}
 	}
-	return endpoint.Proxy(fmt.Sprintf("%s%s", prefix, path), w, r)
+	return endpoint.Proxy(fmt.Sprintf("%s%s", prefix, path), evt, requestID, w, r)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -360,7 +360,8 @@ func (s *S) TestProxy(c *check.C) {
 	request, err := http.NewRequest("DELETE", "/something", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
-	err = Proxy(&service, "/aaa", recorder, request)
+	evt := createEvt(c)
+	err = Proxy(&service, "/aaa", evt, "", recorder, request)
 	c.Assert(err, check.IsNil)
 	c.Assert(recorder.Code, check.Equals, http.StatusNoContent)
 }


### PR DESCRIPTION
User and Event ID are sent in all non-GET requests to service endpoints,
also the request ID header was missing from the bind/unbind-app requests
as was added in this PR.

For proxy requests the user and event IDs are sent as a header value
(X-Tsuru-User/Eventid) to preserve the original message body.