### PR TITLE
provision/kubernetes: removes hack to refresh nodes after update

### DIFF
--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -522,7 +522,6 @@ func (p *kubernetesProvisioner) AddNode(opts provision.AddNodeOptions) error {
 	}
 	if err == nil {
 		servicecommon.RebuildRoutesPoolApps(opts.Pool)
-		go refreshNodeTaints(client, hostAddr)
 	}
 	return err
 }
@@ -642,9 +641,6 @@ func (p *kubernetesProvisioner) internalNodeUpdate(opts provision.UpdateNodeOpti
 	node.Spec.Taints = taints
 	setNodeMetadata(node, opts.Pool, iaasID, opts.Metadata)
 	_, err = client.CoreV1().Nodes().Update(node)
-	if err == nil {
-		go refreshNodeTaints(client, opts.Address)
-	}
 	return err
 }
 


### PR DESCRIPTION
This commit removes a hack that became obsolate since
(https://github.com/kubernetes/kubernetes/commit/fb7674673f484123e92baf6c708cabfc1e15ed79).

Requires Kubernetes 1.7+.