### PR TITLE
provision: enable configuring custom scheme for healthcheck

### DIFF
--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -423,6 +423,7 @@ func (s *S) TestBuilderImageIDWithTsuruYaml(c *check.C) {
   path: /status
   method: GET
   status: 200
+  scheme: https
 hooks:
   build:
     - ./build1
@@ -467,6 +468,7 @@ hooks:
 			"path":   "/status",
 			"method": "GET",
 			"status": 200,
+			"scheme": "https",
 		},
 		"hooks": map[string]interface{}{
 			"build": []interface{}{"./build1", "./build2"},

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -165,6 +165,7 @@ func (s *S) TestImageIDWithTsuruYaml(c *check.C) {
   path: /status
   method: GET
   status: 200
+  scheme: https
 hooks:
   build:
     - ./build1
@@ -191,6 +192,7 @@ hooks:
 			"path":   "/status",
 			"method": "GET",
 			"status": 200,
+			"scheme": "https",
 		},
 		"hooks": map[string]interface{}{
 			"build": []interface{}{"./build1", "./build2"},

--- a/docs/using/tsuru.yaml.rst
+++ b/docs/using/tsuru.yaml.rst
@@ -75,6 +75,7 @@ Here is how you can configure a health check in your yaml file:
 
     healthcheck:
       path: /healthcheck
+      scheme: http
       method: GET
       status: 200
       match: .*OKAY.*
@@ -85,6 +86,7 @@ Here is how you can configure a health check in your yaml file:
 * ``healthcheck:path``: Which path to call in your application. This path will be
   called for each unit. It is the only mandatory field, if it's not set your
   health check will be ignored.
+* ``healthcheck:scheme``: Which scheme to use. Defaults to http.
 * ``healthcheck:method``: The method used to make the http request. Defaults to
   GET.
 * ``healthcheck:status``: The expected response code for the request. Defaults to

--- a/net/client.go
+++ b/net/client.go
@@ -51,5 +51,6 @@ func insecure(client http.Client) http.Client {
 		tlsConfig = &tls.Config{}
 	}
 	tlsConfig.InsecureSkipVerify = true
+	client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	return client
 }

--- a/net/client.go
+++ b/net/client.go
@@ -5,6 +5,7 @@
 package net
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -36,9 +37,19 @@ const (
 )
 
 var (
-	Dial5Full300Client, Dial5Dialer           = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, 5, true)
-	Dial5FullUnlimitedClient, _               = makeTimeoutHTTPClient(5*time.Second, 0, 5, true)
-	Dial5Full300ClientNoKeepAlive, _          = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, -1, true)
-	Dial5Full60ClientNoKeepAlive, _           = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, true)
-	Dial5Full60ClientNoKeepAliveNoRedirect, _ = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, false)
+	Dial5Full300Client, Dial5Dialer                = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, 5, true)
+	Dial5FullUnlimitedClient, _                    = makeTimeoutHTTPClient(5*time.Second, 0, 5, true)
+	Dial5Full300ClientNoKeepAlive, _               = makeTimeoutHTTPClient(5*time.Second, 5*time.Minute, -1, true)
+	Dial5Full60ClientNoKeepAlive, _                = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, true)
+	Dial5Full60ClientNoKeepAliveNoRedirect, _      = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, false)
+	Dial5Full60ClientNoKeepAliveNoRedirectInsecure = insecure(*Dial5Full60ClientNoKeepAliveNoRedirect)
 )
