### PR TITLE
provision/kubernetes: attach with tty on containers started with tty

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -624,7 +624,7 @@ func runPod(args runSinglePodArgs) error {
 	if err != nil {
 		multiErr.Add(err)
 	}
-	err = doAttach(args.client, bytes.NewBufferString("."), args.stdout, args.stderr, pod.Name, args.name)
+	err = doAttach(args.client, bytes.NewBufferString("."), args.stdout, args.stderr, pod.Name, args.name, false)
 	if err != nil {
 		multiErr.Add(errors.WithStack(err))
 	}


### PR DESCRIPTION
On containers started with TTY: true, kubernetes 1.9+ will automatically
try to attach with TTY enabled. This causes a problem if stderr is also
set on the attach call because stderr and tty cannot both be enabled on
the same attach call.