### PR TITLE
app: control lifecycle of goroutines in app.List to update router addrs

### DIFF
--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -168,6 +168,7 @@ func (s *S) setupMocks() {
 }
 
 func (s *S) TearDownTest(c *check.C) {
+	app.GetAppRouterUpdater().Shutdown(stdcontext.Background())
 	cfg, _ := autoscale.CurrentConfig()
 	if cfg != nil {
 		cfg.Shutdown(stdcontext.Background())

--- a/app/app.go
+++ b/app/app.go
@@ -1869,7 +1869,7 @@ func loadCachedAddrsInApps(apps []App) error {
 			}
 		}
 		if hasEmpty {
-			go a.GetRoutersWithAddr()
+			GetAppRouterUpdater().update(a)
 		}
 	}
 	return nil

--- a/app/routerupdater.go
+++ b/app/routerupdater.go
@@ -1,0 +1,58 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tsuru/tsuru/api/shutdown"
+)
+
+const appBackgroudRouterUpdaterLimit = 20
+
+type appRouterUpdater struct {
+	limiter chan struct{}
+	wg      sync.WaitGroup
+}
+
+var globalAppRouterUpdater struct {
+	updater *appRouterUpdater
+	once    sync.Once
+}
+
+func GetAppRouterUpdater() *appRouterUpdater {
+	globalAppRouterUpdater.once.Do(func() {
+		globalAppRouterUpdater.updater = &appRouterUpdater{
+			limiter: make(chan struct{}, appBackgroudRouterUpdaterLimit),
+		}
+		shutdown.Register(globalAppRouterUpdater.updater)
+	})
+	return globalAppRouterUpdater.updater
+}
+
+func (u *appRouterUpdater) update(a *App) {
+	u.wg.Add(1)
+	go func() {
+		u.limiter <- struct{}{}
+		defer func() { <-u.limiter }()
+		defer u.wg.Done()
+		a.GetRoutersWithAddr()
+	}()
+}
+
+func (u *appRouterUpdater) Shutdown(ctx context.Context) error {
+	waitCh := make(chan struct{})
+	go func() {
+		u.wg.Wait()
+		close(waitCh)
+	}()
+	select {
+	case <-waitCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}

--- a/app/routerupdater_test.go
+++ b/app/routerupdater_test.go
@@ -1,0 +1,28 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import (
+	"context"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestAppRouterUpdaterUpdateWait(c *check.C) {
+	a := App{
+		Name:      "app1",
+		TeamOwner: s.team.Name,
+	}
+	err := CreateApp(&a, s.user)
+	c.Assert(err, check.IsNil)
+	updater := GetAppRouterUpdater()
+	updater.update(&a)
+	err = updater.Shutdown(context.Background())
+	c.Assert(err, check.IsNil)
+	apps, err := List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(apps, check.HasLen, 1)
+	c.Assert(apps[0].Routers[0].Address, check.Equals, "app1.fakerouter.com")
+}

--- a/app/suite_test.go
+++ b/app/suite_test.go
@@ -5,11 +5,10 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
-
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
@@ -30,6 +29,7 @@ import (
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/check.v1"
 )
 
@@ -166,6 +166,10 @@ func (s *S) SetUpTest(c *check.C) {
 	builder.Register("fake", s.builder)
 	builder.DefaultBuilder = "fake"
 	setupMocks(s)
+}
+
+func (s *S) TearDownTest(c *check.C) {
+	GetAppRouterUpdater().Shutdown(context.Background())
 }
 
 func setupMocks(s *S) {

--- a/autoscale/autoscale_test.go
+++ b/autoscale/autoscale_test.go
@@ -5,6 +5,7 @@
 package autoscale
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"testing"
@@ -107,6 +108,7 @@ func (s *S) SetUpTest(c *check.C) {
 }
 
 func (s *S) TearDownTest(c *check.C) {
+	app.GetAppRouterUpdater().Shutdown(context.Background())
 	s.conn.Close()
 	config.Unset("docker:auto-scale:max-container-count")
 	config.Unset("docker:auto-scale:prevent-rebalance")

--- a/provision/docker/suite_test.go
+++ b/provision/docker/suite_test.go
@@ -5,6 +5,7 @@
 package docker
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -183,6 +184,7 @@ func (s *S) SetUpTest(c *check.C) {
 }
 
 func (s *S) TearDownTest(c *check.C) {
+	app.GetAppRouterUpdater().Shutdown(context.Background())
 	log.SetLogger(nil)
 	s.server.Stop()
 	if s.extraServer != nil {

--- a/provision/servicecommon/actions_test.go
+++ b/provision/servicecommon/actions_test.go
@@ -5,11 +5,13 @@
 package servicecommon
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/action"
+	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/app/image"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
@@ -67,6 +69,10 @@ func (s *S) SetUpTest(c *check.C) {
 	}
 	servicemanager.Team = s.mockService.Team
 	servicemanager.Plan = s.mockService.Plan
+}
+
+func (s *S) TearDownTest(c *check.C) {
+	app.GetAppRouterUpdater().Shutdown(context.Background())
 }
 
 type managerCall struct {

--- a/repository/gandalf/gandalf_test.go
+++ b/repository/gandalf/gandalf_test.go
@@ -6,6 +6,7 @@ package gandalf
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"testing"
 
@@ -45,6 +46,7 @@ func (s *GandalfSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *GandalfSuite) TearDownSuite(c *check.C) {
+	app.GetAppRouterUpdater().Shutdown(context.Background())
 	s.server.Stop()
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This allow us to limit the number of concurrent calls to the router and
to add a shutdown handler waiting for pending goroutines before
terminating the tsuru process.

This PR also update tests which call app.List to ensure the created
goroutines are finished after each test case.