### PR TITLE
Pre-compile regexps in service and provision/pool pkgs

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -32,6 +32,8 @@ type Service struct {
 
 var (
 	ErrServiceAlreadyExists = errors.New("Service already exists.")
+
+	schemeRegexp = regexp.MustCompile("^https?://")
 )
 
 func (s *Service) Get() error {
@@ -87,7 +89,7 @@ func (s *Service) Delete() error {
 
 func (s *Service) getClient(endpoint string) (cli *Client, err error) {
 	if e, ok := s.Endpoint[endpoint]; ok {
-		if p, _ := regexp.MatchString("^https?://", e); !p {
+		if p := schemeRegexp.MatchString(e); !p {
 			e = "http://" + e
 		}
 		cli = &Client{serviceName: s.Name, endpoint: e, username: s.GetUsername(), password: s.Password}


### PR DESCRIPTION
The MatchString call in the pool pkg was responsible for over 500GB of allocations alone, causing the second largest flat allocation node in a production profile:

```
(pprof) top
Showing nodes accounting for 818.74GB, 53.66% of 1525.77GB total
Dropped 1988 nodes (cum <= 7.63GB)
Showing top 10 nodes out of 247
      flat  flat%   sum%        cum   cum%
  196.45GB 12.88% 12.88%   211.47GB 13.86%  github.com/tsuru/tsuru/vendor/github.com/globalsign/mgo.(*mongoSocket).readLoop
  117.10GB  7.67% 20.55%   117.10GB  7.67%  regexp/syntax.(*compiler).rune
```

```
(pprof) peek regexp.MatchString
Showing nodes accounting for 1562389.06MB, 100% of 1562389.06MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                       546702.77MB 94.69% |   github.com/tsuru/tsuru/provision/pool.(*PoolConstraint).check
                                        30193.94MB  5.23% |   github.com/tsuru/tsuru/provision/pool.getConstraintsForPool
                                          473.92MB 0.082% |   github.com/tsuru/tsuru/service.(*Service).getClient
         0     0%     0% 577370.62MB 36.95%                | regexp.MatchString
                                       478383.95MB 82.86% |   regexp.Compile
                                        98986.67MB 17.14% |   regexp.(*Regexp).MatchString
----------------------------------------------------------+-------------
```