### PR TITLE
provision/kubernetes,cmd: adds migration for kubernetes apps

### DIFF
--- a/cmd/tsurud/migrate.go
+++ b/cmd/tsurud/migrate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/docker"
 	"github.com/tsuru/tsuru/provision/docker/healer"
+	kubeMigrate "github.com/tsuru/tsuru/provision/kubernetes/migrate"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/router"
@@ -90,6 +91,10 @@ func init() {
 		log.Fatalf("unable to register migration: %s", err)
 	}
 	err = migration.RegisterOptional("migrate-roles", migrateRoles)
+	if err != nil {
+		log.Fatalf("unable to register migration: %s", err)
+	}
+	err = migration.Register("migrate-apps-kubernetes-crd", kubeMigrate.MigrateAppsCRDs)
 	if err != nil {
 		log.Fatalf("unable to register migration: %s", err)
 	}

--- a/provision/kubernetes/migrate/migrate.go
+++ b/provision/kubernetes/migrate/migrate.go
@@ -1,0 +1,38 @@
+package migrate
+
+import (
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/app"
+	tsuruerrors "github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/provision/kubernetes"
+	"github.com/tsuru/tsuru/provision/pool"
+)
+
+// MigrateAppsCRDs creates the necessary CRDs for every application
+// on a Kubernetes cluster. This is done by re-provisioning the App
+// on the cluster.
+func MigrateAppsCRDs() error {
+	prov := kubernetes.GetProvisioner()
+	pools, err := pool.ListAllPools()
+	if err != nil {
+		return errors.Wrap(err, "failed to list pools")
+	}
+	var kubePools []string
+	for _, p := range pools {
+		if p.Provisioner == prov.GetName() {
+			kubePools = append(kubePools, p.Name)
+		}
+	}
+	apps, err := app.List(&app.Filter{Pools: kubePools})
+	if err != nil {
+		return errors.Wrap(err, "failed to list apps")
+	}
+	multiErr := tsuruerrors.NewMultiError()
+	for _, a := range apps {
+		errProv := prov.Provision(&a)
+		if errProv != nil {
+			multiErr.Add(errProv)
+		}
+	}
+	return multiErr.ToError()
+}

