### PR TITLE
provision/docker: only set auth if image belogs to registry in config

### DIFF
--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -183,7 +183,7 @@ func pushImageToRegistry(client provision.BuilderDockerClient, app provision.App
 		InactivityTimeout: net.StreamInactivityTimeout,
 		RawJSONStream:     true,
 	}
-	err = client.PushImage(pushOpts, dockercommon.RegistryAuthConfig())
+	err = client.PushImage(pushOpts, dockercommon.RegistryAuthConfig(newImage))
 	if err != nil {
 		return "", err
 	}

--- a/builder/docker/platform.go
+++ b/builder/docker/platform.go
@@ -91,7 +91,7 @@ func (b *dockerBuilder) buildPlatform(name string, args map[string]string, w io.
 		OutputStream:      &buf,
 		InactivityTimeout: net.StreamInactivityTimeout,
 	}
-	err = client.PushImage(pushOpts, dockercommon.RegistryAuthConfig())
+	err = client.PushImage(pushOpts, dockercommon.RegistryAuthConfig(imageName))
 	if err != nil {
 		log.Errorf("[docker] Failed to push image %q (%s): %s", name, err, buf.String())
 		return err

--- a/provision/docker/actions_test.go
+++ b/provision/docker/actions_test.go
@@ -1293,7 +1293,7 @@ func (s *S) TestUpdateAppImageForward(c *check.C) {
 		Repository: registry.Addr() + "/tsuru/app-mightyapp",
 		Tag:        "v1",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(registry.Addr()))
 	c.Assert(err, check.IsNil)
 	args := changeUnitsPipelineArgs{app: app, writer: buf, provisioner: s.p, imageID: nextImgName}
 	context := action.FWContext{Params: []interface{}{args}, Previous: &cont}

--- a/provision/docker/container/container.go
+++ b/provision/docker/container/container.go
@@ -427,7 +427,7 @@ func (c *Container) Commit(client provision.BuilderDockerClient, limiter provisi
 			maxTry = 3
 		}
 		for i := 0; i < maxTry; i++ {
-			err = dockercommon.PushImage(client, repository, tag, dockercommon.RegistryAuthConfig())
+			err = dockercommon.PushImage(client, repository, tag, dockercommon.RegistryAuthConfig(repository))
 			if err != nil {
 				fmt.Fprintf(writer, "Could not send image, trying again. Original error: %s\n", err.Error())
 				log.Errorf("error in push image %s: %s", c.BuildingImage, err)

--- a/provision/docker/containers.go
+++ b/provision/docker/containers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/docker/container"
+	"github.com/tsuru/tsuru/provision/dockercommon"
 	"github.com/tsuru/tsuru/router/rebuild"
 )
 
@@ -334,7 +335,16 @@ func (p *dockerProvisioner) runCommandInContainer(image string, command string, 
 		AppName:       app.GetName(),
 		ActionLimiter: p.ActionLimiter(),
 	}
-	addr, cont, err := cluster.CreateContainerSchedulerOpts(createOptions, schedOpts, net.StreamInactivityTimeout)
+	pullOpts := docker.PullImageOptions{
+		Repository:        createOptions.Config.Image,
+		InactivityTimeout: net.StreamInactivityTimeout,
+	}
+	addr, cont, err := cluster.CreateContainerPullOptsSchedulerOpts(
+		createOptions,
+		pullOpts,
+		dockercommon.RegistryAuthConfig(createOptions.Config.Image),
+		schedOpts,
+	)
 	hostAddr := net.URLToHost(addr)
 	if schedOpts.LimiterDone != nil {
 		schedOpts.LimiterDone()

--- a/provision/docker/dockertest/provisioner.go
+++ b/provision/docker/dockertest/provisioner.go
@@ -344,7 +344,7 @@ type StartContainersArgs struct {
 // will be both returned and stored internally.
 func (p *FakeDockerProvisioner) StartContainers(args StartContainersArgs) ([]container.Container, error) {
 	if args.PullImage {
-		err := p.Cluster().PullImage(docker.PullImageOptions{Repository: args.Image}, dockercommon.RegistryAuthConfig(), args.Endpoint)
+		err := p.Cluster().PullImage(docker.PullImageOptions{Repository: args.Image}, dockercommon.RegistryAuthConfig(args.Image), args.Endpoint)
 		if err != nil {
 			return nil, err
 		}

--- a/provision/docker/dockertest/provisioner_test.go
+++ b/provision/docker/dockertest/provisioner_test.go
@@ -64,7 +64,7 @@ func (s *S) TestNewFakeDockerProvisioner(c *check.C) {
 	_, err = p.storage.RetrieveNode(server.URL())
 	c.Assert(err, check.IsNil)
 	opts := docker.PullImageOptions{Repository: "tsuru/bs"}
-	err = p.Cluster().PullImage(opts, dockercommon.RegistryAuthConfig())
+	err = p.Cluster().PullImage(opts, dockercommon.RegistryAuthConfig(opts.Repository))
 	c.Assert(err, check.IsNil)
 	client, err := docker.NewClient(server.URL())
 	c.Assert(err, check.IsNil)
@@ -75,7 +75,8 @@ func (s *S) TestNewFakeDockerProvisioner(c *check.C) {
 func (s *S) TestStartMultipleServersCluster(c *check.C) {
 	p, err := StartMultipleServersCluster()
 	c.Assert(err, check.IsNil)
-	err = p.Cluster().PullImage(docker.PullImageOptions{Repository: "tsuru/bs"}, dockercommon.RegistryAuthConfig())
+	opts := docker.PullImageOptions{Repository: "tsuru/bs"}
+	err = p.Cluster().PullImage(opts, dockercommon.RegistryAuthConfig(opts.Repository))
 	c.Assert(err, check.IsNil)
 	nodes, err := p.Cluster().Nodes()
 	c.Assert(err, check.IsNil)
@@ -87,7 +88,8 @@ func (s *S) TestDestroy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	p.Destroy()
 	c.Assert(p.servers, check.IsNil)
-	err = p.Cluster().PullImage(docker.PullImageOptions{Repository: "tsuru/bs"}, dockercommon.RegistryAuthConfig())
+	opts := docker.PullImageOptions{Repository: "tsuru/bs"}
+	err = p.Cluster().PullImage(opts, dockercommon.RegistryAuthConfig(opts.Repository))
 	c.Assert(err, check.NotNil)
 	e, ok := err.(cluster.DockerNodeError)
 	c.Assert(ok, check.Equals, true)

--- a/provision/docker/image.go
+++ b/provision/docker/image.go
@@ -53,7 +53,7 @@ func MigrateImages() error {
 				Name:              newImage,
 				InactivityTimeout: net.StreamInactivityTimeout,
 			}
-			err = dcluster.PushImage(pushOpts, dockercommon.RegistryAuthConfig())
+			err = dcluster.PushImage(pushOpts, dockercommon.RegistryAuthConfig(newImage))
 			if err != nil {
 				return err
 			}

--- a/provision/docker/nodecontainer/nodecontainer.go
+++ b/provision/docker/nodecontainer/nodecontainer.go
@@ -202,7 +202,7 @@ func pullWithRetry(client *docker.Client, p DockerProvisioner, image string, max
 	var buf bytes.Buffer
 	var err error
 	pullOpts := docker.PullImageOptions{Repository: image, OutputStream: &buf, InactivityTimeout: net.StreamInactivityTimeout}
-	registryAuth := dockercommon.RegistryAuthConfig()
+	registryAuth := dockercommon.RegistryAuthConfig(image)
 	for ; maxTries > 0; maxTries-- {
 		err = client.PullImage(pullOpts, registryAuth)
 		if err == nil {

--- a/provision/docker/provisioner_test.go
+++ b/provision/docker/provisioner_test.go
@@ -292,7 +292,7 @@ func (s *S) TestDeploy(c *check.C) {
 		Repository: s.team.Name + "/app-" + a.Name,
 		Tag:        "v1-builder",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	imgID, err := s.p.Deploy(&a, builderImgID, evt)
 	c.Assert(err, check.IsNil)
@@ -354,7 +354,7 @@ func (s *S) TestDeployWithLimiterActive(c *check.C) {
 		Repository: "tsuru/app-" + a.Name,
 		Tag:        "v1-builder",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	_, err = s.p.Deploy(&a, builderImgID, evt)
 	c.Assert(err, check.IsNil)
@@ -410,7 +410,7 @@ func (s *S) TestDeployWithLimiterGlobalActive(c *check.C) {
 		Repository: "tsuru/app-" + a.Name,
 		Tag:        "v1-builder",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	imgID, err := s.p.Deploy(&a, builderImgID, evt)
 	c.Assert(err, check.IsNil)
@@ -464,7 +464,7 @@ func (s *S) TestDeployQuotaExceeded(c *check.C) {
 		Repository: "tsuru/app-" + a.Name,
 		Tag:        "v1-builder",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	_, err = s.p.Deploy(&a, builderImgID, evt)
 	c.Assert(err, check.NotNil)
@@ -499,7 +499,7 @@ func (s *S) TestDeployCanceledEvent(c *check.C) {
 		Repository: "tsuru/app-" + app.GetName(),
 		Tag:        "v1-builder",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	done := make(chan bool)
 	go func() {
@@ -727,7 +727,7 @@ func (s *S) TestDeployImageID(c *check.C) {
 		Repository: "tsuru/app-" + a.Name,
 		Tag:        "v1",
 	}
-	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig())
+	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(pullOpts.Repository))
 	c.Assert(err, check.IsNil)
 	_, err = s.p.Deploy(&a, builderImgID, evt)
 	c.Assert(err, check.IsNil)

--- a/provision/swarm/docker.go
+++ b/provision/swarm/docker.go
@@ -203,7 +203,7 @@ func commitPushBuildImage(client *docker.Client, img, contID string, app provisi
 		}
 	}
 	for _, tag := range tags {
-		err = dockercommon.PushImage(client, repository, tag, dockercommon.RegistryAuthConfig())
+		err = dockercommon.PushImage(client, repository, tag, dockercommon.RegistryAuthConfig(repository))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Also image pull calls for node-containers and app-run --isolated were
missing pull auth parameters.