### PR TITLE
cmd: adds ReadCloser transport

### DIFF
--- a/cmd/cmdtest/transport_test.go
+++ b/cmd/cmdtest/transport_test.go
@@ -5,6 +5,7 @@
 package cmdtest
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -23,6 +24,22 @@ func Test(t *testing.T) {
 func (S) TestTransport(c *check.C) {
 	var t http.RoundTripper = &Transport{
 		Message: "Ok",
+		Status:  http.StatusOK,
+		Headers: map[string][]string{"Authorization": {"something"}},
+	}
+	req, _ := http.NewRequest("GET", "/", nil)
+	r, err := t.RoundTrip(req)
+	c.Assert(err, check.IsNil)
+	c.Assert(r.StatusCode, check.Equals, http.StatusOK)
+	defer r.Body.Close()
+	b, _ := ioutil.ReadAll(r.Body)
+	c.Assert(string(b), check.Equals, "Ok")
+	c.Assert(r.Header.Get("Authorization"), check.Equals, "something")
+}
+
+func (S) TestBodyTransport(c *check.C) {
+	var t http.RoundTripper = &BodyTransport{
+		Body:    ioutil.NopCloser(bytes.NewReader([]byte("Ok"))),
 		Status:  http.StatusOK,
 		Headers: map[string][]string{"Authorization": {"something"}},
 	}


### PR DESCRIPTION
This is required for some tsuru-client tests for deploy cancellation