--- a/provision/kubernetes/migrate/migrate_test.go
+++ b/provision/kubernetes/migrate/migrate_test.go
@@ -1,0 +1,121 @@
+package migrate
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/tsuru/tsuru/servicemanager"
+	apptypes "github.com/tsuru/tsuru/types/app"
+
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/provision/cluster"
+	kubeProv "github.com/tsuru/tsuru/provision/kubernetes"
+	tsuruv1clientset "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned"
+	faketsuru "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned/fake"
+	kubeTesting "github.com/tsuru/tsuru/provision/kubernetes/testing"
+	"github.com/tsuru/tsuru/provision/pool"
+	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/check.v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+type S struct {
+	conn          *db.Storage
+	clusterClient *kubeProv.ClusterClient
+	client        *kubeTesting.ClientWrapper
+}
+
+var _ = check.Suite(&S{})
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (s *S) SetUpSuite(c *check.C) {
+	config.Set("auth:hash-cost", bcrypt.MinCost)
+	config.Set("database:driver", "mongodb")
+	config.Set("database:url", "127.0.0.1:27017")
+	config.Set("database:name", "kubernetes_migrate_tests_s")
+	var err error
+	s.conn, err = db.Conn()
+	c.Assert(err, check.IsNil)
+	err = dbtest.ClearAllCollections(s.conn.Apps().Database)
+	c.Assert(err, check.IsNil)
+	servicemanager.Cache = &apptypes.MockCacheService{}
+	clus := &cluster.Cluster{
+		Name:        "c1",
+		Addresses:   []string{"https://clusteraddr"},
+		Provisioner: "kubernetes",
+		Pools:       []string{"kube"},
+	}
+	err = clus.Save()
+	c.Assert(err, check.IsNil)
+	s.clusterClient, err = kubeProv.NewClusterClient(clus)
+	c.Assert(err, check.IsNil)
+	s.client = &kubeTesting.ClientWrapper{
+		Clientset:              fake.NewSimpleClientset(),
+		ClusterInterface:       s.clusterClient,
+		ApiExtensionsClientset: fakeapiextensions.NewSimpleClientset(),
+		TsuruClientset:         faketsuru.NewSimpleClientset(),
+	}
+	s.clusterClient.Interface = s.client
+	kubeProv.ClientForConfig = func(conf *rest.Config) (kubernetes.Interface, error) {
+		return s.client, nil
+	}
+	kubeProv.TsuruClientForConfig = func(conf *rest.Config) (tsuruv1clientset.Interface, error) {
+		return s.client.TsuruClientset, nil
+	}
+	once := sync.Once{}
+	kubeProv.ExtensionsClientForConfig = func(conf *rest.Config) (apiextensionsclientset.Interface, error) {
+		once.Do(func() {
+			mock := kubeTesting.NewKubeMock(s.client, kubeProv.GetProvisioner())
+			s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", mock.CRDReaction(c))
+		})
+		return s.client.ApiExtensionsClientset, nil
+	}
+}
+
+func (s *S) TearDownSuite(c *check.C) {
+	s.conn.Close()
+}
+
+func (s *S) TestMigrateAppsCRDs(c *check.C) {
+	err := pool.AddPool(pool.AddPoolOptions{
+		Name:        "kube",
+		Provisioner: "kubernetes",
+	})
+	c.Assert(err, check.IsNil)
+	err = pool.AddPool(pool.AddPoolOptions{
+		Name:        "kube-failed",
+		Provisioner: "kubernetes",
+	})
+	c.Assert(err, check.IsNil)
+	err = pool.AddPool(pool.AddPoolOptions{
+		Name:        "docker",
+		Provisioner: "docker",
+	})
+	c.Assert(err, check.IsNil)
+	apps := []app.App{
+		{Name: "app-kube", Pool: "kube"},
+		{Name: "app-kube2", Pool: "kube"},
+		{Name: "app-kube-failed", Pool: "kube-failed"},
+		{Name: "app-docker", Pool: "docker"},
+	}
+	for _, a := range apps {
+		err = s.conn.Apps().Insert(a)
+		c.Assert(err, check.IsNil)
+	}
+	err = MigrateAppsCRDs()
+	c.Assert(err, check.ErrorMatches, `.*no cluster.*`)
+	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(len(appList.Items), check.Equals, 2)
+	c.Assert(appList.Items[0].Name, check.Equals, "app-kube")
+	c.Assert(appList.Items[1].Name, check.Equals, "app-kube2")
+}

