### PR TITLE
provision/kubernetes: wait stdin on deploy pod startup

### DIFF
--- a/provision/kubernetes/builder.go
+++ b/provision/kubernetes/builder.go
@@ -43,6 +43,7 @@ func (c *KubeClient) BuildPod(a provision.App, evt *event.Event, archiveFile io.
 		destinationImage: buildingImage,
 		attachInput:      archiveFile,
 		attachOutput:     evt,
+		inputFile:        "/home/application/archive.tar.gz",
 	}
 	err = createBuildPod(params)
 	if err != nil {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -662,6 +662,7 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 		app:              a,
 		sourceImage:      "myimg",
 		destinationImage: "destimg",
+		inputFile:        "/home/application/archive.tar.gz",
 	})
 	c.Assert(err, check.IsNil)
 	pods, err := s.client.Core().Pods(s.client.Namespace()).List(metav1.ListOptions{})
@@ -728,6 +729,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 		app:              a,
 		sourceImage:      "myimg",
 		destinationImage: "destimg",
+		inputFile:        "/dev/null",
 	})
 	c.Assert(err, check.IsNil)
 	pods, err := s.client.CoreV1().Pods(s.client.Namespace()).List(metav1.ListOptions{})
@@ -817,7 +819,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 			Name:  "myapp-v1-deploy",
 			Image: "myimg",
 			Command: []string{"/bin/sh", "-lc", `
-		tsuru_unit_agent   myapp deploy-only
+		cat >/dev/null && tsuru_unit_agent   myapp deploy-only
 		exit_code=$?
 		echo "${exit_code}" >/tmp/intercontainer/status
 		[ "${exit_code}" != "0" ] && exit "${exit_code}"

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -672,6 +672,8 @@ func (p *kubernetesProvisioner) Deploy(a provision.App, buildImageID string, evt
 			sourceImage:      buildImageID,
 			destinationImage: newImage,
 			attachOutput:     evt,
+			attachInput:      strings.NewReader("."),
+			inputFile:        "/dev/null",
 		}
 		err = createDeployPod(params)
 		if err != nil {


### PR DESCRIPTION
This allow us to correctly attach to the pod before any output is lost.