### PR TITLE
provision/kubernetes: return err instead of port 0 when service is not found

### DIFF
--- a/provision/docker/image_test.go
+++ b/provision/docker/image_test.go
@@ -119,13 +119,11 @@ func (s *S) TestMigrateImagesWithRegistry(c *check.C) {
 	images, err := client.ListImages(docker.ListImagesOptions{All: true})
 	c.Assert(err, check.IsNil)
 	c.Assert(images, check.HasLen, 2)
+	sort.Strings(images[0].RepoTags)
+	sort.Strings(images[1].RepoTags)
 	sort.Slice(images, func(i, j int) bool {
 		return strings.Join(images[i].RepoTags, "") < strings.Join(images[j].RepoTags, "")
 	})
-	tags1 := images[0].RepoTags
-	sort.Strings(tags1)
-	tags2 := images[1].RepoTags
-	sort.Strings(tags2)
-	c.Assert(tags1, check.DeepEquals, []string{"localhost:3030/tsuru/app-app1", "localhost:3030/tsuru/app1"})
-	c.Assert(tags2, check.DeepEquals, []string{"localhost:3030/tsuru/app-app2", "localhost:3030/tsuru/app2"})
+	c.Assert(images[0].RepoTags, check.DeepEquals, []string{"localhost:3030/tsuru/app-app1", "localhost:3030/tsuru/app1"})
+	c.Assert(images[1].RepoTags, check.DeepEquals, []string{"localhost:3030/tsuru/app-app2", "localhost:3030/tsuru/app2"})
 }

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -429,9 +429,6 @@ func appPodsFromNode(client *ClusterClient, nodeName string) ([]apiv1.Pod, error
 func getServicePort(client *ClusterClient, srvName string) (int32, error) {
 	srv, err := client.CoreV1().Services(client.Namespace()).Get(srvName, metav1.GetOptions{})
 	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return 0, nil
-		}
 		return 0, errors.WithStack(err)
 	}
 	if len(srv.Spec.Ports) == 0 {

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -516,7 +516,7 @@ func (s *S) TestLabelSetFromMeta(c *check.C) {
 }
 
 func (s *S) TestGetServicePort(c *check.C) {
-	port, err := getServicePort(s.clusterClient, "notfound")
+	_, err := getServicePort(s.clusterClient, "notfound")
 	c.Assert(err, check.NotNil)
 	_, err = s.client.CoreV1().Services(s.client.Namespace()).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -525,7 +525,7 @@ func (s *S) TestGetServicePort(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	port, err = getServicePort(s.clusterClient, "srv1")
+	port, err := getServicePort(s.clusterClient, "srv1")
 	c.Assert(err, check.IsNil)
 	c.Assert(port, check.Equals, int32(0))
 	_, err = s.client.CoreV1().Services(s.client.Namespace()).Create(&apiv1.Service{

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -517,8 +517,7 @@ func (s *S) TestLabelSetFromMeta(c *check.C) {
 
 func (s *S) TestGetServicePort(c *check.C) {
 	port, err := getServicePort(s.clusterClient, "notfound")
-	c.Assert(err, check.IsNil)
-	c.Assert(port, check.Equals, int32(0))
+	c.Assert(err, check.NotNil)
 	_, err = s.client.CoreV1().Services(s.client.Namespace()).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "srv1",


### PR DESCRIPTION
If a Kubernetes service is not found, app routes rebuild command is setting the port to `0`. With this PR, it fails and doesn't change the routes.