--- a/provision/kubernetes/migrate/migrate_test.go
+++ b/provision/kubernetes/migrate/migrate_test.go
@@ -1,22 +1,27 @@
 package migrate
 
 import (
-	"sync"
 	"testing"
-
-	"github.com/tsuru/tsuru/servicemanager"
-	apptypes "github.com/tsuru/tsuru/types/app"
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/app/image"
+	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/auth/native"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision/cluster"
 	kubeProv "github.com/tsuru/tsuru/provision/kubernetes"
+	tsuruv1 "github.com/tsuru/tsuru/provision/kubernetes/pkg/apis/tsuru/v1"
 	tsuruv1clientset "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned"
 	faketsuru "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned/fake"
 	kubeTesting "github.com/tsuru/tsuru/provision/kubernetes/testing"
 	"github.com/tsuru/tsuru/provision/pool"
+	"github.com/tsuru/tsuru/servicemanager"
+	apptypes "github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/quota"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/check.v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -31,6 +36,7 @@ type S struct {
 	conn          *db.Storage
 	clusterClient *kubeProv.ClusterClient
 	client        *kubeTesting.ClientWrapper
+	mock          *kubeTesting.KubeMock
 }
 
 var _ = check.Suite(&S{})
@@ -42,6 +48,8 @@ func (s *S) SetUpSuite(c *check.C) {
 	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017")
 	config.Set("database:name", "kubernetes_migrate_tests_s")
+	config.Set("routers:fake:type", "fake")
+	config.Set("routers:fake:default", true)
 	var err error
 	s.conn, err = db.Conn()
 	c.Assert(err, check.IsNil)
@@ -52,7 +60,7 @@ func (s *S) SetUpSuite(c *check.C) {
 		Name:        "c1",
 		Addresses:   []string{"https://clusteraddr"},
 		Provisioner: "kubernetes",
-		Pools:       []string{"kube"},
+		Pools:       []string{"kube", "test-default"},
 	}
 	err = clus.Save()
 	c.Assert(err, check.IsNil)
@@ -71,22 +79,17 @@ func (s *S) SetUpSuite(c *check.C) {
 	kubeProv.TsuruClientForConfig = func(conf *rest.Config) (tsuruv1clientset.Interface, error) {
 		return s.client.TsuruClientset, nil
 	}
-	once := sync.Once{}
+	s.mock = kubeTesting.NewKubeMock(s.client, kubeProv.GetProvisioner())
+	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))
 	kubeProv.ExtensionsClientForConfig = func(conf *rest.Config) (apiextensionsclientset.Interface, error) {
-		once.Do(func() {
-			mock := kubeTesting.NewKubeMock(s.client, kubeProv.GetProvisioner())
-			s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", mock.CRDReaction(c))
-		})
 		return s.client.ApiExtensionsClientset, nil
 	}
-}
-
-func (s *S) TearDownSuite(c *check.C) {
-	s.conn.Close()
-}
-
-func (s *S) TestMigrateAppsCRDs(c *check.C) {
-	err := pool.AddPool(pool.AddPoolOptions{
+	err = pool.AddPool(pool.AddPoolOptions{
+		Name:        "test-default",
+		Provisioner: "kubernetes",
+	})
+	c.Assert(err, check.IsNil)
+	err = pool.AddPool(pool.AddPoolOptions{
 		Name:        "kube",
 		Provisioner: "kubernetes",
 	})
@@ -101,6 +104,24 @@ func (s *S) TestMigrateAppsCRDs(c *check.C) {
 		Provisioner: "docker",
 	})
 	c.Assert(err, check.IsNil)
+}
+
+func (s *S) SetUpTest(c *check.C) {
+	err := s.conn.Apps().DropCollection()
+	c.Assert(err, check.IsNil)
+	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	for _, a := range appList.Items {
+		err = s.client.TsuruV1().Apps("default").Delete(a.GetName(), &metav1.DeleteOptions{})
+		c.Assert(err, check.IsNil)
+	}
+}
+
+func (s *S) TearDownSuite(c *check.C) {
+	s.conn.Close()
+}
+
+func (s *S) TestMigrateAppsCRDs(c *check.C) {
 	apps := []app.App{
 		{Name: "app-kube", Pool: "kube"},
 		{Name: "app-kube2", Pool: "kube"},
@@ -108,14 +129,59 @@ func (s *S) TestMigrateAppsCRDs(c *check.C) {
 		{Name: "app-docker", Pool: "docker"},
 	}
 	for _, a := range apps {
-		err = s.conn.Apps().Insert(a)
+		err := s.conn.Apps().Insert(a)
 		c.Assert(err, check.IsNil)
 	}
-	err = MigrateAppsCRDs()
-	c.Assert(err, check.ErrorMatches, `.*no cluster.*`)
+	err := MigrateAppsCRDs()
+	c.Assert(err, check.NotNil)
 	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 2)
 	c.Assert(appList.Items[0].Name, check.Equals, "app-kube")
 	c.Assert(appList.Items[1].Name, check.Equals, "app-kube2")
+}
+
+func (s *S) TestMigrateAppsCRDsDeployedApp(c *check.C) {
+	a, _, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	err := s.conn.Apps().Insert(app.App{Name: a.GetName(), Pool: a.GetPool()})
+	c.Assert(err, check.IsNil)
+	nativeScheme := auth.ManagedScheme(native.NativeScheme{})
+	app.AuthScheme = nativeScheme
+	u := &auth.User{Email: "whiskeyjack@genabackis.com", Password: "123456", Quota: quota.UnlimitedQuota}
+	_, err = nativeScheme.Create(u)
+	c.Assert(err, check.IsNil)
+	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
+	c.Assert(err, check.IsNil)
+	evt, err := event.New(&event.Opts{
+		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		Kind:    permission.PermAppDeploy,
+		Owner:   token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	c.Assert(err, check.IsNil)
+	customData := map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "run mycmd arg1",
+		},
+	}
+	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
+	c.Assert(err, check.IsNil)
+	_, err = kubeProv.GetProvisioner().Deploy(a, "tsuru/app-myapp:v1", evt)
+	c.Assert(err, check.IsNil)
+	err = s.client.TsuruV1().Apps("default").Delete(a.GetName(), &metav1.DeleteOptions{})
+	c.Assert(err, check.IsNil)
+	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(len(appList.Items), check.Equals, 0)
+	err = MigrateAppsCRDs()
+	c.Assert(err, check.IsNil)
+	appList, err = s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(len(appList.Items), check.Equals, 1)
+	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
+		NamespaceName: "default",
+		Deployments:   []string{"myapp-web"},
+		Services:      []string{"myapp-web", "myapp-web-units"},
+	})
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -145,7 +145,7 @@ func (p *kubernetesProvisioner) Provision(a provision.App) error {
 	if err != nil {
 		return err
 	}
-	return ensureAppCustomResource(client, a)
+	return ensureAppCustomResourceSynced(client, a)
 }
 
 func (p *kubernetesProvisioner) Destroy(a provision.App) error {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -61,7 +61,7 @@ func (s *S) TestListNodesFilteringByAddress(c *check.C) {
 }
 
 func (s *S) TestListNodesTimeoutShort(c *check.C) {
-	wantedTimeout := 0.1
+	wantedTimeout := 1.0
 	config.Set("kubernetes:api-short-timeout", wantedTimeout)
 	defer config.Unset("kubernetes")
 	block := make(chan bool)
@@ -69,12 +69,12 @@ func (s *S) TestListNodesTimeoutShort(c *check.C) {
 		<-block
 	}))
 	defer func() { close(block); blackhole.Close() }()
