### PR TITLE
builder,provision: adding the latest tag to deploy image

### DIFF
--- a/builder/docker/actions.go
+++ b/builder/docker/actions.go
@@ -210,7 +210,7 @@ var followLogsAndCommit = action.Action{
 			return nil, err
 		}
 		fmt.Fprintf(args.writer, "\n---- Building image ----\n")
-		imageID, err := c.Commit(args.client, limiter(), args.writer)
+		imageID, err := c.Commit(args.client, limiter(), args.writer, false)
 		if err != nil {
 			log.Errorf("error on commit container %s - %s", c.ID, err)
 			return nil, err

--- a/builder/docker/actions_test.go
+++ b/builder/docker/actions_test.go
@@ -272,7 +272,7 @@ func (s *S) TestUpdateAppBuilderImageForward(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
-	imgID, err := cont.Commit(builderClient(client), limiter(), buf)
+	imgID, err := cont.Commit(builderClient(client), limiter(), buf, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(imgID, check.Equals, "tsuru/app-mightyapp:v1")
 	c.Assert(buf.String(), check.Not(check.Equals), "")

--- a/provision/docker/actions.go
+++ b/provision/docker/actions.go
@@ -804,7 +804,7 @@ var followLogsAndCommit = action.Action{
 			}
 		}
 		fmt.Fprintf(args.writer, "\n---- Deploying application image ----\n")
-		imageID, err := c.Commit(args.provisioner.ClusterClient(), args.provisioner.ActionLimiter(), args.writer)
+		imageID, err := c.Commit(args.provisioner.ClusterClient(), args.provisioner.ActionLimiter(), args.writer, true)
 		if err != nil {
 			log.Errorf("error on commit container %s - %s", c.ID, err)
 			return nil, err

--- a/provision/docker/actions_test.go
+++ b/provision/docker/actions_test.go
@@ -1285,7 +1285,7 @@ func (s *S) TestUpdateAppImageForward(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	buf := safe.NewBuffer(nil)
-	imgID, err := cont.Commit(s.p.ClusterClient(), s.p.ActionLimiter(), buf)
+	imgID, err := cont.Commit(s.p.ClusterClient(), s.p.ActionLimiter(), buf, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(imgID, check.Equals, registry.Addr()+"/tsuru/app-mightyapp:v2")
 	c.Assert(buf.String(), check.Not(check.Equals), "")

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -638,12 +638,13 @@ func (s *S) TestDeployErasesOldImagesIfFailed(c *check.C) {
 	c.Assert(err, check.ErrorMatches, ".*my awesome error.*")
 	imgs, err := s.p.Cluster().ListImages(docker.ListImagesOptions{All: true})
 	c.Assert(err, check.IsNil)
-	c.Assert(imgs, check.HasLen, 2)
+	c.Assert(imgs, check.HasLen, 3)
 	c.Assert(imgs[0].RepoTags, check.HasLen, 1)
 	c.Assert(imgs[1].RepoTags, check.HasLen, 1)
-	got := []string{imgs[0].RepoTags[0], imgs[1].RepoTags[0]}
+	c.Assert(imgs[2].RepoTags, check.HasLen, 1)
+	got := []string{imgs[0].RepoTags[0], imgs[1].RepoTags[0], imgs[2].RepoTags[0]}
 	sort.Strings(got)
-	expected := []string{"tsuru/app-appdeployimagetest:v1-builder", "tsuru/python:latest"}
+	expected := []string{"tsuru/app-appdeployimagetest:latest", "tsuru/app-appdeployimagetest:v1-builder", "tsuru/python:latest"}
 	c.Assert(got, check.DeepEquals, expected)
 }
 

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -638,13 +638,12 @@ func (s *S) TestDeployErasesOldImagesIfFailed(c *check.C) {
 	c.Assert(err, check.ErrorMatches, ".*my awesome error.*")
 	imgs, err := s.p.Cluster().ListImages(docker.ListImagesOptions{All: true})
 	c.Assert(err, check.IsNil)
-	c.Assert(imgs, check.HasLen, 3)
+	c.Assert(imgs, check.HasLen, 2)
 	c.Assert(imgs[0].RepoTags, check.HasLen, 1)
 	c.Assert(imgs[1].RepoTags, check.HasLen, 1)
-	c.Assert(imgs[2].RepoTags, check.HasLen, 1)
-	got := []string{imgs[0].RepoTags[0], imgs[1].RepoTags[0], imgs[2].RepoTags[0]}
+	got := []string{imgs[0].RepoTags[0], imgs[1].RepoTags[0]}
 	sort.Strings(got)
-	expected := []string{"tsuru/app-appdeployimagetest:latest", "tsuru/app-appdeployimagetest:v1-builder", "tsuru/python:latest"}
+	expected := []string{"tsuru/app-appdeployimagetest:v1-builder", "tsuru/python:latest"}
 	c.Assert(got, check.DeepEquals, expected)
 }
 

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -143,19 +143,13 @@ func createDeployPod(params createPodParams) error {
 		}
 	}
 	params.cmds = cmds
-	destinationImageWithoutTag := params.destinationImage
-	parts := strings.Split(params.destinationImage, ":")
-	tag := "latest"
-	if len(parts) == 3 {
-		destinationImageWithoutTag = strings.Join([]string{parts[0], parts[1]}, ":")
-		tag = parts[2]
-	}
+	repository, tag := image.SplitImageName(params.destinationImage)
 	if tag != "latest" {
 		params.sidecarCmds = []string{
 			fmt.Sprintf(`
 				docker tag %[1]s %[2]s:latest
 				docker push %[2]s:latest
-			`, params.destinationImage, destinationImageWithoutTag),
+			`, params.destinationImage, repository),
 		}
 	}
 	return createPod(params)

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -984,6 +984,127 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 	c.Assert(buf.String(), check.Matches, `(?s).* ---> myapp-v1-deploy - msg1 \[c1\].* ---> myapp-v1-deploy - mycont - msg2 \[c1, n1\].*`)
 }
 
+func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
+	a, _, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	err := createDeployPod(createPodParams{
+		client:           s.clusterClient,
+		app:              a,
+		sourceImage:      "myimg",
+		destinationImage: "ip:destimg:v1",
+		inputFile:        "/dev/null",
+	})
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.CoreV1().Pods(s.client.Namespace()).List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(pods.Items, check.HasLen, 1)
+	containers := pods.Items[0].Spec.Containers
+	pods.Items[0].Spec.Containers = nil
+	pods.Items[0].Status = apiv1.PodStatus{}
+	c.Assert(pods.Items[0], check.DeepEquals, apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myapp-v1-deploy",
+			Namespace: s.client.Namespace(),
+			Labels: map[string]string{
+				"tsuru.io/is-deploy":            "false",
+				"tsuru.io/is-stopped":           "false",
+				"tsuru.io/is-tsuru":             "true",
+				"tsuru.io/app-name":             "myapp",
+				"tsuru.io/router-type":          "fake",
+				"tsuru.io/is-isolated-run":      "false",
+				"tsuru.io/builder":              "",
+				"tsuru.io/app-process":          "",
+				"tsuru.io/is-build":             "true",
+				"tsuru.io/app-platform":         "python",
+				"tsuru.io/is-service":           "true",
+				"tsuru.io/app-process-replicas": "0",
+				"tsuru.io/app-pool":             "test-default",
+				"tsuru.io/provisioner":          "kubernetes",
+				"tsuru.io/router-name":          "fake",
+			},
+			Annotations: map[string]string{"build-image": "ip:destimg:v1"},
+		},
+		Spec: apiv1.PodSpec{
+			ServiceAccountName: "app-myapp",
+			NodeName:           "n1",
+			NodeSelector:       map[string]string{"tsuru.io/pool": "test-default"},
+			Volumes: []apiv1.Volume{
+				{
+					Name: "dockersock",
+					VolumeSource: apiv1.VolumeSource{
+						HostPath: &apiv1.HostPathVolumeSource{
+							Path: dockerSockPath,
+						},
+					},
+				},
+				{
+					Name: "intercontainer",
+					VolumeSource: apiv1.VolumeSource{
+						EmptyDir: &apiv1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			RestartPolicy: apiv1.RestartPolicyNever,
+		},
+	})
+	c.Assert(containers, check.HasLen, 2)
+	sort.Slice(containers, func(i, j int) bool { return containers[i].Name < containers[j].Name })
+	runAsUser := int64(1000)
+	c.Assert(containers, check.DeepEquals, []apiv1.Container{
+		{
+			Name:  "committer-cont",
+			Image: "docker:1.11.2",
+			VolumeMounts: []apiv1.VolumeMount{
+				{Name: "dockersock", MountPath: dockerSockPath},
+				{Name: "intercontainer", MountPath: buildIntercontainerPath},
+			},
+			TTY: true,
+			Command: []string{
+				"sh", "-ec",
+				`
+							end() { touch /tmp/intercontainer/done; }
+							trap end EXIT
+							while [ ! -f /tmp/intercontainer/status ]; do sleep 1; done
+							exit_code=$(cat /tmp/intercontainer/status)
+							[ "${exit_code}" != "0" ] && exit "${exit_code}"
+							id=$(docker ps -aq -f "label=io.kubernetes.container.name=myapp-v1-deploy" -f "label=io.kubernetes.pod.name=$(hostname)")
+							img="ip:destimg:v1"
+							echo
+							echo '---- Building application image ----'
+							docker commit "${id}" "${img}" >/dev/null
+							sz=$(docker history "${img}" | head -2 | tail -1 | grep -E -o '[0-9.]+\s[a-zA-Z]+\s*$' | sed 's/[[:space:]]*$//g')
+							echo " ---> Sending image to repository (${sz})"
+							docker push "${img}"
+						
+
+				docker tag ip:destimg:v1 ip:destimg:latest
+				docker push ip:destimg:latest
+			`,
+			},
+		},
+		{
+			Name:  "myapp-v1-deploy",
+			Image: "myimg",
+			Command: []string{"/bin/sh", "-lc", `
+		cat >/dev/null && tsuru_unit_agent   myapp deploy-only
+		exit_code=$?
+		echo "${exit_code}" >/tmp/intercontainer/status
+		[ "${exit_code}" != "0" ] && exit "${exit_code}"
+		while [ ! -f /tmp/intercontainer/done ]; do sleep 1; done
+	`},
+			Stdin:     true,
+			StdinOnce: true,
+			Env:       []apiv1.EnvVar{{Name: "TSURU_HOST", Value: ""}},
+			SecurityContext: &apiv1.SecurityContext{
+				RunAsUser: &runAsUser,
+			},
+			VolumeMounts: []apiv1.VolumeMount{
+				{Name: "intercontainer", MountPath: buildIntercontainerPath},
+			},
+		},
+	})
+}
+
 func (s *S) TestServiceManagerDeployServiceWithVolumes(c *check.C) {
 	config.Set("docker:uid", 1001)
 	defer config.Unset("docker:uid")

--- a/provision/swarm/provisioner_test.go
+++ b/provision/swarm/provisioner_test.go
@@ -1097,7 +1097,7 @@ func (s *S) TestDeploy(c *check.C) {
 	attached := s.attachRegister(c, s.clusterSrv, true, a)
 	tags := []string{}
 	s.clusterSrv.CustomHandler("/images/.*/push", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(r.URL.Path, check.Equals, "/images/"+fmt.Sprintf("registry.tsuru.io/tsuru/app-myapp")+"/push")
+		c.Assert(r.URL.Path, check.Equals, "/images/registry.tsuru.io/tsuru/app-myapp/push")
 		tags = append(tags, r.URL.Query().Get("tag"))
 		s.clusterSrv.DefaultHandler().ServeHTTP(w, r)
 	}))


### PR DESCRIPTION
This PR is related to #1945. Now, whenever you deploy a new version of your app, you can pull the last image using the tag `latest`.