### PR TITLE
Get Kubernetes cluster config automatically when running in cluster

### DIFF
--- a/provision/cluster/cluster.go
+++ b/provision/cluster/cluster.go
@@ -65,9 +65,6 @@ func (c *Cluster) validate() error {
 	if err != nil {
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: err.Error()})
 	}
-	if len(c.Addresses) == 0 {
-		return errors.WithStack(&tsuruErrors.ValidationError{Message: "at least one address must be present"})
-	}
 	if len(c.Pools) > 0 {
 		if c.Default {
 			return errors.WithStack(&tsuruErrors.ValidationError{Message: "cannot have both pools and default set"})

--- a/provision/cluster/cluster_test.go
+++ b/provision/cluster/cluster_test.go
@@ -282,15 +282,6 @@ func (s *S) TestClusterSaveValidation(c *check.C) {
 		{
 			c: Cluster{
 				Name:        "c1",
-				Addresses:   []string{},
-				Default:     true,
-				Provisioner: "fake",
-			},
-			err: "at least one address must be present",
-		},
-		{
-			c: Cluster{
-				Name:        "c1",
 				Addresses:   []string{"addr1"},
 				Default:     false,
 				Provisioner: "fake",


### PR DESCRIPTION
When tsuru API is running in a Kubernetes cluster, try to get the cluster configs automatically when registering it.