### PR TITLE
provision/kubernetes: fixes Units failing to list app units

### DIFF
--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -392,7 +392,7 @@ func podsForApps(client *ClusterClient, apps []provision.App) ([]apiv1.Pod, erro
 		if err != nil {
 			return nil, err
 		}
-		sel.Add(*req)
+		sel = sel.Add(*req)
 	}
 	pods, err := client.CoreV1().Pods(client.Namespace()).List(metav1.ListOptions{
 		LabelSelector: sel.String(),

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -472,10 +472,14 @@ func (s *S) TestUpdateNodeToggleDisableTaint(c *check.C) {
 }
 
 func (s *S) TestUnits(c *check.C) {
+	_, err := s.client.CoreV1().Pods(s.client.Namespace()).Create(&apiv1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "non-app-pod",
+	}})
+	c.Assert(err, check.IsNil)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	imgName := "myapp:v1"
-	err := image.SaveImageCustomData(imgName, map[string]interface{}{
+	err = image.SaveImageCustomData(imgName, map[string]interface{}{
 		"processes": map[string]interface{}{
 			"web":    "python myapp.py",
 			"worker": "myworker",


### PR DESCRIPTION
selector.Add actually returns a new Selector with the added requirement
instead of mutating the existing requirements. Before this change, the
API would send an empty list of requirements resulting in every pod
being listed.