### PR TITLE
api,app,auth: refactor service creation funcs to also return error

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -89,11 +89,20 @@ func setupServices() error {
 	if err != nil {
 		return err
 	}
-	servicemanager.Cache = app.CacheService()
-	servicemanager.Team = auth.TeamService()
-	servicemanager.Plan = app.PlanService()
-	servicemanager.Platform = app.PlatformService()
-	return nil
+	servicemanager.Cache, err = app.CacheService()
+	if err != nil {
+		return err
+	}
+	servicemanager.Team, err = auth.TeamService()
+	if err != nil {
+		return err
+	}
+	servicemanager.Plan, err = app.PlanService()
+	if err != nil {
+		return err
+	}
+	servicemanager.Platform, err = app.PlatformService()
+	return err
 }
 
 // RunServer starts tsuru API server. The dry parameter indicates whether the

--- a/app/cache.go
+++ b/app/cache.go
@@ -15,15 +15,15 @@ type cacheService struct {
 	storage appTypes.CacheStorage
 }
 
-func CacheService() appTypes.CacheService {
+func CacheService() (appTypes.CacheService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 	}
-	return &cacheService{dbDriver.CacheStorage}
+	return &cacheService{dbDriver.CacheStorage}, nil
 }
 
 func (s *cacheService) Create(entry appTypes.CacheEntry) error {

--- a/app/plan.go
+++ b/app/plan.go
@@ -14,17 +14,17 @@ type planService struct {
 	storage appTypes.PlanStorage
 }
 
-func PlanService() appTypes.PlanService {
+func PlanService() (appTypes.PlanService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 	}
 	return &planService{
 		storage: dbDriver.PlanStorage,
-	}
+	}, nil
 }
 
 // Create implements Create method of PlanService interface

--- a/app/platform.go
+++ b/app/platform.go
@@ -24,17 +24,17 @@ type platformService struct {
 	storage appTypes.PlatformStorage
 }
 
-func PlatformService() appTypes.PlatformService {
+func PlatformService() (appTypes.PlatformService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 	}
 	return &platformService{
 		storage: dbDriver.PlatformStorage,
-	}
+	}, nil
 }
 
 // Create implements Create method of PlatformService interface

--- a/auth/suite_test.go
+++ b/auth/suite_test.go
@@ -50,7 +50,7 @@ func (s *S) SetUpSuite(c *check.C) {
 	var err error
 	servicemanager.TeamToken, err = TeamTokenService()
 	c.Assert(err, check.IsNil)
-	servicemanager.Team = TeamService()
+	servicemanager.Team, err = TeamService()
 	c.Assert(err, check.IsNil)
 }
 
@@ -67,7 +67,9 @@ func (s *S) SetUpTest(c *check.C) {
 	s.hashed = s.user.Password
 	s.team = &authTypes.Team{Name: "cobrateam"}
 	u := authTypes.User(*s.user)
-	err = TeamService().Create(s.team.Name, &u)
+	svc, err := TeamService()
+	c.Assert(err, check.IsNil)
+	err = svc.Create(s.team.Name, &u)
 	c.Assert(err, check.IsNil)
 	s.server, err = authtest.NewSMTPServer()
 	c.Assert(err, check.IsNil)

--- a/auth/team.go
+++ b/auth/team.go
@@ -23,17 +23,17 @@ type teamService struct {
 	storage authTypes.TeamStorage
 }
 
-func TeamService() authTypes.TeamService {
+func TeamService() (authTypes.TeamService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 	}
 	return &teamService{
 		storage: dbDriver.TeamStorage,
-	}
+	}, nil
 }
 
 func (t *teamService) Create(name string, user *authTypes.User) error {


### PR DESCRIPTION
Returning an error is way better then an unexpected panic during
runtime.