+
+func insecure(client http.Client) http.Client {
+	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	tlsConfig.InsecureSkipVerify = true
+	return client
+}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -303,6 +303,11 @@ func probeFromHC(hc provision.TsuruYamlHealthcheck, port int) (*apiv1.Probe, err
 	if hc.Path == "" {
 		return nil, nil
 	}
+	scheme := hc.Scheme
+	if scheme == "" {
+		scheme = provision.DefaultHealthcheckScheme
+	}
+	scheme = strings.ToUpper(scheme)
 	method := strings.ToUpper(hc.Method)
 	if method != "" && method != "GET" {
 		return nil, errors.New("healthcheck: only GET method is supported in kubernetes provisioner")
@@ -311,8 +316,9 @@ func probeFromHC(hc provision.TsuruYamlHealthcheck, port int) (*apiv1.Probe, err
 		FailureThreshold: int32(hc.AllowedFailures),
 		Handler: apiv1.Handler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path: hc.Path,
-				Port: intstr.FromInt(port),
+				Path:   hc.Path,
+				Port:   intstr.FromInt(port),
+				Scheme: apiv1.URIScheme(scheme),
 			},
 		},
 	}, nil

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -450,7 +450,8 @@ func (s *S) TestServiceManagerDeployServiceWithHC(c *check.C) {
 			"p2":  "cmd2",
 		},
 		"healthcheck": provision.TsuruYamlHealthcheck{
-			Path: "/hc",
+			Path:   "/hc",
+			Scheme: "https",
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -464,8 +465,9 @@ func (s *S) TestServiceManagerDeployServiceWithHC(c *check.C) {
 	c.Assert(dep.Spec.Template.Spec.Containers[0].ReadinessProbe, check.DeepEquals, &apiv1.Probe{
 		Handler: apiv1.Handler{
 			HTTPGet: &apiv1.HTTPGetAction{
-				Path: "/hc",
-				Port: intstr.FromInt(8888),
+				Path:   "/hc",
+				Port:   intstr.FromInt(8888),
+				Scheme: apiv1.URISchemeHTTPS,
 			},
 		},
 	})

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -22,7 +22,10 @@ import (
 	appTypes "github.com/tsuru/tsuru/types/app"
 )
 
-const defaultDockerProvisioner = "docker"
+const (
+	defaultDockerProvisioner = "docker"
+	DefaultHealthcheckScheme = "http"
+)
 
 var (
 	ErrInvalidStatus = errors.New("invalid status")
@@ -687,6 +690,7 @@ type TsuruYamlHealthcheck struct {
 	Path            string //`bson:",omitempty"`
 	Method          string //`bson:",omitempty"`
 	Status          int    //`bson:",omitempty"`
+	Scheme          string
 	Match           string `bson:",omitempty"`
 	RouterBody      string `json:"router_body" yaml:"router_body" bson:"router_body,omitempty"`
 	UseInRouter     bool   `json:"use_in_router" yaml:"use_in_router" bson:"use_in_router,omitempty"`

--- a/provision/swarm/healthcheck.go
+++ b/provision/swarm/healthcheck.go
@@ -19,6 +19,10 @@ func toHealthConfig(hc provision.TsuruYamlHealthcheck, port int) *container.Heal
 	method := hc.Method
 	match := hc.Match
 	status := hc.Status
+	scheme := hc.Scheme
+	if scheme == "" {
+		scheme = provision.DefaultHealthcheckScheme
+	}
 	allowedFailures := hc.AllowedFailures
 	if path == "" {
 		return nil
@@ -35,7 +39,7 @@ func toHealthConfig(hc provision.TsuruYamlHealthcheck, port int) *container.Heal
 	if maxWaitTime == 0 {
 		maxWaitTime = 120
 	}
-	curlLine := fmt.Sprintf("curl -X%s -fsSL http://localhost:%d/%s", method, port, strings.TrimPrefix(path, "/"))
+	curlLine := fmt.Sprintf("curl -k -X%s -fsSL %s://localhost:%d/%s", method, scheme, port, strings.TrimPrefix(path, "/"))
 	if match != "" {
 		curlLine = fmt.Sprintf("%s | egrep %q", curlLine, match)
 	} else {

--- a/provision/swarm/healthcheck_test.go
+++ b/provision/swarm/healthcheck_test.go
@@ -27,7 +27,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 		}, expected: &container.HealthConfig{
 			Test: []string{
 				"CMD-SHELL",
-				"curl -XPUT -fsSL http://localhost:9000/ -o/dev/null -w '%{http_code}' | grep 200",
+				"curl -k -XPUT -fsSL http://localhost:9000/ -o/dev/null -w '%{http_code}' | grep 200",
 			},
 			Timeout:  120 * time.Second,
 			Interval: 3 * time.Second,
@@ -36,10 +36,11 @@ func (s *S) TestToHealthConfig(c *check.C) {
 		{input: provision.TsuruYamlHealthcheck{
 			Path:   "/hc",
 			Status: 201,
+			Scheme: "https",
 		}, expected: &container.HealthConfig{
 			Test: []string{
 				"CMD-SHELL",
-				"curl -XGET -fsSL http://localhost:9000/hc -o/dev/null -w '%{http_code}' | grep 201",
+				"curl -k -XGET -fsSL https://localhost:9000/hc -o/dev/null -w '%{http_code}' | grep 201",
 			},
 			Timeout:  120 * time.Second,
 			Interval: 3 * time.Second,
@@ -53,7 +54,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 		}, expected: &container.HealthConfig{
 			Test: []string{
 				"CMD-SHELL",
-				"curl -XGET -fsSL http://localhost:9000/hc | egrep \"WORK.NG[0-9]+\"",
+				"curl -k -XGET -fsSL http://localhost:9000/hc | egrep \"WORK.NG[0-9]+\"",
 			},
 			Timeout:  120 * time.Second,
 			Interval: 3 * time.Second,

--- a/provision/swarm/provisioner_test.go
+++ b/provision/swarm/provisioner_test.go
@@ -686,7 +686,7 @@ func (s *S) TestAddUnitsWithHealthcheck(c *check.C) {
 	c.Assert(service.Spec.TaskTemplate.ContainerSpec.Healthcheck, check.DeepEquals, &container.HealthConfig{
 		Test: []string{
 			"CMD-SHELL",
-			"curl -XGET -fsSL http://localhost:8888/hc -o/dev/null -w '%{http_code}' | grep 200",
+			"curl -k -XGET -fsSL http://localhost:8888/hc -o/dev/null -w '%{http_code}' | grep 200",
 		},
 		Timeout:  120 * time.Second,
 		Retries:  1,


### PR DESCRIPTION
This PR adds support for custom schemes on the healthcheck. In all provisioners,
certificate validation is skipped (this is the behavior for kubernetes probes).

We should probably consider exposing the scheme to be used on the router healthcheck.