### PR TITLE
provision/kubernetes: disable trying to fetch logs from failed pod

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -282,20 +281,6 @@ func newInvalidPodPhaseError(client *ClusterClient, pod *apiv1.Pod) error {
 	if err == nil && len(events.Items) > 0 {
 		lastEvt := events.Items[len(events.Items)-1]
 		retErr = errors.Errorf("%v - last event: %s", retErr, lastEvt.Message)
-	}
-	if len(pod.Spec.Containers) > 0 {
-		lastLog := int64(100)
-		req := client.CoreV1().Pods(client.Namespace()).GetLogs(pod.Name, &apiv1.PodLogOptions{
-			Container: pod.Spec.Containers[0].Name,
-			TailLines: &lastLog,
-		})
-		reader, logErr := req.Stream()
-		if logErr == nil {
-			logContent, _ := ioutil.ReadAll(reader)
-			if len(logContent) > 0 {
-				retErr = errors.Errorf("%v - log: %s", retErr, string(logContent))
-			}
-		}
 	}
 	return retErr
 }

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -269,22 +269,8 @@ func (s *S) TestWaitForPod(c *check.C) {
 			},
 			Message: "my evt message",
 		}},
-		{phase: apiv1.PodFailed, err: `invalid pod phase "Failed" - log: my log error`, containers: []apiv1.Container{
+		{phase: apiv1.PodFailed, err: `invalid pod phase "Failed"`, containers: []apiv1.Container{
 			{Name: "cont1"},
-		}},
-		{phase: apiv1.PodFailed, err: `invalid pod phase "Failed" - last event: my evt with log - log: my log error`, containers: []apiv1.Container{
-			{Name: "cont1"},
-		}, evt: &apiv1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod1.evt1",
-				Namespace: s.client.Namespace(),
-			},
-			InvolvedObject: apiv1.ObjectReference{
-				Kind:      "Pod",
-				Name:      "pod1",
-				Namespace: s.client.Namespace(),
-			},
-			Message: "my evt with log",
 		}},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This commit disables fetching logs from a failed Pod as this can result
in an unhelpful message in case the node is running docker with an
custom log driver.