### PR TITLE
compose: adds local Dockerfile for build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,3 @@
+FROM golang:alpine
+
+RUN apk add gcc musl-dev --no-cache

--- a/build-compose.sh
+++ b/build-compose.sh
@@ -18,7 +18,9 @@ then
   fi
 fi
 
-if [[ ! $(docker images -q tsuru-build) ]]; then docker build -t tsuru-build -f Dockerfile.build .; fi;
+context=$(mktemp -d)
+docker build -t tsuru-build -f Dockerfile.build $context
+rmdir $context
 
 BUILD_IMAGE='tsuru-build'
 

--- a/build-compose.sh
+++ b/build-compose.sh
@@ -18,8 +18,9 @@ then
   fi
 fi
 
+if [[ ! $(docker images -q tsuru-build) ]]; then docker build -t tsuru-build -f Dockerfile.build .; fi;
 
-BUILD_IMAGE='tsuru/alpine-go:latest'
+BUILD_IMAGE='tsuru-build'
 
 LOCAL_PKG=${GOPATH}'/pkg/linux_amd64'
 CONTAINER_PKG='/go/pkg/linux_amd64'


### PR DESCRIPTION
This PR adds a local Dockerfile to be used by compose-build when building tsuru
for development. Our alpine platforms are not really maintained right now and
updating Go was getting harder and harder. For that reason, this local Dockerfile
relies on Go's official image.