### PR TITLE
provision: ensure node removal removes healer data for node

### DIFF
--- a/provision/docker/scheduler.go
+++ b/provision/docker/scheduler.go
@@ -19,8 +19,8 @@ import (
 	"github.com/tsuru/tsuru/autoscale"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/net"
-	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/docker/container"
+	"github.com/tsuru/tsuru/provision/node"
 )
 
 type segregatedScheduler struct {
@@ -328,7 +328,7 @@ func appGroupCount(hostGroups map[string]int, appCountHost map[string]int) map[s
 // (good to remove a container) value for the pair [(number of containers for
 // app-process), (number of containers in host)]
 func (s *segregatedScheduler) minMaxNodes(nodes []cluster.Node, appName, process string) (string, string, error) {
-	nodesList := make(provision.NodeList, len(nodes))
+	nodesList := make(node.NodeList, len(nodes))
 	for i := range nodes {
 		nodesList[i] = &clusterNodeWrapper{Node: &nodes[i], prov: s.provisioner}
 	}

--- a/provision/env_test.go
+++ b/provision/env_test.go
@@ -12,6 +12,10 @@ import (
 	"gopkg.in/check.v1"
 )
 
+type S struct{}
+
+var _ = check.Suite(&S{})
+
 func (s *S) TestWebProcessDefaultPort(c *check.C) {
 	port := provision.WebProcessDefaultPort()
 	c.Assert(port, check.Equals, "8888")

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -21,6 +21,7 @@ import (
 	tsuruNet "github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/cluster"
+	"github.com/tsuru/tsuru/provision/node"
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	"github.com/tsuru/tsuru/set"
 	apiv1 "k8s.io/api/core/v1"
@@ -639,7 +640,7 @@ func (p *kubernetesProvisioner) RemoveNode(opts provision.RemoveNodeOptions) err
 }
 
 func (p *kubernetesProvisioner) NodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, error) {
-	return provision.FindNodeByAddrs(p, nodeData.Addrs)
+	return node.FindNodeByAddrs(p, nodeData.Addrs)
 }
 
 func (p *kubernetesProvisioner) findNodeByAddress(address string) (*ClusterClient, *kubernetesNodeWrapper, error) {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -25,6 +25,10 @@ import (
 const (
 	defaultDockerProvisioner = "docker"
 	DefaultHealthcheckScheme = "http"
+
+	PoolMetadataName   = "pool"
+	IaaSIDMetadataName = "iaas-id"
+	IaaSMetadataName   = "iaas"
 )
 
 var (

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -570,7 +570,25 @@ func (p *FakeProvisioner) ListNodes(addressFilter []string) ([]provision.Node, e
 }
 
 func (p *FakeProvisioner) NodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, error) {
-	return provision.FindNodeByAddrs(p, nodeData.Addrs)
+	nodeAddrMap := map[string]provision.Node{}
+	for addr, n := range p.nodes {
+		n := n
+		nodeAddrMap[net.URLToHost(addr)] = &n
+	}
+	var node provision.Node
+	for _, addr := range nodeData.Addrs {
+		n := nodeAddrMap[net.URLToHost(addr)]
+		if n != nil {
+			if node != nil {
+				return nil, errors.Errorf("addrs match multiple nodes: %v", nodeData.Addrs)
+			}
+			node = n
+		}
+	}
+	if node == nil {
+		return nil, provision.ErrNodeNotFound
+	}
+	return node, nil
 }
 
 func (p *FakeProvisioner) RebalanceNodes(opts provision.RebalanceNodesOptions) (bool, error) {

--- a/provision/swarm/provisioner.go
+++ b/provision/swarm/provisioner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/cluster"
 	"github.com/tsuru/tsuru/provision/dockercommon"
+	"github.com/tsuru/tsuru/provision/node"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/servicecommon"
 )
@@ -506,7 +507,7 @@ func (p *swarmProvisioner) NodeForNodeData(nodeData provision.NodeStatusData) (p
 			return &swarmNodeWrapper{Node: node, provisioner: p, client: client}, nil
 		}
 	}
-	return provision.FindNodeByAddrs(p, nodeData.Addrs)
+	return node.FindNodeByAddrs(p, nodeData.Addrs)
 }
 
 func (p *swarmProvisioner) AddNode(opts provision.AddNodeOptions) error {


### PR DESCRIPTION
This PR moves existing node logic from the provision pkg to a newly created node pkg. Now, instead of handling healer data removal from inside the provisioner this logic was added to a RemoveNode method in the node pkg.