### PR TITLE
api: ensure servers are shutdown before tsuru shutdown handlers are called

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -134,7 +134,9 @@ func (s *S) TestCreateServersHTTPOnly(c *check.C) {
 	defer resetHandlers()
 
 	handler := RunServer(true)
-	go createServers(handler)
+	srvConf, err := createServers(handler)
+	c.Assert(err, check.IsNil)
+	go srvConf.start()
 
 	err = waitForServer("localhost:" + port)
 	c.Assert(err, check.IsNil)
@@ -155,7 +157,9 @@ func (s *S) TestCreateServersHTTPSOnly(c *check.C) {
 	defer resetHandlers()
 
 	handler := RunServer(true)
-	go createServers(handler)
+	srvConf, err := createServers(handler)
+	c.Assert(err, check.IsNil)
+	go srvConf.start()
 
 	err = waitForServer("localhost:" + port)
 	c.Assert(err, check.IsNil)
@@ -177,7 +181,9 @@ func (s *S) TestCreateServersHTTPSOnlyWithTlsListenConfig(c *check.C) {
 	defer resetHandlers()
 
 	handler := RunServer(true)
-	go createServers(handler)
+	srvConf, err := createServers(handler)
+	c.Assert(err, check.IsNil)
+	go srvConf.start()
 
 	err = waitForServer("localhost:" + port)
 	c.Assert(err, check.IsNil)
@@ -201,7 +207,9 @@ func (s *S) TestCreateServersHTTPAndHTTPS(c *check.C) {
 	defer resetHandlers()
 
 	handler := RunServer(true)
-	go createServers(handler)
+	srvConf, err := createServers(handler)
+	c.Assert(err, check.IsNil)
+	go srvConf.start()
 
 	err = waitForServer("localhost:" + httpsPort)
 	c.Assert(err, check.IsNil)

--- a/api/shutdown/shutdown.go
+++ b/api/shutdown/shutdown.go
@@ -34,27 +34,27 @@ func Do(ctx context.Context, w io.Writer) error {
 	lock.Lock()
 	defer lock.Unlock()
 	done := make(chan bool)
+	wg := sync.WaitGroup{}
+	for _, h := range registered {
+		wg.Add(1)
+		go func(h Shutdownable) {
+			defer wg.Done()
+			var name string
+			if _, ok := h.(fmt.Stringer); ok {
+				name = fmt.Sprintf("%s", h)
+			} else {
+				name = fmt.Sprintf("%T", h)
+			}
+			fmt.Fprintf(w, "running shutdown for %s...\n", name)
+			err := h.Shutdown(ctx)
+			if err != nil {
+				fmt.Fprintf(w, "running shutdown for %s. ERROED: %v", name, err)
+				return
+			}
+			fmt.Fprintf(w, "running shutdown for %s. DONE.\n", name)
+		}(h)
+	}
 	go func() {
-		wg := sync.WaitGroup{}
-		for _, h := range registered {
-			wg.Add(1)
-			go func(h Shutdownable) {
-				defer wg.Done()
-				var name string
-				if _, ok := h.(fmt.Stringer); ok {
-					name = fmt.Sprintf("%s", h)
-				} else {
-					name = fmt.Sprintf("%T", h)
-				}
-				fmt.Fprintf(w, "running shutdown for %s...\n", name)
-				err := h.Shutdown(ctx)
-				if err != nil {
-					fmt.Fprintf(w, "running shutdown for %s. ERROED: %v", name, err)
-					return
-				}
-				fmt.Fprintf(w, "running shutdown for %s. DONE.\n", name)
-			}(h)
-		}
 		wg.Wait()
 		close(done)
 	}()


### PR DESCRIPTION
There was a chance of the server exiting before the shutdown handlers
were called, potentially causing inconsistencies. Also a failure during
startup didn't call the shutdown handlers already registered. This was
fixed now.