### PR TITLE
Remove commit override if authenticated token is from a normal user

### DIFF
--- a/api/deploy.go
+++ b/api/deploy.go
@@ -59,7 +59,6 @@ func deploy(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		}
 		userName = r.FormValue("user")
 	} else {
-		commit = ""
 		userName = t.GetUserName()
 	}
 	instance, err := app.GetByName(appName)

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -494,7 +494,7 @@ func (s *DeploySuite) TestDeployWithCommit(c *check.C) {
 			"app.name":   a.Name,
 			"commit":     "123",
 			"filesize":   0,
-			"kind":       "git",
+			"kind":       "archive-url",
 			"archiveurl": "http://something.tar.gz",
 			"user":       "fulano",
 			"image":      "",

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -547,7 +547,7 @@ func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
 			"archiveurl": "http://something.tar.gz",
 			"user":       s.token.GetUserName(),
 			"image":      "",
-			"origin":     "",
+			"origin":     "git",
 			"build":      false,
 			"rollback":   false,
 		},

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -541,7 +541,7 @@ func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
 		Kind:   "app.deploy",
 		StartCustomData: map[string]interface{}{
 			"app.name":   a.Name,
-			"commit":     "",
+			"commit":     "123",
 			"filesize":   0,
 			"kind":       "archive-url",
 			"archiveurl": "http://something.tar.gz",

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -195,7 +195,7 @@ func (o *DeployOptions) GetKind() (kind DeployKind) {
 		}
 		return DeployUpload
 	}
-	if o.Commit != "" {
+	if o.Commit != "" && o.ArchiveURL == "" {
 		return DeployGit
 	}
 	return DeployArchiveURL


### PR DESCRIPTION
This pull request is more a question than a PR. Is there any reason to override the commit id if the user is a normal user? My point is that is just meta data, what are the impacts? There no --commit option on tsuru-client, so if someone try to use it he is probably aware of what he is doing. 