### PR TITLE
api,app,provision: single ExecuteCommand implementation in provisioners

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -2683,8 +2683,13 @@ func (s *S) TestRunOnce(c *check.C) {
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
 	expected += " [ -d /home/application/current ] && cd /home/application/current;"
 	expected += " ls"
-	cmds := s.provisioner.GetCmds(expected, &a)
-	c.Assert(cmds, check.HasLen, 1)
+	units, err := a.GetUnits()
+	c.Assert(err, check.IsNil)
+	c.Assert(units, check.HasLen, 3)
+	allExecs := s.provisioner.AllExecs()
+	c.Assert(allExecs, check.HasLen, 1)
+	c.Assert(allExecs[units[0].GetID()], check.HasLen, 1)
+	c.Assert(allExecs[units[0].GetID()][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", expected})
 	c.Assert(eventtest.EventDesc{
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
@@ -2715,8 +2720,13 @@ func (s *S) TestRun(c *check.C) {
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
 	expected += " [ -d /home/application/current ] && cd /home/application/current;"
 	expected += " ls"
-	cmds := s.provisioner.GetCmds(expected, &a)
-	c.Assert(cmds, check.HasLen, 1)
+	units, err := a.GetUnits()
+	c.Assert(err, check.IsNil)
+	c.Assert(units, check.HasLen, 1)
+	allExecs := s.provisioner.AllExecs()
+	c.Assert(allExecs, check.HasLen, 1)
+	c.Assert(allExecs[units[0].GetID()], check.HasLen, 1)
+	c.Assert(allExecs[units[0].GetID()][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", expected})
 	c.Assert(eventtest.EventDesc{
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
@@ -2747,8 +2757,10 @@ func (s *S) TestRunIsolated(c *check.C) {
 	expected := "[ -f /home/application/apprc ] && source /home/application/apprc;"
 	expected += " [ -d /home/application/current ] && cd /home/application/current;"
 	expected += " ls"
-	cmds := s.provisioner.GetCmds(expected, &a)
-	c.Assert(cmds, check.HasLen, 1)
+	allExecs := s.provisioner.AllExecs()
+	c.Assert(allExecs, check.HasLen, 1)
+	c.Assert(allExecs["isolated"], check.HasLen, 1)
+	c.Assert(allExecs["isolated"][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", expected})
 	c.Assert(eventtest.EventDesc{
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),

--- a/provision/docker/container/container_test.go
+++ b/provision/docker/container/container_test.go
@@ -616,7 +616,7 @@ func (s *S) TestContainerRemoveStopsContainer(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 }
 
-func (s *S) TestContainerShell(c *check.C) {
+func (s *S) TestContainerExecWithStdin(c *check.C) {
 	var urls struct {
 		items []url.URL
 		sync.Mutex
@@ -634,7 +634,7 @@ func (s *S) TestContainerShell(c *check.C) {
 	c.Assert(err, check.IsNil)
 	var stdout, stderr bytes.Buffer
 	stdin := bytes.NewBufferString("")
-	err = container.Shell(s.cli, stdin, &stdout, &stderr, Pty{Width: 140, Height: 38, Term: "xterm"})
+	err = container.Exec(s.cli, stdin, &stdout, &stderr, Pty{Width: 140, Height: 38, Term: "xterm"}, "cmd1", "arg1")
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.Contains(stdout.String(), ""), check.Equals, true)
 	urls.Lock()
@@ -649,14 +649,14 @@ func (s *S) TestContainerShell(c *check.C) {
 	exec, err := client.InspectExec(matches[1])
 	c.Assert(err, check.IsNil)
 	cmd := append([]string{exec.ProcessConfig.EntryPoint}, exec.ProcessConfig.Arguments...)
-	c.Assert(cmd, check.DeepEquals, []string{"/usr/bin/env", "TERM=xterm", "bash", "-l"})
+	c.Assert(cmd, check.DeepEquals, []string{"cmd1", "arg1"})
 }
 
 func (s *S) TestContainerExec(c *check.C) {
 	container, err := s.newContainer(newContainerOpts{}, nil)
 	c.Assert(err, check.IsNil)
 	var stdout, stderr bytes.Buffer
-	err = container.Exec(s.cli, &stdout, &stderr, "ls", "-lh")
+	err = container.Exec(s.cli, nil, &stdout, &stderr, Pty{}, "ls", "-lh")
 	c.Assert(err, check.IsNil)
 }
 
@@ -668,7 +668,7 @@ func (s *S) TestContainerExecErrorCode(c *check.C) {
 	container, err := s.newContainer(newContainerOpts{}, nil)
 	c.Assert(err, check.IsNil)
 	var stdout, stderr bytes.Buffer
-	err = container.Exec(s.cli, &stdout, &stderr, "ls", "-lh")
+	err = container.Exec(s.cli, nil, &stdout, &stderr, Pty{}, "ls", "-lh")
 	c.Assert(err, check.DeepEquals, &execErr{code: 9})
 }
 

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -242,17 +242,6 @@ type AppLock interface {
 	GetAcquireDate() time.Time
 }
 
-// ShellOptions is the set of options that can be used when calling the method
-// Shell in the provisioner.
-type ShellOptions struct {
-	App    App
-	Conn   io.ReadWriteCloser
-	Width  int
-	Height int
-	Unit   string
-	Term   string
-}
-
 // RollbackableDeployer is a provisioner that allows rolling back to a
 // previously deployed version.
 type RollbackableDeployer interface {
@@ -358,24 +347,20 @@ type Provisioner interface {
 	RegisterUnit(App, string, map[string]interface{}) error
 }
 
-// ShellProvisioner is a provisioner that allows opening a shell to existing
-// units.
-type ShellProvisioner interface {
-	// Open a remote shel in one of the units in the application.
-	Shell(ShellOptions) error
+type ExecOptions struct {
+	App    App
+	Stdout io.Writer
+	Stderr io.Writer
+	Stdin  io.Reader
+	Width  int
+	Height int
+	Term   string
+	Cmds   []string
+	Units  []string
 }
 
-// ExecutableProvisioner is a provisioner that allows executing commands on
-// units.
 type ExecutableProvisioner interface {
-	// ExecuteCommand runs a command in all units of the app.
-	ExecuteCommand(stdout, stderr io.Writer, app App, cmd string, args ...string) error
-
-	// ExecuteCommandOnce runs a command in one unit of the app.
-	ExecuteCommandOnce(stdout, stderr io.Writer, app App, cmd string, args ...string) error
-
-	// ExecuteCommandIsolated runs a command in an new and ephemeral container.
-	ExecuteCommandIsolated(stdout, stderr io.Writer, app App, cmd string, args ...string) error
+	ExecuteCommand(opts ExecOptions) error
 }
 
 // SleepableProvisioner is a provisioner that allows putting applications to

--- a/vendor/github.com/tsuru/docker-cluster/cluster/container.go
+++ b/vendor/github.com/tsuru/docker-cluster/cluster/container.go
@@ -413,3 +413,11 @@ func (c *Cluster) DownloadFromContainer(containerId string, opts docker.Download
 	}
 	return node.DownloadFromContainer(containerId, opts)
 }
+
+func (c *Cluster) ResizeContainerTTY(containerId string, height, width int) error {
+	node, err := c.getNodeForContainer(containerId)
+	if err != nil {
+		return err
+	}
+	return wrapError(node, node.ResizeContainerTTY(containerId, height, width))
+}


### PR DESCRIPTION
Unifying all previous methods allow us to simplify the logic behind each
implementation. Now the differece between app-shell and app-run is
simply the presence of a Stdin reader in the ExecuteCommand call. This
change also removes some logic from inside each provisioner and moves it
to the `app` package, allowing it to be shared (selecting which units to
run and which commands to be executed).

Another benefit is that we now also have `app-shell --isolated` almost
for free.

Fixes #1827