### PR TITLE
provision/kubernetes: drops replicas label from pods

### DIFF
--- a/provision/env.go
+++ b/provision/env.go
@@ -6,6 +6,7 @@ package provision
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app/bind"
@@ -25,6 +26,9 @@ func EnvsForApp(a App, process string, isDeploy bool) []bind.EnvVar {
 		for _, envData := range a.Envs() {
 			envs = append(envs, envData)
 		}
+		sort.Slice(envs, func(i int, j int) bool {
+			return envs[i].Name < envs[j].Name
+		})
 		envs = append(envs, bind.EnvVar{Name: "TSURU_PROCESSNAME", Value: process})
 	}
 	host, _ := config.GetString("host")

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -432,7 +432,7 @@ func createAppDeployment(client *ClusterClient, oldDeployment *v1beta2.Deploymen
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels.ToLabels(),
+					Labels:      labels.WithoutAppReplicas().ToLabels(),
 					Annotations: annotations.ToLabels(),
 				},
 				Spec: apiv1.PodSpec{
@@ -515,7 +515,7 @@ func (m *serviceManager) CurrentLabels(a provision.App, process string) (*provis
 		}
 		return nil, errors.WithStack(err)
 	}
-	return labelSetFromMeta(&dep.Spec.Template.ObjectMeta), nil
+	return labelSetFromMeta(&dep.ObjectMeta), nil
 }
 
 const deadlineExeceededProgressCond = "ProgressDeadlineExceeded"

--- a/provision/labels.go
+++ b/provision/labels.go
@@ -116,6 +116,17 @@ func (s *LabelSet) NodeIaaSID() string {
 	return s.getLabel(labelNodeIaaSID)
 }
 
+func (s *LabelSet) WithoutAppReplicas() *LabelSet {
+	ns := LabelSet{Prefix: s.Prefix, Labels: make(map[string]string)}
+	for k, v := range s.Labels {
+		if k == labelAppProcessReplicas {
+			continue
+		}
+		ns.Labels[k] = v
+	}
+	return &ns
+}
+
 func filterByPrefix(m map[string]string, prefix string, withPrefix bool) map[string]string {
 	result := make(map[string]string, len(m))
 	for k, v := range m {

--- a/provision/labels_test.go
+++ b/provision/labels_test.go
@@ -152,3 +152,24 @@ func (s *S) TestNodeLabels(c *check.C) {
 		Prefix: "myprefix",
 	})
 }
+
+func (s *S) TestLabelSet_WithoutAppReplicas(c *check.C) {
+	config.Set("routers:fake:type", "fake")
+	defer config.Unset("routers")
+	a := provisiontest.NewFakeApp("myapp", "cobol", 0)
+	opts := provision.ServiceLabelsOpts{
+		App:      a,
+		Replicas: 3,
+		Process:  "p1",
+		ServiceLabelExtendedOpts: provision.ServiceLabelExtendedOpts{
+			BuildImage:  "myimg",
+			IsBuild:     true,
+			Provisioner: "kubernetes",
+			Builder:     "docker",
+		},
+	}
+	ls, err := provision.ServiceLabels(opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(ls.Labels["app-process-replicas"], check.Equals, "3")
+	c.Assert(ls.WithoutAppReplicas().Labels["app-process-replicas"], check.Equals, "")
+}


### PR DESCRIPTION
This commit removes the "replicas" label from pods. Without this change,
adding/removing a single (or multiple units) from an app would cause
Kubernetes to behave the same as when a new deploy happens (creating
a new replicaset, doubling the number of units during the operation).

I considered keeping the pod labels to a minimum (probably only the set of
labels used on the selector) but this would require some large change on the way
the provisioner returns the units to tsuru. What do you think, @cezarsa?