-	ClientForConfig = defaultClientForConfig
 	s.mock.MockfakeNodes(c, blackhole.URL)
 	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err := app.CreateApp(a, s.user)
 	c.Assert(err, check.IsNil)
 	t0 := time.Now()
+	ClientForConfig = defaultClientForConfig
 	_, err = s.p.ListNodes([]string{})
 	c.Assert(err, check.ErrorMatches, `(?i).*timeout.*`)
 	c.Assert(time.Since(t0) < time.Duration(wantedTimeout*float64(3*time.Second)), check.Equals, true)
@@ -692,7 +692,7 @@ func (s *S) TestUnitsNoApps(c *check.C) {
 }
 
 func (s *S) TestUnitsTimeoutShort(c *check.C) {
-	wantedTimeout := 0.1
+	wantedTimeout := 1.0
 	config.Set("kubernetes:api-short-timeout", wantedTimeout)
 	defer config.Unset("kubernetes")
 	block := make(chan bool)
@@ -709,12 +709,12 @@ func (s *S) TestUnitsTimeoutShort(c *check.C) {
 		}
 	}))
 	defer func() { close(block); blackhole.Close() }()
-	ClientForConfig = defaultClientForConfig
 	s.mock.MockfakeNodes(c, blackhole.URL)
 	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err := app.CreateApp(a, s.user)
 	c.Assert(err, check.IsNil)
 	t0 := time.Now()
+	ClientForConfig = defaultClientForConfig
 	_, err = s.p.Units(a)
 	c.Assert(err, check.ErrorMatches, `(?i).*timeout.*`)
 	c.Assert(time.Since(t0) < time.Duration(wantedTimeout*float64(3*time.Second)), check.Equals, true)


### PR DESCRIPTION
This commit adds a required migration that is responsible for
ensuring that every kubernetes application has a corresponding
app CRD created on the cluster. This is done by calling the
provision.Provision method on the app.