### PR TITLE
app: handle race during default plan creation

### DIFF
--- a/app/plan.go
+++ b/app/plan.go
@@ -75,7 +75,14 @@ func (s *planService) DefaultPlan() (*appTypes.Plan, error) {
 	}
 	err = s.storage.Insert(dp)
 	if err != nil {
-		return nil, err
+		if err != appTypes.ErrPlanAlreadyExists {
+			return nil, err
+		}
+		plan, errDefault := s.storage.FindDefault()
+		if errDefault != nil {
+			return nil, errDefault
+		}
+		return plan, nil
 	}
 	return &dp, nil
 }


### PR DESCRIPTION
The planService `DefaultPlan()` method is racy. When two apps are created
in parallel there is a chance that we try to insert the "autogenerated"
plan multiple times, failing with: `Error: plan already exists`.

This commit adds a check to validate that after a "plan already exists"
error we are able to retrieve a default plan and return it.

This was caught by our integration tests which create apps in parallel.