### PR TITLE
Add support for webhooks triggered on events

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -84,6 +84,8 @@ func getAuthScheme() (string, error) {
 	return name, err
 }
 
+var onceServices sync.Once
+
 func setupServices() error {
 	var err error
 	servicemanager.TeamToken, err = auth.TeamTokenService()
@@ -122,10 +124,12 @@ func RunServer(dry bool) http.Handler {
 	if err != nil {
 		fatal(err)
 	}
-	err = setupServices()
-	if err != nil {
-		fatal(err)
-	}
+	onceServices.Do(func() {
+		err = setupServices()
+		if err != nil {
+			fatal(err)
+		}
+	})
 
 	m := apiRouter.NewRouter()
 

--- a/api/server.go
+++ b/api/server.go
@@ -106,7 +106,7 @@ func setupServices() error {
 	if err != nil {
 		return err
 	}
-	servicemanager.WebHook, err = webhook.WebHookService()
+	servicemanager.Webhook, err = webhook.WebhookService()
 	return err
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -223,6 +223,7 @@ func RunServer(dry bool) http.Handler {
 
 	m.Add("1.6", "Get", "/events/webhooks", AuthorizationRequiredHandler(webhookList))
 	m.Add("1.6", "Post", "/events/webhooks", AuthorizationRequiredHandler(webhookCreate))
+	m.Add("1.6", "Get", "/events/webhooks/{name}", AuthorizationRequiredHandler(webhookInfo))
 	m.Add("1.6", "Put", "/events/webhooks/{name}", AuthorizationRequiredHandler(webhookUpdate))
 	m.Add("1.6", "Delete", "/events/webhooks/{name}", AuthorizationRequiredHandler(webhookDelete))
 

--- a/api/server.go
+++ b/api/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tsuru/tsuru/autoscale"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/event/webhook"
 	"github.com/tsuru/tsuru/hc"
 	"github.com/tsuru/tsuru/healer"
 	"github.com/tsuru/tsuru/log"
@@ -102,6 +103,10 @@ func setupServices() error {
 		return err
 	}
 	servicemanager.Platform, err = app.PlatformService()
+	if err != nil {
+		return err
+	}
+	servicemanager.WebHook, err = webhook.WebHookService()
 	return err
 }
 
@@ -215,6 +220,11 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.1", "Get", "/events/kinds", AuthorizationRequiredHandler(kindList))
 	m.Add("1.1", "Get", "/events/{uuid}", AuthorizationRequiredHandler(eventInfo))
 	m.Add("1.1", "Post", "/events/{uuid}/cancel", AuthorizationRequiredHandler(eventCancel))
+
+	m.Add("1.6", "Get", "/events/webhooks", AuthorizationRequiredHandler(webhookList))
+	m.Add("1.6", "Post", "/events/webhooks", AuthorizationRequiredHandler(webhookCreate))
+	m.Add("1.6", "Put", "/events/webhooks/{name}", AuthorizationRequiredHandler(webhookUpdate))
+	m.Add("1.6", "Delete", "/events/webhooks/{name}", AuthorizationRequiredHandler(webhookDelete))
 
 	m.Add("1.0", "Get", "/platforms", AuthorizationRequiredHandler(platformList))
 	m.Add("1.0", "Post", "/platforms", AuthorizationRequiredHandler(platformAdd))

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -62,6 +62,12 @@ func webhookCreate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusBadRequest)
 		return err
 	}
+	if webhook.TeamOwner == "" {
+		webhook.TeamOwner, err = autoTeamOwner(t, permission.PermWebhookCreate)
+		if err != nil {
+			return err
+		}
+	}
 	ctx := permission.Context(permission.CtxTeam, webhook.TeamOwner)
 	if !permission.Check(t, permission.PermWebhookCreate, ctx) {
 		return permission.ErrUnauthorized

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/ajg/form"
+	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/servicemanager"
+	eventTypes "github.com/tsuru/tsuru/types/event"
+)
+
+// title: webhook list
+// path: /events/webhooks
+// method: GET
+// produce: application/json
+// responses:
+//   200: List webhooks
+//   204: No content
+//   401: Unauthorized
+func webhookList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
+	ctxs := permission.ContextsForPermission(t, permission.PermWebhookRead, permission.CtxTeam)
+	var teams []string
+	for _, c := range ctxs {
+		if c.CtxType == permission.CtxGlobal {
+			teams = nil
+			break
+		}
+		teams = append(teams, c.Value)
+	}
+	webhooks, err := servicemanager.WebHook.List(teams)
+	if err != nil {
+		return err
+	}
+	if len(webhooks) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return nil
+	}
+	return json.NewEncoder(w).Encode(webhooks)
+}
+
+// title: webhook create
+// path: /events/webhooks
+// method: POST
+// responses:
+//   200: Webhook created
+//   401: Unauthorized
+//   400: Invalid webhook
+//   409: Webhook already exists
+func webhookCreate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
+	r.ParseForm()
+	dec := form.NewDecoder(nil)
+	dec.IgnoreUnknownKeys(true)
+	dec.IgnoreCase(true)
+	var webhook eventTypes.WebHook
+	err := dec.DecodeValues(&webhook, r.Form)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return err
+	}
+	ctx := permission.Context(permission.CtxTeam, webhook.TeamOwner)
+	if !permission.Check(t, permission.PermWebhookCreate, ctx) {
+		return permission.ErrUnauthorized
+	}
+	evt, err := event.New(&event.Opts{
+		Target:     event.Target{Type: event.TargetTypeWebHook, Value: webhook.Name},
+		Kind:       permission.PermWebhookCreate,
+		Owner:      t,
+		CustomData: event.FormToCustomData(r.Form),
+		Allowed:    event.Allowed(permission.PermWebhookReadEvents, ctx),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		evt.Done(err)
+	}()
+	err = servicemanager.WebHook.Create(webhook)
+	if err == eventTypes.ErrWebHookAlreadyExists {
+		w.WriteHeader(http.StatusConflict)
+	} else if _, ok := err.(*errors.ValidationError); ok {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	return err
+}
+
+// title: webhook update
+// path: /events/webhooks/{name}
+// method: PUT
+// responses:
+//   200: Webhook updated
+//   401: Unauthorized
+//   400: Invalid webhook
+//   404: Webhook not found
+func webhookUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
+	r.ParseForm()
+	dec := form.NewDecoder(nil)
+	dec.IgnoreUnknownKeys(true)
+	dec.IgnoreCase(true)
+	var webhook eventTypes.WebHook
+	err := dec.DecodeValues(&webhook, r.Form)
+	if err != nil {
+		return &errors.HTTP{Code: http.StatusBadRequest, Message: fmt.Sprintf("unable to parse webhook: %v", err)}
+	}
+	webhook.Name = r.URL.Query().Get(":name")
+	ctx := permission.Context(permission.CtxTeam, webhook.TeamOwner)
+	if !permission.Check(t, permission.PermWebhookUpdate, ctx) {
+		return permission.ErrUnauthorized
+	}
+	evt, err := event.New(&event.Opts{
+		Target:     event.Target{Type: event.TargetTypeWebHook, Value: webhook.Name},
+		Kind:       permission.PermWebhookUpdate,
+		Owner:      t,
+		CustomData: event.FormToCustomData(r.Form),
+		Allowed:    event.Allowed(permission.PermWebhookReadEvents, ctx),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		evt.Done(err)
+	}()
+	err = servicemanager.WebHook.Update(webhook)
+	if err == eventTypes.ErrWebHookNotFound {
+		w.WriteHeader(http.StatusNotFound)
+	} else if _, ok := err.(*errors.ValidationError); ok {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	return err
+}
+
+// title: webhook delete
+// path: /events/webhooks/{name}
+// method: DELETE
+// responses:
+//   200: Webhook deleted
+//   401: Unauthorized
+//   404: Webhook not found
+func webhookDelete(w http.ResponseWriter, r *http.Request, t auth.Token) error {
+	webhookName := r.URL.Query().Get(":name")
+	webhook, err := servicemanager.WebHook.Find(webhookName)
+	if err != nil {
+		if err == eventTypes.ErrWebHookNotFound {
+			w.WriteHeader(http.StatusNotFound)
+		}
+		return err
+	}
+	ctx := permission.Context(permission.CtxTeam, webhook.TeamOwner)
+	if !permission.Check(t, permission.PermWebhookDelete, ctx) {
+		return permission.ErrUnauthorized
+	}
+	evt, err := event.New(&event.Opts{
+		Target:     event.Target{Type: event.TargetTypeWebHook, Value: webhook.Name},
+		Kind:       permission.PermWebhookDelete,
+		Owner:      t,
+		CustomData: event.FormToCustomData(r.Form),
+		Allowed:    event.Allowed(permission.PermWebhookReadEvents, ctx),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		evt.Done(err)
+	}()
+	return servicemanager.WebHook.Delete(webhookName)
+}

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -1,0 +1,317 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/ajg/form"
+	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/servicemanager"
+	eventTypes "github.com/tsuru/tsuru/types/event"
+	check "gopkg.in/check.v1"
+)
+
+func (s *S) TestWebHookList(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	webHook2 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh2",
+		URL:       "http://me",
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	err = servicemanager.WebHook.Create(webHook2)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	var result []eventTypes.WebHook
+	err = json.Unmarshal(recorder.Body.Bytes(), &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result, check.DeepEquals, []eventTypes.WebHook{
+		{
+			TeamOwner: s.team.Name,
+			Name:      "wh1",
+			URL:       "http://me",
+			Headers:   http.Header{},
+			EventFilter: eventTypes.WebHookEventFilter{
+				TargetTypes:  []string{},
+				TargetValues: []string{},
+				KindTypes:    []string{},
+				KindNames:    []string{"app.deploy"},
+			},
+		},
+		{
+			TeamOwner: s.team.Name,
+			Name:      "wh2",
+			URL:       "http://me",
+			Headers:   http.Header{},
+			EventFilter: eventTypes.WebHookEventFilter{
+				TargetTypes:  []string{},
+				TargetValues: []string{},
+				KindTypes:    []string{},
+				KindNames:    []string{},
+			},
+		},
+	})
+}
+
+func (s *S) TestWebHookListEmpty(c *check.C) {
+	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusNoContent)
+}
+
+func (s *S) TestWebHookListByTeam(c *check.C) {
+	token := userWithPermission(c, permission.Permission{
+		Scheme:  permission.PermWebhookRead,
+		Context: permission.Context(permission.CtxTeam, "t2"),
+	})
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	webHook2 := eventTypes.WebHook{
+		TeamOwner: "t2",
+		Name:      "wh2",
+		URL:       "http://me",
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	err = servicemanager.WebHook.Create(webHook2)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	var result []eventTypes.WebHook
+	err = json.Unmarshal(recorder.Body.Bytes(), &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result, check.DeepEquals, []eventTypes.WebHook{
+		{
+			TeamOwner: "t2",
+			Name:      "wh2",
+			URL:       "http://me",
+			Headers:   http.Header{},
+			EventFilter: eventTypes.WebHookEventFilter{
+				TargetTypes:  []string{},
+				TargetValues: []string{},
+				KindTypes:    []string{},
+				KindNames:    []string{},
+			},
+		},
+	})
+}
+
+func (s *S) TestWebHookCreate(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK, check.Commentf("body: %s", recorder.Body.String()))
+	wh, err := servicemanager.WebHook.Find("wh1")
+	c.Assert(err, check.IsNil)
+	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		Headers:   http.Header{},
+		EventFilter: eventTypes.WebHookEventFilter{
+			TargetTypes:  []string{},
+			TargetValues: []string{},
+			KindTypes:    []string{},
+			KindNames:    []string{"app.deploy"},
+		},
+	})
+}
+
+func (s *S) TestWebHookCreateConflict(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusConflict)
+}
+
+func (s *S) TestWebHookCreateInvalid(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+}
+
+func (s *S) TestWebHookUpdate(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	webHook1.Name = "---ignored---"
+	webHook1.URL += "/xyz"
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	wh, err := servicemanager.WebHook.Find("wh1")
+	c.Assert(err, check.IsNil)
+	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me/xyz",
+		Headers:   http.Header{},
+		EventFilter: eventTypes.WebHookEventFilter{
+			TargetTypes:  []string{},
+			TargetValues: []string{},
+			KindTypes:    []string{},
+			KindNames:    []string{"app.deploy"},
+		},
+	})
+}
+
+func (s *S) TestWebHookUpdateNotFound(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
+}
+
+func (s *S) TestWebHookUpdateInvalid(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	webHook1.URL = ""
+	bodyData, err := form.EncodeToString(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+}
+
+func (s *S) TestWebHookDelete(c *check.C) {
+	webHook1 := eventTypes.WebHook{
+		TeamOwner: s.team.Name,
+		Name:      "wh1",
+		URL:       "http://me",
+		EventFilter: eventTypes.WebHookEventFilter{
+			KindNames: []string{"app.deploy"},
+		},
+	}
+	err := servicemanager.WebHook.Create(webHook1)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("DELETE", "/1.6/events/webhooks/wh1", nil)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	_, err = servicemanager.WebHook.Find("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}
+
+func (s *S) TestWebHookDeleteNotFound(c *check.C) {
+	request, err := http.NewRequest("DELETE", "/1.6/events/webhooks/wh1", nil)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
+}

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -17,23 +17,23 @@ import (
 	check "gopkg.in/check.v1"
 )
 
-func (s *S) TestWebHookList(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookList(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	webHook2 := eventTypes.WebHook{
+	webhook2 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh2",
 		URL:       "http://me",
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
-	err = servicemanager.WebHook.Create(webHook2)
+	err = servicemanager.Webhook.Create(webhook2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
 	c.Assert(err, check.IsNil)
@@ -41,16 +41,16 @@ func (s *S) TestWebHookList(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var result []eventTypes.WebHook
+	var result []eventTypes.Webhook
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
-	c.Assert(result, check.DeepEquals, []eventTypes.WebHook{
+	c.Assert(result, check.DeepEquals, []eventTypes.Webhook{
 		{
 			TeamOwner: s.team.Name,
 			Name:      "wh1",
 			URL:       "http://me",
 			Headers:   http.Header{},
-			EventFilter: eventTypes.WebHookEventFilter{
+			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
 				KindTypes:    []string{},
@@ -62,7 +62,7 @@ func (s *S) TestWebHookList(c *check.C) {
 			Name:      "wh2",
 			URL:       "http://me",
 			Headers:   http.Header{},
-			EventFilter: eventTypes.WebHookEventFilter{
+			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
 				KindTypes:    []string{},
@@ -72,7 +72,7 @@ func (s *S) TestWebHookList(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookListEmpty(c *check.C) {
+func (s *S) TestWebhookListEmpty(c *check.C) {
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -81,27 +81,27 @@ func (s *S) TestWebHookListEmpty(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusNoContent)
 }
 
-func (s *S) TestWebHookListByTeam(c *check.C) {
+func (s *S) TestWebhookListByTeam(c *check.C) {
 	token := userWithPermission(c, permission.Permission{
 		Scheme:  permission.PermWebhookRead,
 		Context: permission.Context(permission.CtxTeam, "t2"),
 	})
-	webHook1 := eventTypes.WebHook{
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	webHook2 := eventTypes.WebHook{
+	webhook2 := eventTypes.Webhook{
 		TeamOwner: "t2",
 		Name:      "wh2",
 		URL:       "http://me",
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
-	err = servicemanager.WebHook.Create(webHook2)
+	err = servicemanager.Webhook.Create(webhook2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
 	c.Assert(err, check.IsNil)
@@ -109,16 +109,16 @@ func (s *S) TestWebHookListByTeam(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var result []eventTypes.WebHook
+	var result []eventTypes.Webhook
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
-	c.Assert(result, check.DeepEquals, []eventTypes.WebHook{
+	c.Assert(result, check.DeepEquals, []eventTypes.Webhook{
 		{
 			TeamOwner: "t2",
 			Name:      "wh2",
 			URL:       "http://me",
 			Headers:   http.Header{},
-			EventFilter: eventTypes.WebHookEventFilter{
+			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
 				KindTypes:    []string{},
@@ -128,16 +128,16 @@ func (s *S) TestWebHookListByTeam(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookCreate(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookCreate(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	bodyData, err := form.EncodeToString(webHook1)
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -146,14 +146,14 @@ func (s *S) TestWebHookCreate(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK, check.Commentf("body: %s", recorder.Body.String()))
-	wh, err := servicemanager.WebHook.Find("wh1")
+	wh, err := servicemanager.Webhook.Find("wh1")
 	c.Assert(err, check.IsNil)
-	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+	c.Assert(wh, check.DeepEquals, eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
 		Headers:   http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
 			KindTypes:    []string{},
@@ -162,15 +162,15 @@ func (s *S) TestWebHookCreate(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookCreateAutoTeam(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookCreateAutoTeam(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		Name: "wh1",
 		URL:  "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	bodyData, err := form.EncodeToString(webHook1)
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -179,14 +179,14 @@ func (s *S) TestWebHookCreateAutoTeam(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK, check.Commentf("body: %s", recorder.Body.String()))
-	wh, err := servicemanager.WebHook.Find("wh1")
+	wh, err := servicemanager.Webhook.Find("wh1")
 	c.Assert(err, check.IsNil)
-	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+	c.Assert(wh, check.DeepEquals, eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
 		Headers:   http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
 			KindTypes:    []string{},
@@ -195,18 +195,18 @@ func (s *S) TestWebHookCreateAutoTeam(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookCreateConflict(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookCreateConflict(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
-	bodyData, err := form.EncodeToString(webHook1)
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -217,15 +217,15 @@ func (s *S) TestWebHookCreateConflict(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusConflict)
 }
 
-func (s *S) TestWebHookCreateInvalid(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookCreateInvalid(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	bodyData, err := form.EncodeToString(webHook1)
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("POST", "/1.6/events/webhooks", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -236,20 +236,20 @@ func (s *S) TestWebHookCreateInvalid(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 
-func (s *S) TestWebHookUpdate(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookUpdate(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
-	webHook1.Name = "---ignored---"
-	webHook1.URL += "/xyz"
-	bodyData, err := form.EncodeToString(webHook1)
+	webhook1.Name = "---ignored---"
+	webhook1.URL += "/xyz"
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -258,14 +258,14 @@ func (s *S) TestWebHookUpdate(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	wh, err := servicemanager.WebHook.Find("wh1")
+	wh, err := servicemanager.Webhook.Find("wh1")
 	c.Assert(err, check.IsNil)
-	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+	c.Assert(wh, check.DeepEquals, eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me/xyz",
 		Headers:   http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
 			KindTypes:    []string{},
@@ -274,16 +274,16 @@ func (s *S) TestWebHookUpdate(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookUpdateNotFound(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookUpdateNotFound(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	bodyData, err := form.EncodeToString(webHook1)
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -294,19 +294,19 @@ func (s *S) TestWebHookUpdateNotFound(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
 }
 
-func (s *S) TestWebHookUpdateInvalid(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookUpdateInvalid(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
-	webHook1.URL = ""
-	bodyData, err := form.EncodeToString(webHook1)
+	webhook1.URL = ""
+	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.6/events/webhooks/wh1", strings.NewReader(bodyData))
 	c.Assert(err, check.IsNil)
@@ -317,16 +317,16 @@ func (s *S) TestWebHookUpdateInvalid(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 
-func (s *S) TestWebHookDelete(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookDelete(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("DELETE", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)
@@ -335,11 +335,11 @@ func (s *S) TestWebHookDelete(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	_, err = servicemanager.WebHook.Find("wh1")
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+	_, err = servicemanager.Webhook.Find("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }
 
-func (s *S) TestWebHookDeleteNotFound(c *check.C) {
+func (s *S) TestWebhookDeleteNotFound(c *check.C) {
 	request, err := http.NewRequest("DELETE", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -349,16 +349,16 @@ func (s *S) TestWebHookDeleteNotFound(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
 }
 
-func (s *S) TestWebHookInfo(c *check.C) {
-	webHook1 := eventTypes.WebHook{
+func (s *S) TestWebhookInfo(c *check.C) {
+	webhook1 := eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me/xyz",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.WebHook.Create(webHook1)
+	err := servicemanager.Webhook.Create(webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)
@@ -367,15 +367,15 @@ func (s *S) TestWebHookInfo(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var wh eventTypes.WebHook
+	var wh eventTypes.Webhook
 	err = json.Unmarshal(recorder.Body.Bytes(), &wh)
 	c.Assert(err, check.IsNil)
-	c.Assert(wh, check.DeepEquals, eventTypes.WebHook{
+	c.Assert(wh, check.DeepEquals, eventTypes.Webhook{
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me/xyz",
 		Headers:   http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
 			KindTypes:    []string{},
@@ -384,7 +384,7 @@ func (s *S) TestWebHookInfo(c *check.C) {
 	})
 }
 
-func (s *S) TestWebHookInfoNotFound(c *check.C) {
+func (s *S) TestWebhookInfoNotFound(c *check.C) {
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -1695,6 +1695,116 @@ paths:
         - event
       security:
         - Bearer: []
+  /1.6/events/webhooks:
+    get:
+      operationId: WebHookList
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: WebHooks list.
+          schema:
+            type: array
+            items:
+              type: object
+              $ref: '#/definitions/WebHook'
+        '204':
+          description: No content.
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+      tags:
+        - event
+      security:
+        - Bearer: []
+    post:
+      operationId: WebHookCreate
+      consumes:
+        - application/json
+      parameters:
+        - name: webhook
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/WebHook'
+      responses:
+        '200':
+          description: WebHook created.
+        '400':
+          description: Invalid data
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '409':
+          description: WebHook already exists.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+      tags:
+        - event
+      security:
+        - Bearer: []
+  /1.6/events/webhooks/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        type: string
+        minLength: 1
+        description: WebHook name.
+    put:
+      operationId: WebHookUpdate
+      consumes:
+        - application/json
+      parameters:
+        - name: webhook
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/WebHook'
+      responses:
+        '200':
+          description: WebHook updated.
+        '400':
+          description: Invalid data
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '404':
+          description: WebHook not found.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+      tags:
+        - event
+      security:
+        - Bearer: []
+    delete:
+      operationId: WebHookDelete
+      responses:
+        '200':
+          description: WebHook created.
+        '400':
+          description: Invalid data
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '404':
+          description: WebHook not found.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+      tags:
+        - event
+      security:
+        - Bearer: []
 definitions:
   ErrorMessage:
     description: Error message.
@@ -2391,3 +2501,52 @@ definitions:
     properties:
       reason:
         type: string
+  WebHook:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      team_owner:
+        type: string
+      event_filter:
+        type: object
+        $ref: '#/definitions/WebHookEventFilter'
+      url:
+        type: string
+      headers:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+      method:
+        type: string
+      body:
+        type: string
+      insecure:
+        type: boolean
+  WebHookEventFilter:
+    type: object
+    properties:
+      target_types:
+        type: array
+        items:
+          type: string
+      target_values:
+        type: array
+        items:
+          type: string
+      kind_types:
+        type: array
+        items:
+          type: string
+      kind_names:
+        type: array
+        items:
+          type: string
+      error_only:
+        type: boolean
+      success_only:
+        type: boolean

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -1755,6 +1755,28 @@ paths:
         type: string
         minLength: 1
         description: WebHook name.
+    get:
+      operationId: WebHookInfo
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: WebHook.
+          schema:
+            type: object
+            $ref: '#/definitions/WebHook'
+        '404':
+          description: Not founds.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/ErrorMessage'
+      tags:
+        - event
+      security:
+        - Bearer: []
     put:
       operationId: WebHookUpdate
       consumes:

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -2533,6 +2533,8 @@ definitions:
         $ref: '#/definitions/WebhookEventFilter'
       url:
         type: string
+      proxy_url:
+        type: string
       headers:
         type: object
         additionalProperties:

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -1697,29 +1697,25 @@ paths:
         - Bearer: []
   /1.6/events/webhooks:
     get:
-      operationId: WebHookList
+      operationId: WebhookList
       produces:
         - application/json
       responses:
         '200':
-          description: WebHooks list.
+          description: Webhooks list.
           schema:
             type: array
             items:
               type: object
-              $ref: '#/definitions/WebHook'
+              $ref: '#/definitions/Webhook'
         '204':
           description: No content.
-        '401':
-          description: Unauthorized.
-          schema:
-            $ref: '#/definitions/ErrorMessage'
       tags:
         - event
       security:
         - Bearer: []
     post:
-      operationId: WebHookCreate
+      operationId: WebhookCreate
       consumes:
         - application/json
       parameters:
@@ -1727,10 +1723,10 @@ paths:
           required: true
           in: body
           schema:
-            $ref: '#/definitions/WebHook'
+            $ref: '#/definitions/Webhook'
       responses:
         '200':
-          description: WebHook created.
+          description: Webhook created.
         '400':
           description: Invalid data
           schema:
@@ -1740,7 +1736,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorMessage'
         '409':
-          description: WebHook already exists.
+          description: Webhook already exists.
           schema:
             $ref: '#/definitions/ErrorMessage'
       tags:
@@ -1754,17 +1750,17 @@ paths:
         required: true
         type: string
         minLength: 1
-        description: WebHook name.
+        description: Webhook name.
     get:
-      operationId: WebHookInfo
+      operationId: WebhookGet
       produces:
         - application/json
       responses:
         '200':
-          description: WebHook.
+          description: Webhook.
           schema:
             type: object
-            $ref: '#/definitions/WebHook'
+            $ref: '#/definitions/Webhook'
         '404':
           description: Not founds.
           schema:
@@ -1778,7 +1774,7 @@ paths:
       security:
         - Bearer: []
     put:
-      operationId: WebHookUpdate
+      operationId: WebhookUpdate
       consumes:
         - application/json
       parameters:
@@ -1786,10 +1782,10 @@ paths:
           required: true
           in: body
           schema:
-            $ref: '#/definitions/WebHook'
+            $ref: '#/definitions/Webhook'
       responses:
         '200':
-          description: WebHook updated.
+          description: Webhook updated.
         '400':
           description: Invalid data
           schema:
@@ -1799,7 +1795,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorMessage'
         '404':
-          description: WebHook not found.
+          description: Webhook not found.
           schema:
             $ref: '#/definitions/ErrorMessage'
       tags:
@@ -1807,10 +1803,10 @@ paths:
       security:
         - Bearer: []
     delete:
-      operationId: WebHookDelete
+      operationId: WebhookDelete
       responses:
         '200':
-          description: WebHook created.
+          description: Webhook created.
         '400':
           description: Invalid data
           schema:
@@ -1820,7 +1816,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorMessage'
         '404':
-          description: WebHook not found.
+          description: Webhook not found.
           schema:
             $ref: '#/definitions/ErrorMessage'
       tags:
@@ -2523,7 +2519,7 @@ definitions:
     properties:
       reason:
         type: string
-  WebHook:
+  Webhook:
     type: object
     properties:
       name:
@@ -2534,7 +2530,7 @@ definitions:
         type: string
       event_filter:
         type: object
-        $ref: '#/definitions/WebHookEventFilter'
+        $ref: '#/definitions/WebhookEventFilter'
       url:
         type: string
       headers:
@@ -2549,7 +2545,7 @@ definitions:
         type: string
       insecure:
         type: boolean
-  WebHookEventFilter:
+  WebhookEventFilter:
     type: object
     properties:
       target_types:

--- a/event/event.go
+++ b/event/event.go
@@ -104,6 +104,7 @@ var (
 	TargetTypeEventBlock      = TargetType("event-block")
 	TargetTypeCluster         = TargetType("cluster")
 	TargetTypeVolume          = TargetType("volume")
+	TargetTypeWebHook         = TargetType("webhook")
 )
 
 const (
@@ -244,6 +245,26 @@ func GetTargetType(t string) (TargetType, error) {
 		return TargetTypeTeam, nil
 	case "user":
 		return TargetTypeUser, nil
+	case "iaas":
+		return TargetTypeIaas, nil
+	case "role":
+		return TargetTypeRole, nil
+	case "platform":
+		return TargetTypePlatform, nil
+	case "plan":
+		return TargetTypePlan, nil
+	case "node-container":
+		return TargetTypeNodeContainer, nil
+	case "install-host":
+		return TargetTypeInstallHost, nil
+	case "event-block":
+		return TargetTypeEventBlock, nil
+	case "cluster":
+		return TargetTypeCluster, nil
+	case "volume":
+		return TargetTypeVolume, nil
+	case "webhook":
+		return TargetTypeWebHook, nil
 	}
 	return TargetType(""), ErrInvalidTargetType
 }

--- a/event/event.go
+++ b/event/event.go
@@ -610,6 +610,13 @@ func GetRunning(target Target, kind string) (*Event, error) {
 	return &evt, nil
 }
 
+func GetByHexID(hexid string) (*Event, error) {
+	if !bson.IsObjectIdHex(hexid) {
+		return nil, errors.Errorf("receive ID is not a valid event object id: %q", hexid)
+	}
+	return GetByID(bson.ObjectIdHex(hexid))
+}
+
 func GetByID(id bson.ObjectId) (*Event, error) {
 	conn, err := db.Conn()
 	if err != nil {
@@ -1176,8 +1183,8 @@ func (e *Event) done(evtErr error, customData interface{}, abort bool) (err erro
 		if err != nil {
 			log.Errorf("[events] error marking event as done - %#v: %s", e, err)
 		} else {
-			if servicemanager.WebHook != nil {
-				servicemanager.WebHook.Notify(string(e.UniqueID))
+			if !abort && servicemanager.WebHook != nil {
+				servicemanager.WebHook.Notify(e.UniqueID.Hex())
 			}
 		}
 	}()

--- a/event/event.go
+++ b/event/event.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/safe"
+	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 )
 
@@ -1153,6 +1154,10 @@ func (e *Event) done(evtErr error, customData interface{}, abort bool) (err erro
 		eventCurrent.WithLabelValues(e.Kind.Name).Dec()
 		if err != nil {
 			log.Errorf("[events] error marking event as done - %#v: %s", e, err)
+		} else {
+			if servicemanager.WebHook != nil {
+				servicemanager.WebHook.Notify(string(e.UniqueID))
+			}
 		}
 	}()
 	updater.remove(e.ID)

--- a/event/event.go
+++ b/event/event.go
@@ -104,7 +104,7 @@ var (
 	TargetTypeEventBlock      = TargetType("event-block")
 	TargetTypeCluster         = TargetType("cluster")
 	TargetTypeVolume          = TargetType("volume")
-	TargetTypeWebHook         = TargetType("webhook")
+	TargetTypeWebhook         = TargetType("webhook")
 )
 
 const (
@@ -264,7 +264,7 @@ func GetTargetType(t string) (TargetType, error) {
 	case "volume":
 		return TargetTypeVolume, nil
 	case "webhook":
-		return TargetTypeWebHook, nil
+		return TargetTypeWebhook, nil
 	}
 	return TargetType(""), ErrInvalidTargetType
 }
@@ -1183,8 +1183,8 @@ func (e *Event) done(evtErr error, customData interface{}, abort bool) (err erro
 		if err != nil {
 			log.Errorf("[events] error marking event as done - %#v: %s", e, err)
 		} else {
-			if !abort && servicemanager.WebHook != nil {
-				servicemanager.WebHook.Notify(e.UniqueID.Hex())
+			if !abort && servicemanager.Webhook != nil {
+				servicemanager.Webhook.Notify(e.UniqueID.Hex())
 			}
 		}
 	}()

--- a/event/eventlist_test.go
+++ b/event/eventlist_test.go
@@ -32,7 +32,7 @@ var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
 	var err error
-	servicemanager.WebHook, err = webhook.WebHookService()
+	servicemanager.Webhook, err = webhook.WebhookService()
 	c.Assert(err, check.IsNil)
 }
 

--- a/event/eventlist_test.go
+++ b/event/eventlist_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/tsuru/tsuru/db/dbtest"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/event/eventtest"
+	"github.com/tsuru/tsuru/event/webhook"
 	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/servicemanager"
+	_ "github.com/tsuru/tsuru/storage/mongodb"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/check.v1"
 )
@@ -26,6 +29,12 @@ type S struct {
 }
 
 var _ = check.Suite(&S{})
+
+func (s *S) SetUpSuite(c *check.C) {
+	var err error
+	servicemanager.WebHook, err = webhook.WebHookService()
+	c.Assert(err, check.IsNil)
+}
 
 func (s *S) SetUpTest(c *check.C) {
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")

--- a/event/webhook/webhook.go
+++ b/event/webhook/webhook.go
@@ -1,0 +1,145 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package webhook
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/api/shutdown"
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/log"
+	tsuruNet "github.com/tsuru/tsuru/net"
+	"github.com/tsuru/tsuru/storage"
+	eventTypes "github.com/tsuru/tsuru/types/event"
+)
+
+var (
+	_ eventTypes.WebHookService = &webHookService{}
+
+	chanBufferSize   = 1000
+	defaultUserAgent = "tsuru-webhook-client/1.0"
+)
+
+func WebHookService() (eventTypes.WebHookService, error) {
+	dbDriver, err := storage.GetCurrentDbDriver()
+	if err != nil {
+		dbDriver, err = storage.GetDefaultDbDriver()
+		if err != nil {
+			return nil, err
+		}
+	}
+	s := &webHookService{
+		storage: dbDriver.WebHookStorage,
+		evtCh:   make(chan string, chanBufferSize),
+		quitCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+	go s.run()
+	shutdown.Register(s)
+	return s, nil
+}
+
+type webHookService struct {
+	storage eventTypes.WebHookStorage
+	evtCh   chan string
+	quitCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+func (s *webHookService) Shutdown(ctx context.Context) error {
+	doneCtx := ctx.Done()
+	close(s.quitCh)
+	select {
+	case <-s.doneCh:
+	case <-doneCtx:
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (s *webHookService) Notify(evtID string) {
+	select {
+	case s.evtCh <- evtID:
+	case <-s.quitCh:
+	}
+}
+
+func (s *webHookService) run() {
+	defer close(s.doneCh)
+	for {
+		select {
+		case evtID := <-s.evtCh:
+			err := s.handleEvent(evtID)
+			if err != nil {
+				log.Errorf("[webhooks] error handling webhooks for event %s", evtID)
+			}
+		case <-s.quitCh:
+			return
+		}
+	}
+}
+
+func (s *webHookService) handleEvent(evtID string) error {
+	evt, err := event.GetByID(bson.ObjectId(evtID))
+	if err != nil {
+		return err
+	}
+	filter := eventTypes.EventFilter{
+		TargetTypes:  []string{string(evt.Target.Type)},
+		TargetValues: []string{evt.Target.Value},
+		KindTypes:    []string{string(evt.Kind.Type)},
+		KindNames:    []string{evt.Kind.Name},
+	}
+	for _, t := range evt.ExtraTargets {
+		filter.TargetTypes = append(filter.TargetTypes, string(t.Target.Type))
+		filter.TargetValues = append(filter.TargetValues, t.Target.Value)
+	}
+	hooks, err := s.storage.FindByEvent(filter, evt.Error == "")
+	if err != nil {
+		return err
+	}
+	for _, h := range hooks {
+		err = s.doHook(h)
+		if err != nil {
+			log.Errorf("[webhooks] error calling webhook %q: %v", h.Name, err)
+		}
+	}
+	return nil
+}
+
+func (s *webHookService) doHook(hook eventTypes.WebHook) error {
+	var body io.Reader
+	if hook.Body != "" {
+		body = strings.NewReader(hook.Body)
+	}
+	req, err := http.NewRequest(hook.Method, hook.URL.String(), body)
+	if err != nil {
+		return err
+	}
+	req.Header = hook.Headers
+	if req.UserAgent() == "" {
+		req.Header.Set("User-Agent", defaultUserAgent)
+	}
+	client := tsuruNet.Dial5Full60ClientNoKeepAlive
+	if hook.Insecure {
+		client = &tsuruNet.Dial5Full60ClientNoKeepAliveInsecure
+	}
+	rsp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 400 {
+		data, _ := ioutil.ReadAll(rsp.Body)
+		return errors.Errorf("invalid status code calling hook: %d: %s", rsp.StatusCode, string(data))
+	}
+	return nil
+}

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -87,7 +87,7 @@ func (s *S) TestWebHookServiceNotify(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(string(evt.UniqueID))
+	s.service.Notify(evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, "ahoy")
 	c.Assert(receivedReq.Method, check.Equals, "PUT")
@@ -140,7 +140,7 @@ func (s *S) TestWebHookServiceNotifyDefaultBody(c *check.C) {
 		URL:  srv.URL,
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(string(evt.UniqueID))
+	s.service.Notify(evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, string(evtData))
 	c.Assert(receivedReq.Method, check.Equals, "POST")

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -1,0 +1,105 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package webhook
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/permission"
+	_ "github.com/tsuru/tsuru/storage/mongodb"
+	eventTypes "github.com/tsuru/tsuru/types/event"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type S struct {
+	service *webHookService
+}
+
+var _ = check.Suite(&S{})
+
+func (s *S) SetUpTest(c *check.C) {
+	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=150")
+	config.Set("database:name", "tsuru_event_webhook_tests")
+	conn, err := db.Conn()
+	c.Assert(err, check.IsNil)
+	defer conn.Close()
+	err = dbtest.ClearAllCollections(conn.Events().Database)
+	c.Assert(err, check.IsNil)
+	svc, err := WebHookService()
+	c.Assert(err, check.IsNil)
+	s.service = svc.(*webHookService)
+}
+
+func (s *S) TearDownTest(c *check.C) {
+	err := s.service.Shutdown(context.Background())
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestNotify(c *check.C) {
+	evt, err := event.New(&event.Opts{
+		Target: event.Target{Type: "app", Value: "myapp"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "xapp1"}},
+			{Target: event.Target{Type: "app", Value: "xapp2"}},
+		},
+		RawOwner: event.Owner{
+			Type: "user",
+			Name: "me@me.com",
+		},
+		Kind:    permission.PermAppUpdateEnvSet,
+		Allowed: event.Allowed(permission.PermAppReadEvents, permission.Context(permission.CtxApp, "myapp")),
+	})
+	c.Assert(err, check.IsNil)
+	err = evt.Done(nil)
+	c.Assert(err, check.IsNil)
+	called := make(chan struct{})
+	var receivedReq *http.Request
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(called)
+		receivedBody, _ = ioutil.ReadAll(r.Body)
+		receivedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	c.Assert(err, check.IsNil)
+	u.Path = "/a/b/c"
+	u.RawQuery = "a=b&c=d"
+	err = s.service.storage.Insert(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  *u,
+		Body: "ahoy",
+		Headers: http.Header{
+			"X-Ahoy": []string{"Errrr"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	s.service.Notify(string(evt.UniqueID))
+	<-called
+	c.Assert(string(receivedBody), check.Equals, "ahoy")
+	c.Assert(receivedReq.URL.Path, check.Equals, "/a/b/c")
+	c.Assert(receivedReq.URL.Query(), check.DeepEquals, url.Values{
+		"a": []string{"b"},
+		"c": []string{"d"},
+	})
+	c.Assert(receivedReq.Header, check.DeepEquals, http.Header{
+		"X-Ahoy":          []string{"Errrr"},
+		"User-Agent":      []string{"tsuru-webhook-client/1.0"},
+		"Accept-Encoding": []string{"gzip"},
+		"Content-Length":  []string{"4"},
+	})
+}

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -81,7 +81,7 @@ func (s *S) TestWebhookServiceNotify(c *check.C) {
 		Name:   "xyz",
 		URL:    srv.URL + "/a/b/c?a=b&c=d",
 		Method: "PUT",
-		Body:   "ahoy",
+		Body:   "ahoy {{ --",
 		Headers: http.Header{
 			"X-Ahoy": []string{"Errrr"},
 		},
@@ -89,7 +89,7 @@ func (s *S) TestWebhookServiceNotify(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.service.Notify(evt.UniqueID.Hex())
 	<-called
-	c.Assert(string(receivedBody), check.Equals, "ahoy")
+	c.Assert(string(receivedBody), check.Equals, "ahoy {{ --")
 	c.Assert(receivedReq.Method, check.Equals, "PUT")
 	c.Assert(receivedReq.URL.Path, check.Equals, "/a/b/c")
 	c.Assert(receivedReq.URL.Query(), check.DeepEquals, url.Values{
@@ -100,7 +100,7 @@ func (s *S) TestWebhookServiceNotify(c *check.C) {
 		"X-Ahoy":          []string{"Errrr"},
 		"User-Agent":      []string{"tsuru-webhook-client/1.0"},
 		"Accept-Encoding": []string{"gzip"},
-		"Content-Length":  []string{"4"},
+		"Content-Length":  []string{"10"},
 	})
 }
 
@@ -146,6 +146,60 @@ func (s *S) TestWebhookServiceNotifyDefaultBody(c *check.C) {
 	c.Assert(receivedReq.Method, check.Equals, "POST")
 	c.Assert(receivedReq.URL.Path, check.Equals, "/")
 	c.Assert(receivedReq.Header.Get("Content-Type"), check.Equals, "application/json")
+}
+
+func (s *S) TestWebhookServiceNotifyTemplate(c *check.C) {
+	evt, err := event.New(&event.Opts{
+		Target: event.Target{Type: "app", Value: "myapp"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "xapp1"}},
+			{Target: event.Target{Type: "app", Value: "xapp2"}},
+		},
+		RawOwner: event.Owner{
+			Type: "user",
+			Name: "me@me.com",
+		},
+		Kind:    permission.PermAppUpdateEnvSet,
+		Allowed: event.Allowed(permission.PermAppReadEvents, permission.Context(permission.CtxApp, "myapp")),
+	})
+	c.Assert(err, check.IsNil)
+	err = evt.Done(nil)
+	c.Assert(err, check.IsNil)
+	called := make(chan struct{})
+	var receivedReq *http.Request
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(called)
+		receivedBody, _ = ioutil.ReadAll(r.Body)
+		receivedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	err = s.service.storage.Insert(eventTypes.Webhook{
+		Name:   "xyz",
+		URL:    srv.URL + "/a/b/c?a=b&c=d",
+		Method: "PUT",
+		Body:   "{{.Kind.Name}} event for {{.Target.Type}} named {{.Target.Value}}",
+		Headers: http.Header{
+			"X-Ahoy": []string{"Errrr"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	s.service.Notify(evt.UniqueID.Hex())
+	<-called
+	c.Assert(string(receivedBody), check.Equals, "app.update.env.set event for app named myapp")
+	c.Assert(receivedReq.Method, check.Equals, "PUT")
+	c.Assert(receivedReq.URL.Path, check.Equals, "/a/b/c")
+	c.Assert(receivedReq.URL.Query(), check.DeepEquals, url.Values{
+		"a": []string{"b"},
+		"c": []string{"d"},
+	})
+	c.Assert(receivedReq.Header, check.DeepEquals, http.Header{
+		"X-Ahoy":          []string{"Errrr"},
+		"User-Agent":      []string{"tsuru-webhook-client/1.0"},
+		"Accept-Encoding": []string{"gzip"},
+		"Content-Length":  []string{"44"},
+	})
 }
 
 func (s *S) TestWebhookServiceCreate(c *check.C) {

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -6,6 +6,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
@@ -48,7 +50,7 @@ func (s *S) TearDownTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) TestNotify(c *check.C) {
+func (s *S) TestWebHookServiceNotify(c *check.C) {
 	evt, err := event.New(&event.Opts{
 		Target: event.Target{Type: "app", Value: "myapp"},
 		ExtraTargets: []event.ExtraTarget{
@@ -75,14 +77,11 @@ func (s *S) TestNotify(c *check.C) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	u, err := url.Parse(srv.URL)
-	c.Assert(err, check.IsNil)
-	u.Path = "/a/b/c"
-	u.RawQuery = "a=b&c=d"
 	err = s.service.storage.Insert(eventTypes.WebHook{
-		Name: "xyz",
-		URL:  *u,
-		Body: "ahoy",
+		Name:   "xyz",
+		URL:    srv.URL + "/a/b/c?a=b&c=d",
+		Method: "PUT",
+		Body:   "ahoy",
 		Headers: http.Header{
 			"X-Ahoy": []string{"Errrr"},
 		},
@@ -91,6 +90,7 @@ func (s *S) TestNotify(c *check.C) {
 	s.service.Notify(string(evt.UniqueID))
 	<-called
 	c.Assert(string(receivedBody), check.Equals, "ahoy")
+	c.Assert(receivedReq.Method, check.Equals, "PUT")
 	c.Assert(receivedReq.URL.Path, check.Equals, "/a/b/c")
 	c.Assert(receivedReq.URL.Query(), check.DeepEquals, url.Values{
 		"a": []string{"b"},
@@ -102,4 +102,157 @@ func (s *S) TestNotify(c *check.C) {
 		"Accept-Encoding": []string{"gzip"},
 		"Content-Length":  []string{"4"},
 	})
+}
+
+func (s *S) TestWebHookServiceNotifyDefaultBody(c *check.C) {
+	evt, err := event.New(&event.Opts{
+		Target: event.Target{Type: "app", Value: "myapp"},
+		ExtraTargets: []event.ExtraTarget{
+			{Target: event.Target{Type: "app", Value: "xapp1"}},
+			{Target: event.Target{Type: "app", Value: "xapp2"}},
+		},
+		RawOwner: event.Owner{
+			Type: "user",
+			Name: "me@me.com",
+		},
+		Kind:    permission.PermAppUpdateEnvSet,
+		Allowed: event.Allowed(permission.PermAppReadEvents, permission.Context(permission.CtxApp, "myapp")),
+	})
+	c.Assert(err, check.IsNil)
+	err = evt.Done(nil)
+	c.Assert(err, check.IsNil)
+	doneEvt, err := event.GetByID(evt.UniqueID)
+	c.Assert(err, check.IsNil)
+	evtData, err := json.Marshal(doneEvt)
+	c.Assert(err, check.IsNil)
+	called := make(chan struct{})
+	var receivedReq *http.Request
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(called)
+		receivedBody, _ = ioutil.ReadAll(r.Body)
+		receivedReq = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	err = s.service.storage.Insert(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  srv.URL,
+	})
+	c.Assert(err, check.IsNil)
+	s.service.Notify(string(evt.UniqueID))
+	<-called
+	c.Assert(string(receivedBody), check.Equals, string(evtData))
+	c.Assert(receivedReq.Method, check.Equals, "POST")
+	c.Assert(receivedReq.URL.Path, check.Equals, "/")
+	c.Assert(receivedReq.Header.Get("Content-Type"), check.Equals, "application/json")
+}
+
+func (s *S) TestWebHookServiceCreate(c *check.C) {
+	err := s.service.Create(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://a",
+		Body: "ahoy",
+		Headers: http.Header{
+			"X-Ahoy": []string{"Errrr"},
+		},
+		EventFilter: eventTypes.WebHookEventFilter{
+			TargetTypes: []string{"app"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	w, err := s.service.Find("xyz")
+	c.Assert(err, check.IsNil)
+	c.Assert(w, check.DeepEquals, eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://a",
+		Body: "ahoy",
+		Headers: http.Header{
+			"X-Ahoy": []string{"Errrr"},
+		},
+		EventFilter: eventTypes.WebHookEventFilter{
+			TargetTypes:  []string{"app"},
+			TargetValues: []string{},
+			KindTypes:    []string{},
+			KindNames:    []string{},
+		},
+	})
+}
+
+func (s *S) TestWebHookServiceCreateInvalid(c *check.C) {
+	err := s.service.Create(eventTypes.WebHook{
+		Name: "",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.DeepEquals, &errors.ValidationError{Message: "webhook name must not be empty"})
+	err = s.service.Create(eventTypes.WebHook{
+		Name: "_-*x",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.DeepEquals, &errors.ValidationError{Message: "name does not match regex \"^[a-z][a-z0-9-]{0,62}$\""})
+	err = s.service.Create(eventTypes.WebHook{
+		Name: "c",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.service.Create(eventTypes.WebHook{
+		Name: "c",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookAlreadyExists)
+	err = s.service.Create(eventTypes.WebHook{
+		Name: "d",
+	})
+	c.Assert(err, check.DeepEquals, &errors.ValidationError{Message: "webhook url must not be empty"})
+}
+
+func (s *S) TestWebHookServiceUpdate(c *check.C) {
+	err := s.service.Create(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.service.Update(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://b",
+	})
+	c.Assert(err, check.IsNil)
+	w, err := s.service.Find("xyz")
+	c.Assert(err, check.IsNil)
+	c.Assert(w, check.DeepEquals, eventTypes.WebHook{
+		Name:    "xyz",
+		URL:     "http://b",
+		Headers: http.Header{},
+		EventFilter: eventTypes.WebHookEventFilter{
+			TargetTypes:  []string{},
+			TargetValues: []string{},
+			KindTypes:    []string{},
+			KindNames:    []string{},
+		},
+	})
+}
+
+func (s *S) TestWebHookServiceUpdateInvalid(c *check.C) {
+	err := s.service.Update(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://b",
+	})
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}
+
+func (s *S) TestWebHookServiceDelete(c *check.C) {
+	err := s.service.Create(eventTypes.WebHook{
+		Name: "xyz",
+		URL:  "http://a",
+	})
+	c.Assert(err, check.IsNil)
+	err = s.service.Delete("xyz")
+	c.Assert(err, check.IsNil)
+	_, err = s.service.Find("xyz")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}
+
+func (s *S) TestWebHookServiceDeleteNotFound(c *check.C) {
+	err := s.service.Delete("xyz")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
 }

--- a/net/client.go
+++ b/net/client.go
@@ -43,6 +43,7 @@ var (
 	Dial5Full60ClientNoKeepAlive, _                = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, true)
 	Dial5Full60ClientNoKeepAliveNoRedirect, _      = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, false)
 	Dial5Full60ClientNoKeepAliveNoRedirectInsecure = insecure(*Dial5Full60ClientNoKeepAliveNoRedirect)
+	Dial5Full60ClientNoKeepAliveInsecure           = insecure(*Dial5Full60ClientNoKeepAlive)
 )
 
 func insecure(client http.Client) http.Client {

--- a/net/client.go
+++ b/net/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -54,4 +55,23 @@ func insecure(client http.Client) http.Client {
 	tlsConfig.InsecureSkipVerify = true
 	client.Transport.(*http.Transport).TLSClientConfig = tlsConfig
 	return client
+}
+
+func WithProxy(cli http.Client, proxyURL string) (*http.Client, error) {
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	newTransport := http.Transport{
+		Proxy: http.ProxyURL(u),
+	}
+	baseTrans, _ := cli.Transport.(*http.Transport)
+	if baseTrans != nil {
+		newTransport.Dial = baseTrans.Dial
+		newTransport.TLSHandshakeTimeout = baseTrans.TLSHandshakeTimeout
+		newTransport.MaxIdleConnsPerHost = baseTrans.MaxIdleConnsPerHost
+		newTransport.TLSClientConfig = baseTrans.TLSClientConfig
+	}
+	cli.Transport = &newTransport
+	return &cli, nil
 }

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -224,4 +224,10 @@ var (
 	PermVolumeUpdate                     = PermissionRegistry.get("volume.update")                       // [global volume team pool]
 	PermVolumeUpdateBind                 = PermissionRegistry.get("volume.update.bind")                  // [global volume team pool]
 	PermVolumeUpdateUnbind               = PermissionRegistry.get("volume.update.unbind")                // [global volume team pool]
+	PermWebhook                          = PermissionRegistry.get("webhook")                             // [global team]
+	PermWebhookCreate                    = PermissionRegistry.get("webhook.create")                      // [global team]
+	PermWebhookDelete                    = PermissionRegistry.get("webhook.delete")                      // [global team]
+	PermWebhookRead                      = PermissionRegistry.get("webhook.read")                        // [global team]
+	PermWebhookReadEvents                = PermissionRegistry.get("webhook.read.events")                 // [global team]
+	PermWebhookUpdate                    = PermissionRegistry.get("webhook.update")                      // [global team]
 )

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -221,4 +221,12 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"volume.update.bind",
 	"volume.update.unbind",
 	"volume.delete",
+).addWithCtx(
+	"webhook", []contextType{CtxTeam},
+).add(
+	"webhook.read",
+	"webhook.read.events",
+	"webhook.create",
+	"webhook.update",
+	"webhook.delete",
 )

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -7,6 +7,7 @@ package servicemanager
 import (
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/event"
 )
 
 var (
@@ -15,4 +16,5 @@ var (
 	Platform  app.PlatformService
 	Team      auth.TeamService
 	TeamToken auth.TeamTokenService
+	WebHook   event.WebHookService
 )

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -16,5 +16,5 @@ var (
 	Platform  app.PlatformService
 	Team      auth.TeamService
 	TeamToken auth.TeamTokenService
-	WebHook   event.WebHookService
+	Webhook   event.WebhookService
 )

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/event"
 )
 
 type DbDriver struct {
@@ -19,6 +20,7 @@ type DbDriver struct {
 	PlanStorage      app.PlanStorage
 	CacheStorage     app.CacheStorage
 	TeamTokenStorage auth.TeamTokenStorage
+	WebHookStorage   event.WebHookStorage
 }
 
 var (

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -20,7 +20,7 @@ type DbDriver struct {
 	PlanStorage      app.PlanStorage
 	CacheStorage     app.CacheStorage
 	TeamTokenStorage auth.TeamTokenStorage
-	WebHookStorage   event.WebHookStorage
+	WebhookStorage   event.WebhookStorage
 }
 
 var (

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -13,7 +13,7 @@ func init() {
 		PlanStorage:      &PlanStorage{},
 		CacheStorage:     &cacheStorage{},
 		TeamTokenStorage: &teamTokenStorage{},
-		WebHookStorage:   &webhookStorage{},
+		WebhookStorage:   &webhookStorage{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -13,6 +13,7 @@ func init() {
 		PlanStorage:      &PlanStorage{},
 		CacheStorage:     &cacheStorage{},
 		TeamTokenStorage: &teamTokenStorage{},
+		WebHookStorage:   &webhookStorage{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/webhook.go
+++ b/storage/mongodb/webhook.go
@@ -16,7 +16,7 @@ import (
 
 type webhookStorage struct{}
 
-func webhoookCollection(conn *db.Storage) *dbStorage.Collection {
+func webhookCollection(conn *db.Storage) *dbStorage.Collection {
 	coll := conn.Collection("webhook")
 	coll.EnsureIndex(mgo.Index{
 		Key:    []string{"name"},
@@ -25,46 +25,46 @@ func webhoookCollection(conn *db.Storage) *dbStorage.Collection {
 	return coll
 }
 
-var _ event.WebHookStorage = &webhookStorage{}
+var _ event.WebhookStorage = &webhookStorage{}
 
-func (s *webhookStorage) Insert(w event.WebHook) error {
+func (s *webhookStorage) Insert(w event.Webhook) error {
 	conn, err := db.Conn()
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
-	err = webhoookCollection(conn).Insert(w)
+	err = webhookCollection(conn).Insert(w)
 	if err != nil && mgo.IsDup(err) {
-		err = event.ErrWebHookAlreadyExists
+		err = event.ErrWebhookAlreadyExists
 	}
 	return err
 }
 
-func (s *webhookStorage) Update(w event.WebHook) error {
+func (s *webhookStorage) Update(w event.Webhook) error {
 	conn, err := db.Conn()
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
-	err = webhoookCollection(conn).Update(bson.M{"name": w.Name}, w)
+	err = webhookCollection(conn).Update(bson.M{"name": w.Name}, w)
 	if err == mgo.ErrNotFound {
-		err = event.ErrWebHookNotFound
+		err = event.ErrWebhookNotFound
 	}
 	return err
 }
 
-func (s *webhookStorage) findQuery(query bson.M) ([]event.WebHook, error) {
+func (s *webhookStorage) findQuery(query bson.M) ([]event.Webhook, error) {
 	conn, err := db.Conn()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
-	var webhooks []event.WebHook
-	err = webhoookCollection(conn).Find(query).All(&webhooks)
+	var webhooks []event.Webhook
+	err = webhookCollection(conn).Find(query).All(&webhooks)
 	return webhooks, err
 }
 
-func (s *webhookStorage) FindAllByTeams(teams []string) ([]event.WebHook, error) {
+func (s *webhookStorage) FindAllByTeams(teams []string) ([]event.Webhook, error) {
 	var query bson.M
 	if teams != nil {
 		query = bson.M{"teamowner": bson.M{"$in": teams}}
@@ -72,12 +72,9 @@ func (s *webhookStorage) FindAllByTeams(teams []string) ([]event.WebHook, error)
 	return s.findQuery(query)
 }
 
-func (s *webhookStorage) FindByEvent(f event.WebHookEventFilter, isSuccess bool) ([]event.WebHook, error) {
+func (s *webhookStorage) FindByEvent(f event.WebhookEventFilter, isSuccess bool) ([]event.Webhook, error) {
 	for _, name := range f.KindNames {
 		parts := strings.Split(name, ".")
-		if len(parts) == 0 {
-			continue
-		}
 		parts = parts[:len(parts)-1]
 		for i := 1; i < len(parts); i++ {
 			parts[i] = parts[i-1] + "." + parts[i]
@@ -98,17 +95,17 @@ func (s *webhookStorage) FindByEvent(f event.WebHookEventFilter, isSuccess bool)
 	return s.findQuery(bson.M{"$and": andBlock})
 }
 
-func (s *webhookStorage) FindByName(name string) (*event.WebHook, error) {
+func (s *webhookStorage) FindByName(name string) (*event.Webhook, error) {
 	conn, err := db.Conn()
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
-	var result event.WebHook
-	err = webhoookCollection(conn).Find(bson.M{"name": name}).One(&result)
+	var result event.Webhook
+	err = webhookCollection(conn).Find(bson.M{"name": name}).One(&result)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			err = event.ErrWebHookNotFound
+			err = event.ErrWebhookNotFound
 		}
 		return nil, err
 	}
@@ -121,9 +118,9 @@ func (s *webhookStorage) Delete(name string) error {
 		return err
 	}
 	defer conn.Close()
-	err = webhoookCollection(conn).Remove(bson.M{"name": name})
+	err = webhookCollection(conn).Remove(bson.M{"name": name})
 	if err == mgo.ErrNotFound {
-		err = event.ErrWebHookNotFound
+		err = event.ErrWebhookNotFound
 	}
 	return err
 }

--- a/storage/mongodb/webhook.go
+++ b/storage/mongodb/webhook.go
@@ -1,0 +1,129 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"strings"
+
+	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/tsuru/tsuru/db"
+	dbStorage "github.com/tsuru/tsuru/db/storage"
+	"github.com/tsuru/tsuru/types/event"
+)
+
+type webhookStorage struct{}
+
+func webhoookCollection(conn *db.Storage) *dbStorage.Collection {
+	coll := conn.Collection("webhook")
+	coll.EnsureIndex(mgo.Index{
+		Key:    []string{"name"},
+		Unique: true,
+	})
+	return coll
+}
+
+var _ event.WebHookStorage = &webhookStorage{}
+
+func (s *webhookStorage) Insert(w event.WebHook) error {
+	conn, err := db.Conn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	err = webhoookCollection(conn).Insert(w)
+	if err != nil && mgo.IsDup(err) {
+		err = event.ErrWebHookAlreadyExists
+	}
+	return err
+}
+
+func (s *webhookStorage) Update(w event.WebHook) error {
+	conn, err := db.Conn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	err = webhoookCollection(conn).Update(bson.M{"name": w.Name}, w)
+	if err == mgo.ErrNotFound {
+		err = event.ErrWebHookNotFound
+	}
+	return err
+}
+
+func (s *webhookStorage) findQuery(query bson.M) ([]event.WebHook, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	var webhooks []event.WebHook
+	err = webhoookCollection(conn).Find(query).All(&webhooks)
+	return webhooks, err
+}
+
+func (s *webhookStorage) FindAllByTeams(teams []string) ([]event.WebHook, error) {
+	var query bson.M
+	if teams != nil {
+		query = bson.M{"teamowner": bson.M{"$in": teams}}
+	}
+	return s.findQuery(query)
+}
+
+func (s *webhookStorage) FindByEvent(f event.EventFilter, isSuccess bool) ([]event.WebHook, error) {
+	for _, name := range f.KindNames {
+		parts := strings.Split(name, ".")
+		if len(parts) == 0 {
+			continue
+		}
+		parts = parts[:len(parts)-1]
+		for i := 1; i < len(parts); i++ {
+			parts[i] = parts[i-1] + "." + parts[i]
+		}
+		f.KindNames = append(f.KindNames, parts...)
+	}
+	andBlock := []bson.M{
+		{"$or": []bson.M{{"eventfilter.targettypes": bson.M{"$in": f.TargetTypes}}, {"eventfilter.targettypes": []string{}}}},
+		{"$or": []bson.M{{"eventfilter.targetvalues": bson.M{"$in": f.TargetValues}}, {"eventfilter.targetvalues": []string{}}}},
+		{"$or": []bson.M{{"eventfilter.kindtypes": bson.M{"$in": f.KindTypes}}, {"eventfilter.kindtypes": []string{}}}},
+		{"$or": []bson.M{{"eventfilter.kindnames": bson.M{"$in": f.KindNames}}, {"eventfilter.kindnames": []string{}}}},
+	}
+	if isSuccess {
+		andBlock = append(andBlock, bson.M{"eventfilter.erroronly": false})
+	} else {
+		andBlock = append(andBlock, bson.M{"eventfilter.successonly": false})
+	}
+	return s.findQuery(bson.M{"$and": andBlock})
+}
+
+func (s *webhookStorage) FindByName(name string) (*event.WebHook, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	var result event.WebHook
+	err = webhoookCollection(conn).Find(bson.M{"name": name}).One(&result)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			err = event.ErrWebHookNotFound
+		}
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (s *webhookStorage) Delete(name string) error {
+	conn, err := db.Conn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	err = webhoookCollection(conn).Remove(bson.M{"name": name})
+	if err == mgo.ErrNotFound {
+		err = event.ErrWebHookNotFound
+	}
+	return err
+}

--- a/storage/mongodb/webhook.go
+++ b/storage/mongodb/webhook.go
@@ -72,7 +72,7 @@ func (s *webhookStorage) FindAllByTeams(teams []string) ([]event.WebHook, error)
 	return s.findQuery(query)
 }
 
-func (s *webhookStorage) FindByEvent(f event.EventFilter, isSuccess bool) ([]event.WebHook, error) {
+func (s *webhookStorage) FindByEvent(f event.WebHookEventFilter, isSuccess bool) ([]event.WebHook, error) {
 	for _, name := range f.KindNames {
 		parts := strings.Split(name, ".")
 		if len(parts) == 0 {

--- a/storage/mongodb/webhook_test.go
+++ b/storage/mongodb/webhook_test.go
@@ -1,0 +1,15 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.WebHookSuite{
+	WebHookStorage: &webhookStorage{},
+	SuiteHooks:     &mongodbBaseTest{},
+})

--- a/storage/mongodb/webhook_test.go
+++ b/storage/mongodb/webhook_test.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-var _ = check.Suite(&storagetest.WebHookSuite{
-	WebHookStorage: &webhookStorage{},
+var _ = check.Suite(&storagetest.WebhookSuite{
+	WebhookStorage: &webhookStorage{},
 	SuiteHooks:     &mongodbBaseTest{},
 })

--- a/storage/storagetest/webhook_suite.go
+++ b/storage/storagetest/webhook_suite.go
@@ -13,33 +13,33 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type WebHookSuite struct {
+type WebhookSuite struct {
 	SuiteHooks
-	WebHookStorage eventTypes.WebHookStorage
+	WebhookStorage eventTypes.WebhookStorage
 }
 
-func (s *WebHookSuite) TestInsertWebHook(c *check.C) {
-	w := eventTypes.WebHook{
+func (s *WebhookSuite) TestInsertWebhook(c *check.C) {
+	w := eventTypes.Webhook{
 		Name:      "wh1",
 		TeamOwner: "team1",
 		URL:       "http://mysrv.com:123/abc?a=b",
 		Method:    "GET",
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{"app"},
 			TargetValues: []string{"myapp"},
 		},
 	}
-	err := s.WebHookStorage.Insert(w)
+	err := s.WebhookStorage.Insert(w)
 	c.Assert(err, check.IsNil)
-	webHook, err := s.WebHookStorage.FindByName(w.Name)
+	webhook, err := s.WebhookStorage.FindByName(w.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(webHook, check.DeepEquals, &eventTypes.WebHook{
+	c.Assert(webhook, check.DeepEquals, &eventTypes.Webhook{
 		Name:      "wh1",
 		TeamOwner: "team1",
 		URL:       "http://mysrv.com:123/abc?a=b",
 		Method:    "GET",
 		Headers:   http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindTypes:    []string{},
 			KindNames:    []string{},
 			TargetTypes:  []string{"app"},
@@ -48,8 +48,8 @@ func (s *WebHookSuite) TestInsertWebHook(c *check.C) {
 	})
 }
 
-func (s *WebHookSuite) TestFindByEvent(c *check.C) {
-	filters := []eventTypes.WebHookEventFilter{
+func (s *WebhookSuite) TestFindByEvent(c *check.C) {
+	filters := []eventTypes.WebhookEventFilter{
 		{TargetTypes: []string{"app"}, TargetValues: []string{"myapp"}},
 		{ErrorOnly: true},
 		{SuccessOnly: true},
@@ -63,23 +63,23 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 		{},
 	}
 	for i, f := range filters {
-		w := eventTypes.WebHook{
+		w := eventTypes.Webhook{
 			Name:        fmt.Sprintf("wh-%d", i),
 			TeamOwner:   "team1",
 			URL:         "http://mysrv.com:123/abc?a=b",
 			Method:      "GET",
 			EventFilter: f,
 		}
-		err := s.WebHookStorage.Insert(w)
+		err := s.WebhookStorage.Insert(w)
 		c.Assert(err, check.IsNil)
 	}
 	tests := []struct {
-		f        eventTypes.WebHookEventFilter
+		f        eventTypes.WebhookEventFilter
 		success  bool
 		expected []string
 	}{
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"myapp"},
 				KindTypes:    []string{"permission"},
@@ -89,7 +89,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-0", "wh-1", "wh-3", "wh-4", "wh-5", "wh-7", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"myapp"},
 				KindTypes:    []string{"permission"},
@@ -99,7 +99,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-0", "wh-2", "wh-4", "wh-5", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"otherapp"},
 				KindTypes:    []string{"permission"},
@@ -109,7 +109,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-2", "wh-4", "wh-5", "wh-8", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"anyapp"},
 				KindTypes:    []string{"permission"},
@@ -119,7 +119,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-2", "wh-5", "wh-9", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"node"},
 				TargetValues: []string{"10.0.0.1", "10.0.0.2"},
 				KindTypes:    []string{"internal"},
@@ -129,7 +129,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-2", "wh-6", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"myapp", "otherapp"},
 				KindTypes:    []string{"permission"},
@@ -139,7 +139,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 			expected: []string{"wh-0", "wh-2", "wh-4", "wh-5", "wh-8", "wh-9", "wh-10"},
 		},
 		{
-			f: eventTypes.WebHookEventFilter{
+			f: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{"app"},
 				TargetValues: []string{"myapp", "otherapp"},
 				KindTypes:    []string{"permission"},
@@ -150,7 +150,7 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 		},
 	}
 	for i, tt := range tests {
-		hooks, err := s.WebHookStorage.FindByEvent(tt.f, tt.success)
+		hooks, err := s.WebhookStorage.FindByEvent(tt.f, tt.success)
 		c.Assert(err, check.IsNil)
 		names := webhooksNames(hooks)
 		sort.Strings(tt.expected)
@@ -158,15 +158,15 @@ func (s *WebHookSuite) TestFindByEvent(c *check.C) {
 	}
 }
 
-func (s *WebHookSuite) TestInsertDuplicateWebHook(c *check.C) {
-	t := eventTypes.WebHook{Name: "WebHookname"}
-	err := s.WebHookStorage.Insert(t)
+func (s *WebhookSuite) TestInsertDuplicateWebhook(c *check.C) {
+	t := eventTypes.Webhook{Name: "Webhookname"}
+	err := s.WebhookStorage.Insert(t)
 	c.Assert(err, check.IsNil)
-	err = s.WebHookStorage.Insert(t)
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookAlreadyExists)
+	err = s.WebhookStorage.Insert(t)
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookAlreadyExists)
 }
 
-func webhooksNames(hooks []eventTypes.WebHook) []string {
+func webhooksNames(hooks []eventTypes.Webhook) []string {
 	var names []string
 	for _, h := range hooks {
 		names = append(names, h.Name)
@@ -175,53 +175,53 @@ func webhooksNames(hooks []eventTypes.WebHook) []string {
 	return names
 }
 
-func (s *WebHookSuite) TestFindAllByTeams(c *check.C) {
-	w1 := eventTypes.WebHook{Name: "wh1", TeamOwner: "t1"}
-	err := s.WebHookStorage.Insert(w1)
+func (s *WebhookSuite) TestFindAllByTeams(c *check.C) {
+	w1 := eventTypes.Webhook{Name: "wh1", TeamOwner: "t1"}
+	err := s.WebhookStorage.Insert(w1)
 	c.Assert(err, check.IsNil)
-	w2 := eventTypes.WebHook{Name: "wh2", TeamOwner: "t2"}
-	err = s.WebHookStorage.Insert(w2)
+	w2 := eventTypes.Webhook{Name: "wh2", TeamOwner: "t2"}
+	err = s.WebhookStorage.Insert(w2)
 	c.Assert(err, check.IsNil)
-	webhooks, err := s.WebHookStorage.FindAllByTeams(nil)
+	webhooks, err := s.WebhookStorage.FindAllByTeams(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1", "wh2"})
-	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{})
+	webhooks, err = s.WebhookStorage.FindAllByTeams([]string{})
 	c.Assert(err, check.IsNil)
 	c.Assert(webhooksNames(webhooks), check.IsNil)
-	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{"t1"})
+	webhooks, err = s.WebhookStorage.FindAllByTeams([]string{"t1"})
 	c.Assert(err, check.IsNil)
 	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1"})
-	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{"t1", "t2"})
+	webhooks, err = s.WebhookStorage.FindAllByTeams([]string{"t1", "t2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1", "wh2"})
 }
 
-func (s *WebHookSuite) TestDelete(c *check.C) {
-	w := eventTypes.WebHook{Name: "wh1"}
-	err := s.WebHookStorage.Insert(w)
+func (s *WebhookSuite) TestDelete(c *check.C) {
+	w := eventTypes.Webhook{Name: "wh1"}
+	err := s.WebhookStorage.Insert(w)
 	c.Assert(err, check.IsNil)
-	err = s.WebHookStorage.Delete("wh1")
+	err = s.WebhookStorage.Delete("wh1")
 	c.Assert(err, check.IsNil)
-	err = s.WebHookStorage.Delete("wh1")
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
-	_, err = s.WebHookStorage.FindByName("wh1")
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+	err = s.WebhookStorage.Delete("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
+	_, err = s.WebhookStorage.FindByName("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }
 
-func (s *WebHookSuite) TestUpdate(c *check.C) {
-	w := eventTypes.WebHook{Name: "wh1"}
-	err := s.WebHookStorage.Insert(w)
+func (s *WebhookSuite) TestUpdate(c *check.C) {
+	w := eventTypes.Webhook{Name: "wh1"}
+	err := s.WebhookStorage.Insert(w)
 	c.Assert(err, check.IsNil)
 	w.Method = "GET"
-	err = s.WebHookStorage.Update(w)
+	err = s.WebhookStorage.Update(w)
 	c.Assert(err, check.IsNil)
-	dbW, err := s.WebHookStorage.FindByName("wh1")
+	dbW, err := s.WebhookStorage.FindByName("wh1")
 	c.Assert(err, check.IsNil)
-	c.Assert(dbW, check.DeepEquals, &eventTypes.WebHook{
+	c.Assert(dbW, check.DeepEquals, &eventTypes.Webhook{
 		Name:    "wh1",
 		Method:  "GET",
 		Headers: http.Header{},
-		EventFilter: eventTypes.WebHookEventFilter{
+		EventFilter: eventTypes.WebhookEventFilter{
 			KindTypes:    []string{},
 			KindNames:    []string{},
 			TargetTypes:  []string{},
@@ -230,12 +230,12 @@ func (s *WebHookSuite) TestUpdate(c *check.C) {
 	})
 }
 
-func (s *WebHookSuite) TestUpdateNotFound(c *check.C) {
-	err := s.WebHookStorage.Update(eventTypes.WebHook{Name: "wh1"})
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+func (s *WebhookSuite) TestUpdateNotFound(c *check.C) {
+	err := s.WebhookStorage.Update(eventTypes.Webhook{Name: "wh1"})
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }
 
-func (s *WebHookSuite) TestFindByNameNotFound(c *check.C) {
-	_, err := s.WebHookStorage.FindByName("wh1")
-	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+func (s *WebhookSuite) TestFindByNameNotFound(c *check.C) {
+	_, err := s.WebhookStorage.FindByName("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }

--- a/storage/storagetest/webhook_suite.go
+++ b/storage/storagetest/webhook_suite.go
@@ -1,0 +1,249 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"github.com/tsuru/tsuru/permission"
+	eventTypes "github.com/tsuru/tsuru/types/event"
+	"gopkg.in/check.v1"
+)
+
+type WebHookSuite struct {
+	SuiteHooks
+	WebHookStorage eventTypes.WebHookStorage
+}
+
+func (s *WebHookSuite) TestInsertWebHook(c *check.C) {
+	u, _ := url.Parse("http://mysrv.com:123/abc?a=b")
+	w := eventTypes.WebHook{
+		Name:      "wh1",
+		TeamOwner: "team1",
+		URL:       *u,
+		Method:    "GET",
+		EventFilter: eventTypes.EventFilter{
+			TargetTypes:  []string{"app"},
+			TargetValues: []string{"myapp"},
+		},
+	}
+	err := s.WebHookStorage.Insert(w)
+	c.Assert(err, check.IsNil)
+	webHook, err := s.WebHookStorage.FindByName(w.Name)
+	c.Assert(err, check.IsNil)
+	c.Assert(webHook, check.DeepEquals, &eventTypes.WebHook{
+		Name:      "wh1",
+		TeamOwner: "team1",
+		URL:       *u,
+		Method:    "GET",
+		Headers:   http.Header{},
+		EventFilter: eventTypes.EventFilter{
+			KindTypes:    []string{},
+			KindNames:    []string{},
+			TargetTypes:  []string{"app"},
+			TargetValues: []string{"myapp"},
+			AllowedPermissions: eventTypes.WebHookAllowedPermission{
+				Contexts: []permission.PermissionContext{},
+			},
+		},
+	})
+}
+
+func (s *WebHookSuite) TestFindByEvent(c *check.C) {
+	filters := []eventTypes.EventFilter{
+		{TargetTypes: []string{"app"}, TargetValues: []string{"myapp"}},
+		{ErrorOnly: true},
+		{SuccessOnly: true},
+		{TargetTypes: []string{"app"}, TargetValues: []string{"myapp"}, ErrorOnly: true},
+		{TargetTypes: []string{"app"}, TargetValues: []string{"myapp", "otherapp"}},
+		{KindTypes: []string{"permission"}, KindNames: []string{"app.deploy", "app.update"}},
+		{TargetTypes: []string{"node"}, KindNames: []string{"node.create", "healer"}},
+		{TargetTypes: []string{"app"}, TargetValues: []string{"myapp"}, ErrorOnly: true, KindTypes: []string{"permission"}, KindNames: []string{"app.deploy", "app.update"}},
+		{TargetTypes: []string{"app"}, TargetValues: []string{"otherapp"}},
+		{KindTypes: []string{"permission"}, KindNames: []string{"app.update"}},
+	}
+	u, _ := url.Parse("http://mysrv.com:123/abc?a=b")
+	for i, f := range filters {
+		w := eventTypes.WebHook{
+			Name:        fmt.Sprintf("wh-%d", i),
+			TeamOwner:   "team1",
+			URL:         *u,
+			Method:      "GET",
+			EventFilter: f,
+		}
+		err := s.WebHookStorage.Insert(w)
+		c.Assert(err, check.IsNil)
+	}
+	tests := []struct {
+		f        eventTypes.EventFilter
+		success  bool
+		expected []string
+	}{
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"myapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.deploy"},
+			},
+			success:  false,
+			expected: []string{"wh-0", "wh-1", "wh-3", "wh-4", "wh-5", "wh-7"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"myapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.deploy"},
+			},
+			success:  true,
+			expected: []string{"wh-0", "wh-2", "wh-4", "wh-5"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"otherapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.deploy"},
+			},
+			success:  true,
+			expected: []string{"wh-2", "wh-4", "wh-5", "wh-8"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"anyapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.update.env.set"},
+			},
+			success:  true,
+			expected: []string{"wh-2", "wh-5", "wh-9"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"node"},
+				TargetValues: []string{"10.0.0.1", "10.0.0.2"},
+				KindTypes:    []string{"internal"},
+				KindNames:    []string{"healer"},
+			},
+			success:  true,
+			expected: []string{"wh-2", "wh-6"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"myapp", "otherapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.update"},
+			},
+			success:  true,
+			expected: []string{"wh-0", "wh-2", "wh-4", "wh-5", "wh-8", "wh-9"},
+		},
+		{
+			f: eventTypes.EventFilter{
+				TargetTypes:  []string{"app"},
+				TargetValues: []string{"myapp", "otherapp"},
+				KindTypes:    []string{"permission"},
+				KindNames:    []string{"app.update"},
+			},
+			success:  false,
+			expected: []string{"wh-0", "wh-1", "wh-3", "wh-4", "wh-5", "wh-7", "wh-8", "wh-9"},
+		},
+	}
+	for i, tt := range tests {
+		hooks, err := s.WebHookStorage.FindByEvent(tt.f, tt.success)
+		c.Assert(err, check.IsNil)
+		names := webhooksNames(hooks)
+		c.Assert(names, check.DeepEquals, tt.expected, check.Commentf("failed test %d", i))
+	}
+}
+
+func (s *WebHookSuite) TestInsertDuplicateWebHook(c *check.C) {
+	t := eventTypes.WebHook{Name: "WebHookname"}
+	err := s.WebHookStorage.Insert(t)
+	c.Assert(err, check.IsNil)
+	err = s.WebHookStorage.Insert(t)
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookAlreadyExists)
+}
+
+func webhooksNames(hooks []eventTypes.WebHook) []string {
+	var names []string
+	for _, h := range hooks {
+		names = append(names, h.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *WebHookSuite) TestFindAllByTeams(c *check.C) {
+	w1 := eventTypes.WebHook{Name: "wh1", TeamOwner: "t1"}
+	err := s.WebHookStorage.Insert(w1)
+	c.Assert(err, check.IsNil)
+	w2 := eventTypes.WebHook{Name: "wh2", TeamOwner: "t2"}
+	err = s.WebHookStorage.Insert(w2)
+	c.Assert(err, check.IsNil)
+	webhooks, err := s.WebHookStorage.FindAllByTeams(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1", "wh2"})
+	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{})
+	c.Assert(err, check.IsNil)
+	c.Assert(webhooksNames(webhooks), check.IsNil)
+	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{"t1"})
+	c.Assert(err, check.IsNil)
+	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1"})
+	webhooks, err = s.WebHookStorage.FindAllByTeams([]string{"t1", "t2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(webhooksNames(webhooks), check.DeepEquals, []string{"wh1", "wh2"})
+}
+
+func (s *WebHookSuite) TestDelete(c *check.C) {
+	w := eventTypes.WebHook{Name: "wh1"}
+	err := s.WebHookStorage.Insert(w)
+	c.Assert(err, check.IsNil)
+	err = s.WebHookStorage.Delete("wh1")
+	c.Assert(err, check.IsNil)
+	err = s.WebHookStorage.Delete("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+	_, err = s.WebHookStorage.FindByName("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}
+
+func (s *WebHookSuite) TestUpdate(c *check.C) {
+	w := eventTypes.WebHook{Name: "wh1"}
+	err := s.WebHookStorage.Insert(w)
+	c.Assert(err, check.IsNil)
+	w.Method = "GET"
+	err = s.WebHookStorage.Update(w)
+	c.Assert(err, check.IsNil)
+	dbW, err := s.WebHookStorage.FindByName("wh1")
+	c.Assert(err, check.IsNil)
+	c.Assert(dbW, check.DeepEquals, &eventTypes.WebHook{
+		Name:    "wh1",
+		Method:  "GET",
+		Headers: http.Header{},
+		EventFilter: eventTypes.EventFilter{
+			KindTypes:    []string{},
+			KindNames:    []string{},
+			TargetTypes:  []string{},
+			TargetValues: []string{},
+			AllowedPermissions: eventTypes.WebHookAllowedPermission{
+				Contexts: []permission.PermissionContext{},
+			},
+		},
+	})
+}
+
+func (s *WebHookSuite) TestUpdateNotFound(c *check.C) {
+	err := s.WebHookStorage.Update(eventTypes.WebHook{Name: "wh1"})
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}
+
+func (s *WebHookSuite) TestFindByNameNotFound(c *check.C) {
+	_, err := s.WebHookStorage.FindByName("wh1")
+	c.Assert(err, check.Equals, eventTypes.ErrWebHookNotFound)
+}

--- a/types/event/webhook.go
+++ b/types/event/webhook.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	ErrWebHookAlreadyExists = errors.New("webhook already exists with the same name")
-	ErrWebHookNotFound      = errors.New("webhook not found")
+	ErrWebhookAlreadyExists = errors.New("webhook already exists with the same name")
+	ErrWebhookNotFound      = errors.New("webhook not found")
 )
 
-type WebHookEventFilter struct {
+type WebhookEventFilter struct {
 	TargetTypes  []string `json:"target_types" form:"target_types"`
 	TargetValues []string `json:"target_values" form:"target_values"`
 	KindTypes    []string `json:"kind_types" form:"kind_types"`
@@ -23,11 +23,11 @@ type WebHookEventFilter struct {
 	SuccessOnly  bool     `json:"success_only" form:"success_only"`
 }
 
-type WebHook struct {
+type Webhook struct {
 	Name        string             `json:"name" form:"name"`
 	Description string             `json:"description" form:"description"`
 	TeamOwner   string             `json:"team_owner" form:"team_owner"`
-	EventFilter WebHookEventFilter `json:"event_filter" form:"event_filter"`
+	EventFilter WebhookEventFilter `json:"event_filter" form:"event_filter"`
 	URL         string             `json:"url" form:"url"`
 	Headers     http.Header        `json:"headers" form:"headers"`
 	Method      string             `json:"method" form:"method"`
@@ -35,20 +35,20 @@ type WebHook struct {
 	Insecure    bool               `json:"insecure" form:"insecure"`
 }
 
-type WebHookService interface {
+type WebhookService interface {
 	Notify(evtID string)
-	Create(WebHook) error
-	Update(WebHook) error
+	Create(Webhook) error
+	Update(Webhook) error
 	Delete(string) error
-	Find(string) (WebHook, error)
-	List([]string) ([]WebHook, error)
+	Find(string) (Webhook, error)
+	List([]string) ([]Webhook, error)
 }
 
-type WebHookStorage interface {
-	Insert(WebHook) error
-	Update(WebHook) error
-	FindAllByTeams([]string) ([]WebHook, error)
-	FindByName(string) (*WebHook, error)
-	FindByEvent(f WebHookEventFilter, isSuccess bool) ([]WebHook, error)
+type WebhookStorage interface {
+	Insert(Webhook) error
+	Update(Webhook) error
+	FindAllByTeams([]string) ([]Webhook, error)
+	FindByName(string) (*Webhook, error)
+	FindByEvent(f WebhookEventFilter, isSuccess bool) ([]Webhook, error)
 	Delete(string) error
 }

--- a/types/event/webhook.go
+++ b/types/event/webhook.go
@@ -29,6 +29,7 @@ type Webhook struct {
 	TeamOwner   string             `json:"team_owner" form:"team_owner"`
 	EventFilter WebhookEventFilter `json:"event_filter" form:"event_filter"`
 	URL         string             `json:"url" form:"url"`
+	ProxyURL    string             `json:"proxy_url" form:"proxy_url"`
 	Headers     http.Header        `json:"headers" form:"headers"`
 	Method      string             `json:"method" form:"method"`
 	Body        string             `json:"body" form:"body"`

--- a/types/event/webhook.go
+++ b/types/event/webhook.go
@@ -7,9 +7,6 @@ package event
 import (
 	"errors"
 	"net/http"
-	"net/url"
-
-	"github.com/tsuru/tsuru/permission"
 )
 
 var (
@@ -17,35 +14,34 @@ var (
 	ErrWebHookNotFound      = errors.New("webhook not found")
 )
 
-type EventFilter struct {
-	TargetTypes        []string
-	TargetValues       []string
-	KindTypes          []string
-	KindNames          []string
-	ErrorOnly          bool
-	SuccessOnly        bool
-	AllowedPermissions WebHookAllowedPermission
-}
-
-type WebHookAllowedPermission struct {
-	Scheme   string
-	Contexts []permission.PermissionContext
+type WebHookEventFilter struct {
+	TargetTypes  []string `json:"target_types" form:"target_types"`
+	TargetValues []string `json:"target_values" form:"target_values"`
+	KindTypes    []string `json:"kind_types" form:"kind_types"`
+	KindNames    []string `json:"kind_names" form:"kind_names"`
+	ErrorOnly    bool     `json:"error_only" form:"error_only"`
+	SuccessOnly  bool     `json:"success_only" form:"success_only"`
 }
 
 type WebHook struct {
-	Name        string
-	Description string
-	TeamOwner   string
-	EventFilter EventFilter
-	URL         url.URL
-	Headers     http.Header
-	Method      string
-	Body        string
-	Insecure    bool
+	Name        string             `json:"name" form:"name"`
+	Description string             `json:"description" form:"description"`
+	TeamOwner   string             `json:"team_owner" form:"team_owner"`
+	EventFilter WebHookEventFilter `json:"event_filter" form:"event_filter"`
+	URL         string             `json:"url" form:"url"`
+	Headers     http.Header        `json:"headers" form:"headers"`
+	Method      string             `json:"method" form:"method"`
+	Body        string             `json:"body" form:"body"`
+	Insecure    bool               `json:"insecure" form:"insecure"`
 }
 
 type WebHookService interface {
 	Notify(evtID string)
+	Create(WebHook) error
+	Update(WebHook) error
+	Delete(string) error
+	Find(string) (WebHook, error)
+	List([]string) ([]WebHook, error)
 }
 
 type WebHookStorage interface {
@@ -53,6 +49,6 @@ type WebHookStorage interface {
 	Update(WebHook) error
 	FindAllByTeams([]string) ([]WebHook, error)
 	FindByName(string) (*WebHook, error)
-	FindByEvent(f EventFilter, isSuccess bool) ([]WebHook, error)
+	FindByEvent(f WebHookEventFilter, isSuccess bool) ([]WebHook, error)
 	Delete(string) error
 }

--- a/types/event/webhook.go
+++ b/types/event/webhook.go
@@ -1,0 +1,58 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package event
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/tsuru/tsuru/permission"
+)
+
+var (
+	ErrWebHookAlreadyExists = errors.New("webhook already exists with the same name")
+	ErrWebHookNotFound      = errors.New("webhook not found")
+)
+
+type EventFilter struct {
+	TargetTypes        []string
+	TargetValues       []string
+	KindTypes          []string
+	KindNames          []string
+	ErrorOnly          bool
+	SuccessOnly        bool
+	AllowedPermissions WebHookAllowedPermission
+}
+
+type WebHookAllowedPermission struct {
+	Scheme   string
+	Contexts []permission.PermissionContext
+}
+
+type WebHook struct {
+	Name        string
+	Description string
+	TeamOwner   string
+	EventFilter EventFilter
+	URL         url.URL
+	Headers     http.Header
+	Method      string
+	Body        string
+	Insecure    bool
+}
+
+type WebHookService interface {
+	Notify(evtID string)
+}
+
+type WebHookStorage interface {
+	Insert(WebHook) error
+	Update(WebHook) error
+	FindAllByTeams([]string) ([]WebHook, error)
+	FindByName(string) (*WebHook, error)
+	FindByEvent(f EventFilter, isSuccess bool) ([]WebHook, error)
+	Delete(string) error
+}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -5,7 +5,12 @@
 // Package validation provide utilities functions for data validation.
 package validation
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/tsuru/tsuru/errors"
+)
 
 var (
 	emailRegexp = regexp.MustCompile(`^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$`)
@@ -39,4 +44,11 @@ func ValidateLength(value string, min, max int) bool {
 // containing only lower case letters, numbers or dashes and starts with a letter
 func ValidateName(name string) bool {
 	return nameRegexp.MatchString(name)
+}
+
+func EnsureValidateName(name string) error {
+	if !ValidateName(name) {
+		return &errors.ValidationError{Message: fmt.Sprintf("name does not match regex %q", nameRegexp.String())}
+	}
+	return nil
 }


### PR DESCRIPTION
WebHooks can now be registered in the tsuru API to be triggered whenever an event matches the webhook specification.

The two main parts for this PR are:
1 - Routes for WebHooks CRUD and corresponding service and storage methods.
2 - Each time an event is finished (`evt.Done()` call), tsuru will send to event to a channel where a dedicated goroutine will pick the event and search for all webhooks matching it. After listing all webhooks that must be called tsuru will proceed to call them sequentially.

By default the webhook request is a POST containing in its body the event that triggered it serialized as JSON, but this behavior can be overridden by setting a custom method and body in the event.
