### PR TITLE
provision/kubernetes: support app pool update with multiple namespaces

### DIFF
--- a/app/actions.go
+++ b/app/actions.go
@@ -542,7 +542,21 @@ var updateAppProvisioner = action.Action{
 		}
 		return nil, nil
 	},
-	//TODO: add Backwards
+	Backward: func(ctx action.BWContext) {
+		app := ctx.Params[0].(*App)
+		oldApp := ctx.Params[1].(*App)
+		newProv, err := app.getProvisioner()
+		if err != nil {
+			log.Errorf("BACKWARDS update-app-provisioner - failed to get app provisioner: %v", err)
+			return
+		}
+		w := ctx.Params[2].(io.Writer)
+		if upProv, ok := newProv.(provision.UpdatableProvisioner); ok {
+			if err := upProv.UpdateApp(app, oldApp, w); err != nil {
+				log.Errorf("BACKWARDS update-app-provisioner - failed to update app back to previous state: %v", err)
+			}
+		}
+	},
 }
 
 var validateNewCNames = action.Action{

--- a/app/actions.go
+++ b/app/actions.go
@@ -542,6 +542,7 @@ var updateAppProvisioner = action.Action{
 		}
 		return nil, nil
 	},
+	//TODO: add Backwards
 }
 
 var validateNewCNames = action.Action{

--- a/app/actions.go
+++ b/app/actions.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 
+	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/servicemanager"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/quota"
@@ -517,6 +518,29 @@ var destroyAppOldProvisioner = action.Action{
 			return nil, err
 		}
 		return nil, oldProv.Destroy(oldApp)
+	},
+}
+
+var updateAppProvisioner = action.Action{
+	Name: "update-app-provisioner",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		app, ok := ctx.Params[0].(*App)
+		if !ok {
+			return nil, errors.New("expected app ptr as first arg")
+		}
+		oldApp, ok := ctx.Params[1].(*App)
+		if !ok {
+			return nil, errors.New("expected app ptr as second arg")
+		}
+		oldProv, err := oldApp.getProvisioner()
+		if err != nil {
+			return nil, err
+		}
+		w, _ := ctx.Params[2].(io.Writer)
+		if upProv, ok := oldProv.(provision.UpdatableProvisioner); ok {
+			return nil, upProv.UpdateApp(oldApp, app, w)
+		}
+		return nil, nil
 	},
 }
 

--- a/app/actions_test.go
+++ b/app/actions_test.go
@@ -682,14 +682,16 @@ func (s *S) TestUpdateAppProvisionerBackward(c *check.C) {
 	})
 	opts := pool.AddPoolOptions{Name: "test", Provisioner: "fake1", Public: true}
 	err := pool.AddPool(opts)
+	c.Assert(err, check.IsNil)
 	app := App{Name: "myapp", Platform: "django", Pool: "test", TeamOwner: s.team.Name}
 	err = CreateApp(&app, s.user)
-	newApp := App{Name: "myapp", Platform: "python", Pool: "test", TeamOwner: s.team.Name}
 	c.Assert(err, check.IsNil)
+	newApp := App{Name: "myapp", Platform: "python", Pool: "test", TeamOwner: s.team.Name}
 	err = app.AddUnits(1, "web", nil)
 	c.Assert(err, check.IsNil)
 	fwctx := action.FWContext{Params: []interface{}{&newApp, &app, ioutil.Discard}}
 	_, err = updateAppProvisioner.Forward(fwctx)
+	c.Assert(err, check.IsNil)
 	units, err := app.Units()
 	c.Assert(err, check.IsNil)
 	provApp, err := p1.GetAppFromUnitID(units[0].ID)

--- a/app/actions_test.go
+++ b/app/actions_test.go
@@ -5,12 +5,17 @@
 package app
 
 import (
+	"io/ioutil"
+
 	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/pool"
+	"github.com/tsuru/tsuru/provision/provisiontest"
 	"github.com/tsuru/tsuru/repository"
 	"github.com/tsuru/tsuru/router/routertest"
 	appTypes "github.com/tsuru/tsuru/types/app"
@@ -667,4 +672,34 @@ func (s *S) TestAddRouterBackendBackward(c *check.C) {
 
 func (s *S) TestAddRouterBackendMinParams(c *check.C) {
 	c.Assert(addRouterBackend.MinParams, check.Equals, 1)
+}
+
+func (s *S) TestUpdateAppProvisionerBackward(c *check.C) {
+	p1 := provisiontest.NewFakeProvisioner()
+	p1.Name = "fake1"
+	provision.Register("fake1", func() (provision.Provisioner, error) {
+		return p1, nil
+	})
+	opts := pool.AddPoolOptions{Name: "test", Provisioner: "fake1", Public: true}
+	err := pool.AddPool(opts)
+	app := App{Name: "myapp", Platform: "django", Pool: "test", TeamOwner: s.team.Name}
+	err = CreateApp(&app, s.user)
+	newApp := App{Name: "myapp", Platform: "python", Pool: "test", TeamOwner: s.team.Name}
+	c.Assert(err, check.IsNil)
+	err = app.AddUnits(1, "web", nil)
+	c.Assert(err, check.IsNil)
+	fwctx := action.FWContext{Params: []interface{}{&newApp, &app, ioutil.Discard}}
+	_, err = updateAppProvisioner.Forward(fwctx)
+	units, err := app.Units()
+	c.Assert(err, check.IsNil)
+	provApp, err := p1.GetAppFromUnitID(units[0].ID)
+	c.Assert(err, check.IsNil)
+	c.Assert(provApp.GetPlatform(), check.Equals, "python")
+	bwctx := action.BWContext{Params: []interface{}{&newApp, &app, ioutil.Discard}}
+	updateAppProvisioner.Backward(bwctx)
+	units, err = app.Units()
+	c.Assert(err, check.IsNil)
+	provApp, err = p1.GetAppFromUnitID(units[0].ID)
+	c.Assert(err, check.IsNil)
+	c.Assert(provApp.GetPlatform(), check.Equals, "django")
 }

--- a/app/app.go
+++ b/app/app.go
@@ -530,6 +530,9 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 	actions := []*action.Action{
 		&saveApp,
 	}
+	if newProv.GetName() == oldProv.GetName() {
+		actions = append(actions, &updateAppProvisioner)
+	}
 	if newProv.GetName() != oldProv.GetName() {
 		actions = append(actions,
 			&provisionAppNewProvisioner,

--- a/builder/kubernetes/suite_test.go
+++ b/builder/kubernetes/suite_test.go
@@ -110,6 +110,7 @@ func (s *S) SetUpTest(c *check.C) {
 	kubeProv.ExtensionsClientForConfig = func(conf *rest.Config) (apiextensionsclientset.Interface, error) {
 		return s.client.ApiExtensionsClientset, nil
 	}
+	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))
 	routertest.FakeRouter.Reset()
 	rand.Seed(0)
 	err = pool.AddPool(pool.AddPoolOptions{

--- a/etc/tsuru-compose.conf
+++ b/etc/tsuru-compose.conf
@@ -46,8 +46,9 @@ log:
 kubernetes:
   deploy-sidecar-image: tsuru/deploy-agent:latest
   deploy-inspect-image: tsuru/deploy-agent:latest
+  use-pool-namespaces: true
 volume-plans:
   minikube:
     kubernetes:
       storage-class: standard
-  use-pool-namespaces: true
+debug: true

--- a/provision/kubernetes/actions.go
+++ b/provision/kubernetes/actions.go
@@ -1,4 +1,4 @@
-// Copyright 2013 tsuru authors. All rights reserved.
+// Copyright 2018 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/provision/kubernetes/actions.go
+++ b/provision/kubernetes/actions.go
@@ -1,0 +1,137 @@
+// Copyright 2013 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kubernetes
+
+import (
+	"io"
+
+	"github.com/tsuru/tsuru/action"
+	"github.com/tsuru/tsuru/log"
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/router/rebuild"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type updatePipelineParams struct {
+	p   *kubernetesProvisioner
+	new provision.App
+	old provision.App
+	w   io.Writer
+}
+
+var provisionNewApp = action.Action{
+	Name: "provision-new-app",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		return nil, params.p.Provision(params.new)
+	},
+	Backward: func(ctx action.BWContext) {
+		params := ctx.Params[0].(updatePipelineParams)
+		if err := params.p.Destroy(params.new); err != nil {
+			log.Errorf("failed to destroy new app: %v", err)
+		}
+	},
+}
+
+var restartApp = action.Action{
+	Name: "restart-new-app",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		return nil, params.p.Restart(params.new, "", params.w)
+	},
+	Backward: func(ctx action.BWContext) {
+	},
+}
+
+var rebuildAppRoutes = action.Action{
+	Name: "rebuild-routes-app",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		rebuild.RoutesRebuildOrEnqueue(params.new.GetName())
+		return nil, nil
+	},
+	Backward: func(ctx action.BWContext) {
+		params := ctx.Params[0].(updatePipelineParams)
+		rebuild.RoutesRebuildOrEnqueue(params.old.GetName())
+	},
+}
+
+var destroyOldApp = action.Action{
+	Name: "destroy-old-app",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		return nil, params.p.Destroy(params.old)
+	},
+	Backward: func(ctx action.BWContext) {
+	},
+}
+
+var updateAppCR = action.Action{
+	Name: "update-app-custom-resource",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		client, err := clusterForPool(params.old.GetPool())
+		if err != nil {
+			return nil, err
+		}
+		tclient, err := TsuruClientForConfig(client.restConfig)
+		if err != nil {
+			return nil, err
+		}
+		oldAppCR, err := tclient.TsuruV1().Apps(client.Namespace()).Get(params.old.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		oldAppCR.Spec.NamespaceName = client.PoolNamespace(params.new.GetPool())
+		_, err = tclient.TsuruV1().Apps(client.Namespace()).Update(oldAppCR)
+		return nil, err
+	},
+	Backward: func(ctx action.BWContext) {
+		params := ctx.Params[0].(updatePipelineParams)
+		client, err := clusterForPool(params.old.GetPool())
+		if err != nil {
+			log.Errorf("failed to get client for pool: %v", err)
+			return
+		}
+		tclient, err := TsuruClientForConfig(client.restConfig)
+		if err != nil {
+			log.Errorf("failed to get tclient for pool: %v", err)
+			return
+		}
+		oldAppCR, err := tclient.TsuruV1().Apps(client.Namespace()).Get(params.old.GetName(), metav1.GetOptions{})
+		if err != nil {
+			log.Errorf("failed to get cr for app: %v", err)
+			return
+		}
+		oldAppCR.Spec.NamespaceName = client.PoolNamespace(params.old.GetPool())
+		_, err = tclient.TsuruV1().Apps(client.Namespace()).Update(oldAppCR)
+		if err != nil {
+			log.Errorf("failed to update app cr: %v", err)
+		}
+	},
+}
+
+var removeOldAppResources = action.Action{
+	Name: "remove-old-app-resources",
+	Forward: func(ctx action.FWContext) (action.Result, error) {
+		params := ctx.Params[0].(updatePipelineParams)
+		client, err := clusterForPool(params.old.GetPool())
+		if err != nil {
+			return nil, err
+		}
+		tclient, err := TsuruClientForConfig(client.restConfig)
+		if err != nil {
+			return nil, err
+		}
+		oldAppCR, err := tclient.TsuruV1().Apps(client.Namespace()).Get(params.old.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		oldAppCR.Spec.NamespaceName = client.PoolNamespace(params.old.GetPool())
+		return nil, params.p.removeResources(client, oldAppCR)
+	},
+	Backward: func(ctx action.BWContext) {
+	},
+}

--- a/provision/kubernetes/builder.go
+++ b/provision/kubernetes/builder.go
@@ -35,7 +35,11 @@ func (c *KubeClient) BuildPod(a provision.App, evt *event.Event, archiveFile io.
 	if err != nil {
 		return "", err
 	}
-	defer cleanupPod(client, buildPodName, client.AppNamespace(a))
+	ns, err := client.AppNamespace(a)
+	if err != nil {
+		return "", err
+	}
+	defer cleanupPod(client, buildPodName, ns)
 	params := createPodParams{
 		app:               a,
 		client:            client,

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -142,11 +142,15 @@ func (c *ClusterClient) SetTimeout(timeout time.Duration) error {
 }
 
 func (c *ClusterClient) AppNamespace(app provision.App) (string, error) {
+	return c.appNamespaceByName(app.GetName())
+}
+
+func (c *ClusterClient) appNamespaceByName(appName string) (string, error) {
 	tclient, err := TsuruClientForConfig(c.restConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to get client for crd: %v", err)
 	}
-	a, err := tclient.TsuruV1().Apps(c.Namespace()).Get(app.GetName(), metav1.GetOptions{})
+	a, err := tclient.TsuruV1().Apps(c.Namespace()).Get(appName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get app custom resource: %v", err)
 	}

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -148,11 +148,11 @@ func (c *ClusterClient) AppNamespace(app provision.App) (string, error) {
 func (c *ClusterClient) appNamespaceByName(appName string) (string, error) {
 	tclient, err := TsuruClientForConfig(c.restConfig)
 	if err != nil {
-		return "", fmt.Errorf("failed to get client for crd: %v", err)
+		return "", errors.Wrap(err, "failed to get client for crd")
 	}
 	a, err := tclient.TsuruV1().Apps(c.Namespace()).Get(appName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to get app custom resource: %v", err)
+		return "", errors.Wrap(err, "failed to get app custom resource")
 	}
 	return a.Spec.NamespaceName, nil
 }

--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -157,15 +157,15 @@ func (s *S) TestClusterNamespace(c *check.C) {
 	c1 := cluster.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": "x"}}
 	client, err := NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "x")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "x")
 	c1 = cluster.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": ""}}
 	client, err = NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "default")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "default")
 	c1 = cluster.Cluster{Addresses: []string{"addr1"}}
 	client, err = NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "default")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "default")
 }
 
 func (s *S) TestClusterNamespacePerPool(c *check.C) {
@@ -174,17 +174,17 @@ func (s *S) TestClusterNamespacePerPool(c *check.C) {
 	c1 := cluster.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": "x"}}
 	client, err := NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "x-mypool")
-	c.Assert(client.Namespace(""), check.Equals, "x")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "x-mypool")
+	c.Assert(client.PoolNamespace(""), check.Equals, "x")
 	c1 = cluster.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": ""}}
 	client, err = NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "tsuru-mypool")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "tsuru-mypool")
 	c1 = cluster.Cluster{Addresses: []string{"addr1"}}
 	client, err = NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.Namespace("mypool"), check.Equals, "tsuru-mypool")
-	c.Assert(client.Namespace(""), check.Equals, "tsuru")
+	c.Assert(client.PoolNamespace("mypool"), check.Equals, "tsuru-mypool")
+	c.Assert(client.PoolNamespace(""), check.Equals, "tsuru")
 }
 
 func (s *S) TestClusterOvercommitFactor(c *check.C) {

--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -150,7 +150,11 @@ func (s *S) TestClusterAppNamespace(c *check.C) {
 	client, err := NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
 	a := provisiontest.NewFakeApp("myapp", "python", 0)
-	c.Assert(client.AppNamespace(a), check.Equals, "default")
+	err = s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	ns, err := client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	c.Assert(ns, check.Equals, "default")
 }
 
 func (s *S) TestClusterNamespace(c *check.C) {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -382,8 +382,8 @@ func ensureNamespaceForApp(client *ClusterClient, app provision.App) error {
 	return ensureNamespace(client, client.AppNamespace(app))
 }
 
-func ensureNamespaceForPool(client *ClusterClient, pool string) error {
-	return ensureNamespace(client, client.Namespace(pool))
+func ensurePoolNamespace(client *ClusterClient, pool string) error {
+	return ensureNamespace(client, client.PoolNamespace(pool))
 }
 
 func ensureNamespace(client *ClusterClient, namespace string) error {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1800,8 +1800,8 @@ func (s *S) TestServiceManagerDeployServiceRollbackPendingPod(c *check.C) {
 			labelsCp[k] = v
 		}
 		go func() {
-			ns, err := s.client.AppNamespace(a)
-			c.Assert(err, check.IsNil)
+			ns, nsErr := s.client.AppNamespace(a)
+			c.Assert(nsErr, check.IsNil)
 			_, repErr := s.client.Clientset.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "replica-for-" + dep.Name,
@@ -1854,7 +1854,9 @@ func (s *S) TestServiceManagerDeployServiceNoRollbackFullTimeoutSameRevision(c *
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.client.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Create(&v1beta2.Deployment{
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.AppsV1beta2().Deployments(ns).Create(&v1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "myapp-p1",
 		},

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -70,7 +70,9 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	one := int32(1)
 	ten := int32(10)
@@ -103,10 +105,12 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		"tsuru.io/router-type": "fake",
 		"tsuru.io/router-name": "fake",
 	}
+	nsName, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	c.Assert(dep, check.DeepEquals, &v1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "myapp-p1",
-			Namespace:   s.client.AppNamespace(a),
+			Namespace:   nsName,
 			Labels:      depLabels,
 			Annotations: annotations,
 		},
@@ -176,12 +180,12 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 			},
 		},
 	})
-	srv, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	srv, err := s.client.CoreV1().Services(nsName).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(srv, check.DeepEquals, &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: nsName,
 			Labels: map[string]string{
 				"tsuru.io/is-tsuru":             "true",
 				"tsuru.io/is-service":           "true",
@@ -219,12 +223,12 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 			Type: apiv1.ServiceTypeNodePort,
 		},
 	})
-	srvHeadless, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).Get("myapp-p1-units", metav1.GetOptions{})
+	srvHeadless, err := s.client.CoreV1().Services(nsName).Get("myapp-p1-units", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(srvHeadless, check.DeepEquals, &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-units",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: nsName,
 			Labels: map[string]string{
 				"tsuru.io/is-tsuru":             "true",
 				"tsuru.io/is-service":           "true",
@@ -264,12 +268,12 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 			Type:      apiv1.ServiceTypeClusterIP,
 		},
 	})
-	account, err := s.client.CoreV1().ServiceAccounts(s.client.AppNamespace(a)).Get("app-myapp", metav1.GetOptions{})
+	account, err := s.client.CoreV1().ServiceAccounts(nsName).Get("app-myapp", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(account, check.DeepEquals, &apiv1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-myapp",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: nsName,
 			Labels: map[string]string{
 				"tsuru.io/is-tsuru":    "true",
 				"tsuru.io/app-name":    "myapp",
@@ -292,7 +296,7 @@ func (s *S) TestServiceManagerDeployServiceWithPoolNamespaces(c *check.C) {
 		ns, ok := action.(ktesting.CreateAction).GetObject().(*apiv1.Namespace)
 		c.Assert(ok, check.Equals, true)
 		if new == 2 {
-			c.Assert(ns.ObjectMeta.Name, check.Equals, s.client.AppNamespace(a))
+			c.Assert(ns.ObjectMeta.Name, check.Equals, "tsuru-test-default")
 		} else if new < 2 {
 			c.Assert(ns.ObjectMeta.Name, check.Equals, s.client.Namespace())
 		}
@@ -334,12 +338,14 @@ func (s *S) TestServiceManagerDeployServiceCustomPort(c *check.C) {
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	srv, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	nsName, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	srv, err := s.client.CoreV1().Services(nsName).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(srv, check.DeepEquals, &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: nsName,
 			Labels: map[string]string{
 				"tsuru.io/is-tsuru":             "true",
 				"tsuru.io/is-service":           "true",
@@ -502,7 +508,9 @@ func (s *S) TestServiceManagerDeployServiceUpdateStates(c *check.C) {
 			c.Assert(err, check.IsNil)
 		}
 		var dep *v1beta2.Deployment
-		dep, err = s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+		nsName, err := s.client.AppNamespace(a)
+		c.Assert(err, check.IsNil)
+		dep, err = s.client.Clientset.AppsV1beta2().Deployments(nsName).Get("myapp-p1", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
 		waitDep()
 		tt.fn(dep)
@@ -659,12 +667,14 @@ func (s *S) TestServiceManagerDeployServiceWithHC(c *check.C) {
 			"p2":  servicecommon.ProcessState{Start: true},
 		}, nil)
 		c.Assert(err, check.IsNil)
-		dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-web", metav1.GetOptions{})
+		nsName, err := s.client.AppNamespace(a)
+		c.Assert(err, check.IsNil)
+		dep, err := s.client.Clientset.AppsV1beta2().Deployments(nsName).Get("myapp-web", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
 		c.Assert(dep.Spec.Template.Spec.Containers[0].ReadinessProbe, check.DeepEquals, tt.expectedReadiness)
 		c.Assert(dep.Spec.Template.Spec.Containers[0].LivenessProbe, check.DeepEquals, tt.expectedLiveness)
 		c.Assert(dep.Spec.Template.Spec.Containers[0].Lifecycle, check.DeepEquals, tt.expectedLifecycle)
-		dep, err = s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p2", metav1.GetOptions{})
+		dep, err = s.client.Clientset.AppsV1beta2().Deployments(nsName).Get("myapp-p2", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
 		c.Assert(dep.Spec.Template.Spec.Containers[0].ReadinessProbe, check.IsNil)
 		c.Assert(dep.Spec.Template.Spec.Containers[0].LivenessProbe, check.IsNil)
@@ -697,7 +707,8 @@ func (s *S) TestServiceManagerDeployServiceWithRestartHooks(c *check.C) {
 		"p2":  servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	ns := s.client.AppNamespace(a)
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-web", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedLifecycle := &apiv1.Lifecycle{
@@ -741,12 +752,14 @@ func (s *S) TestServiceManagerDeployServiceWithRegistryAuth(c *check.C) {
 		"web": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-web", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-web", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(dep.Spec.Template.Spec.ImagePullSecrets, check.DeepEquals, []apiv1.LocalObjectReference{
 		{Name: "registry-myreg.com"},
 	})
-	secrets, err := s.client.CoreV1().Secrets(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	secrets, err := s.client.CoreV1().Secrets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(secrets.Items, check.DeepEquals, []apiv1.Secret{
 		{
@@ -795,6 +808,8 @@ func (s *S) TestServiceManagerDeployServiceProgressMessages(c *check.C) {
 	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err := app.CreateApp(a, s.user)
 	c.Assert(err, check.IsNil)
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	s.client.PrependReactor("create", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 		obj := action.(ktesting.CreateAction).GetObject()
 		dep := obj.(*v1beta2.Deployment)
@@ -804,7 +819,7 @@ func (s *S) TestServiceManagerDeployServiceProgressMessages(c *check.C) {
 			<-watchCalled
 			time.Sleep(time.Second)
 			depCopy.Status.UnavailableReplicas = 0
-			s.client.AppsV1beta2().Deployments(s.clusterClient.AppNamespace(a)).Update(&depCopy)
+			s.client.AppsV1beta2().Deployments(ns).Update(&depCopy)
 		}()
 		return false, nil, nil
 	})
@@ -824,7 +839,7 @@ func (s *S) TestServiceManagerDeployServiceProgressMessages(c *check.C) {
 		"web": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-web", metav1.GetOptions{})
+	_, err = s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-web", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Matches, `(?s).* ---> 1 of 1 new units created.*? ---> 0 of 1 new units ready.*? ---> 1 of 1 new units ready.*? ---> Done updating units.*`)
 	c.Assert(buf.String(), check.Matches, `(?s).*  ---> pod-name-1 - msg1 \[c1\].*?  ---> pod-name-1 - msg2 \[c1, n1\].*`)
@@ -874,7 +889,9 @@ func (s *S) TestServiceManagerDeployServiceCancel(c *check.C) {
 		"web": servicecommon.ProcessState{Start: true},
 	}, evt)
 	c.Assert(err, check.DeepEquals, provision.ErrUnitStartup{Err: context.Canceled})
-	_, err = s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-web", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-web", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(buf.String(), check.Matches, `(?s).* ---> 1 of 1 new units created.*? ---> 0 of 1 new units ready.*? ROLLING BACK AFTER FAILURE .*? ---> context canceled <---.*`)
 }
@@ -904,10 +921,12 @@ func (s *S) TestServiceManagerDeployServiceWithNodeContainers(c *check.C) {
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(dep, check.NotNil)
-	daemon, err := s.client.Clientset.AppsV1beta2().DaemonSets(s.client.AppNamespace(a)).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err := s.client.Clientset.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemon, check.NotNil)
 }
@@ -954,7 +973,9 @@ func (s *S) TestServiceManagerDeployServiceWithUID(c *check.C) {
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedUID := int64(1001)
 	c.Assert(dep.Spec.Template.Spec.SecurityContext, check.DeepEquals, &apiv1.PodSecurityContext{
@@ -980,7 +1001,9 @@ func (s *S) TestServiceManagerDeployServiceWithResourceRequirements(c *check.C) 
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedMemory := resource.NewQuantity(1024, resource.BinarySI)
 	c.Assert(dep.Spec.Template.Spec.Containers[0].Resources, check.DeepEquals, apiv1.ResourceRequirements{
@@ -1012,7 +1035,9 @@ func (s *S) TestServiceManagerDeployServiceWithClusterWideOvercommitFactor(c *ch
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedMemory := resource.NewQuantity(1024, resource.BinarySI)
 	expectedMemoryRequest := resource.NewQuantity(341, resource.BinarySI)
@@ -1046,7 +1071,9 @@ func (s *S) TestServiceManagerDeployServiceWithClusterPoolOvercommitFactor(c *ch
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedMemory := resource.NewQuantity(1024, resource.BinarySI)
 	expectedMemoryRequest := resource.NewQuantity(512, resource.BinarySI)
@@ -1063,7 +1090,9 @@ func (s *S) TestServiceManagerDeployServiceWithClusterPoolOvercommitFactor(c *ch
 func (s *S) TestCreateBuildPodContainers(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
-	err := createBuildPod(context.Background(), createPodParams{
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	err = createBuildPod(context.Background(), createPodParams{
 		client:            s.clusterClient,
 		app:               a,
 		sourceImage:       "myimg",
@@ -1071,7 +1100,9 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 		inputFile:         "/home/application/archive.tar.gz",
 	})
 	c.Assert(err, check.IsNil)
-	pods, err := s.client.Core().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.Core().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 1)
 	containers := pods.Items[0].Spec.Containers
@@ -1122,7 +1153,9 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 func (s *S) TestCreateDeployPodContainers(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
-	err := createDeployPod(context.Background(), createPodParams{
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	err = createDeployPod(context.Background(), createPodParams{
 		client:            s.clusterClient,
 		app:               a,
 		sourceImage:       "myimg",
@@ -1130,7 +1163,9 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 		inputFile:         "/dev/null",
 	})
 	c.Assert(err, check.IsNil)
-	pods, err := s.client.CoreV1().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 1)
 	containers := pods.Items[0].Spec.Containers
@@ -1139,7 +1174,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 	c.Assert(pods.Items[0], check.DeepEquals, apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-v1-deploy",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 			Labels: map[string]string{
 				"tsuru.io/is-deploy":            "false",
 				"tsuru.io/is-stopped":           "false",
@@ -1238,7 +1273,9 @@ func (s *S) TestCreateDeployPodContainersWithRegistryAuth(c *check.C) {
 	defer config.Unset("docker:registry-auth:password")
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
-	err := createDeployPod(context.Background(), createPodParams{
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	err = createDeployPod(context.Background(), createPodParams{
 		client:            s.clusterClient,
 		app:               a,
 		sourceImage:       "myimg",
@@ -1246,7 +1283,9 @@ func (s *S) TestCreateDeployPodContainersWithRegistryAuth(c *check.C) {
 		inputFile:         "/dev/null",
 	})
 	c.Assert(err, check.IsNil)
-	pods, err := s.client.CoreV1().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 1)
 	containers := pods.Items[0].Spec.Containers
@@ -1255,7 +1294,7 @@ func (s *S) TestCreateDeployPodContainersWithRegistryAuth(c *check.C) {
 	c.Assert(pods.Items[0], check.DeepEquals, apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-v1-deploy",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 			Labels: map[string]string{
 				"tsuru.io/is-deploy":            "false",
 				"tsuru.io/is-stopped":           "false",
@@ -1323,6 +1362,8 @@ mkdir -p $(dirname /dev/null) && cat >/dev/null && tsuru_unit_agent   myapp depl
 func (s *S) TestCreateDeployPodProgress(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
 	fakeWatcher := watch.NewFakeWithChanSize(2, false)
 	fakeWatcher.Add(&apiv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1352,6 +1393,8 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 	})
 	watchCalled := make(chan struct{})
 	podReactorDone := make(chan struct{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	s.client.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 		obj := action.(ktesting.CreateAction).GetObject()
 		pod := obj.(*apiv1.Pod)
@@ -1364,7 +1407,7 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 			<-watchCalled
 			time.Sleep(time.Second)
 			podCopy.Status.ContainerStatuses = nil
-			s.clusterClient.CoreV1().Pods(s.clusterClient.AppNamespace(a)).Update(&podCopy)
+			s.clusterClient.CoreV1().Pods(ns).Update(&podCopy)
 		}()
 		return false, nil, nil
 	})
@@ -1373,7 +1416,7 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 		return true, fakeWatcher, nil
 	})
 	buf := safe.NewBuffer(nil)
-	err := createDeployPod(context.Background(), createPodParams{
+	err = createDeployPod(context.Background(), createPodParams{
 		client:            s.clusterClient,
 		app:               a,
 		sourceImage:       "myimg",
@@ -1384,7 +1427,7 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	<-podReactorDone
-	pods, err := s.client.CoreV1().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 1)
 	c.Assert(buf.String(), check.Matches, `(?s).*stdout data.*`)
@@ -1395,7 +1438,9 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
-	err := createDeployPod(context.Background(), createPodParams{
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	err = createDeployPod(context.Background(), createPodParams{
 		client:            s.clusterClient,
 		app:               a,
 		sourceImage:       "myimg",
@@ -1403,7 +1448,9 @@ func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 		inputFile:         "/dev/null",
 	})
 	c.Assert(err, check.IsNil)
-	pods, err := s.client.CoreV1().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 1)
 	containers := pods.Items[0].Spec.Containers
@@ -1412,7 +1459,7 @@ func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 	c.Assert(pods.Items[0], check.DeepEquals, apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-v1-deploy",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 			Labels: map[string]string{
 				"tsuru.io/is-deploy":            "false",
 				"tsuru.io/is-stopped":           "false",
@@ -1539,7 +1586,9 @@ func (s *S) TestServiceManagerDeployServiceWithVolumes(c *check.C) {
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
 	c.Assert(err, check.IsNil)
-	dep, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).Get("myapp-p1", metav1.GetOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(dep.Spec.Template.Spec.Volumes, check.DeepEquals, []apiv1.Volume{
 		{
@@ -1611,10 +1660,12 @@ func (s *S) TestServiceManagerDeployServiceRollbackFullTimeout(c *check.C) {
 	})
 	c.Assert(buf.String(), check.Matches, `(?s).*---- Updating units \[p1\] ----.*ROLLING BACK AFTER FAILURE.*---> timeout waiting full rollout after .* waiting for units: Pod myapp-p1-pod-1-1: invalid pod phase \"Running\" <---\s*$`)
 	cleanupDeployment(s.clusterClient, a, "p1")
-	_, err = s.client.CoreV1().Events(s.client.AppNamespace(a)).Create(&apiv1.Event{
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.CoreV1().Events(ns).Create(&apiv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod.evt1",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 		},
 		Reason:  "Unhealthy",
 		Message: "my evt message",
@@ -1646,6 +1697,8 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 	})
 	c.Assert(err, check.IsNil)
 	var rollbackObj *extensions.DeploymentRollback
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	s.client.PrependReactor("create", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
 		obj := action.(ktesting.CreateAction).GetObject()
 		if action.GetSubresource() == "rollback" {
@@ -1662,7 +1715,7 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 			labelsCp[k] = v
 		}
 		go func() {
-			_, repErr := s.client.Clientset.AppsV1beta2().ReplicaSets(s.client.AppNamespace(a)).Create(&v1beta2.ReplicaSet{
+			_, repErr := s.client.Clientset.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "replica-for-" + dep.Name,
 					Labels: labelsCp,
@@ -1696,10 +1749,10 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 	})
 	c.Assert(buf.String(), check.Matches, `(?s).*---- Updating units \[p1\] ----.*ROLLING BACK AFTER FAILURE.*---> timeout waiting healthcheck after .* waiting for units: Pod myapp-p1-pod-1-1: invalid pod phase \"Running\" <---\s*$`)
 	cleanupDeployment(s.clusterClient, a, "p1")
-	_, err = s.client.CoreV1().Events(s.client.AppNamespace(a)).Create(&apiv1.Event{
+	_, err = s.client.CoreV1().Events(ns).Create(&apiv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod.evt1",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 		},
 		Reason:  "Unhealthy",
 		Message: "my evt message",
@@ -1747,7 +1800,9 @@ func (s *S) TestServiceManagerDeployServiceRollbackPendingPod(c *check.C) {
 			labelsCp[k] = v
 		}
 		go func() {
-			_, repErr := s.client.Clientset.AppsV1beta2().ReplicaSets(s.client.AppNamespace(a)).Create(&v1beta2.ReplicaSet{
+			ns, err := s.client.AppNamespace(a)
+			c.Assert(err, check.IsNil)
+			_, repErr := s.client.Clientset.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "replica-for-" + dep.Name,
 					Labels: labelsCp,
@@ -1871,34 +1926,36 @@ func (s *S) TestServiceManagerRemoveService(c *check.C) {
 		"tsuru.io/provisioner":          provisionerName,
 		"tsuru.io/builder":              "",
 	}
-	_, err = s.client.Clientset.AppsV1beta2().ReplicaSets(s.client.AppNamespace(a)).Create(&v1beta2.ReplicaSet{
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.Clientset.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-xxx",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 			Labels:    expectedLabels,
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.client.CoreV1().Pods(s.client.AppNamespace(a)).Create(&apiv1.Pod{
+	_, err = s.client.CoreV1().Pods(ns).Create(&apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-xyz",
-			Namespace: s.client.AppNamespace(a),
+			Namespace: ns,
 			Labels:    expectedLabels,
 		},
 	})
 	c.Assert(err, check.IsNil)
 	err = m.RemoveService(a, "p1")
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	deps, err := s.client.Clientset.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 0)
-	srvs, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	srvs, err := s.client.CoreV1().Services(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(srvs.Items, check.HasLen, 0)
-	pods, err := s.client.CoreV1().Pods(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 0)
-	replicas, err := s.client.Clientset.AppsV1beta2().ReplicaSets(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	replicas, err := s.client.Clientset.AppsV1beta2().ReplicaSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(replicas.Items, check.HasLen, 0)
 }
@@ -1924,10 +1981,12 @@ func (s *S) TestServiceManagerRemoveServiceMiddleFailure(c *check.C) {
 	})
 	err = m.RemoveService(a, "p1")
 	c.Assert(err, check.ErrorMatches, "(?s).*my dep err.*")
-	deps, err := s.client.Clientset.AppsV1beta2().Deployments(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	deps, err := s.client.Clientset.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
-	srvs, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	srvs, err := s.client.CoreV1().Services(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(srvs.Items, check.HasLen, 0)
 }

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -378,7 +378,7 @@ func cleanupDeployment(client *ClusterClient, a provision.App, process string) e
 
 func cleanupDaemonSet(client *ClusterClient, name, pool string) error {
 	dsName := daemonSetName(name, pool)
-	ns := client.Namespace(pool)
+	ns := client.PoolNamespace(pool)
 	err := client.AppsV1beta2().DaemonSets(ns).Delete(dsName, &metav1.DeleteOptions{
 		PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 	})

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -391,8 +391,11 @@ func (s *S) TestCleanupDeployment(c *check.C) {
 		"tsuru.io/router-name":          "fake",
 		"tsuru.io/provisioner":          "kubernetes",
 	}
-	ns := s.client.AppNamespace(a)
-	_, err := s.client.AppsV1beta2().Deployments(ns).Create(&v1beta2.Deployment{
+	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.AppsV1beta2().Deployments(ns).Create(&v1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1",
 			Namespace: ns,

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -466,7 +466,7 @@ func (s *S) TestCleanupReplicas(c *check.C) {
 }
 
 func (s *S) TestCleanupDaemonSet(c *check.C) {
-	ns := s.client.Namespace("pool")
+	ns := s.client.PoolNamespace("pool")
 	_, err := s.client.AppsV1beta2().DaemonSets(ns).Create(&v1beta2.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-container-bs-pool-p1",

--- a/provision/kubernetes/migrate/migrate_test.go
+++ b/provision/kubernetes/migrate/migrate_test.go
@@ -180,8 +180,9 @@ func (s *S) TestMigrateAppsCRDsDeployedApp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
-		NamespaceName: "default",
-		Deployments:   []string{"myapp-web"},
-		Services:      []string{"myapp-web", "myapp-web-units"},
+		NamespaceName:      "default",
+		ServiceAccountName: "app-myapp",
+		Deployments:        []string{"myapp-web"},
+		Services:           []string{"myapp-web", "myapp-web-units"},
 	})
 }

--- a/provision/kubernetes/migrate/migrate_test.go
+++ b/provision/kubernetes/migrate/migrate_test.go
@@ -5,23 +5,16 @@ import (
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app"
-	"github.com/tsuru/tsuru/app/image"
-	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/auth/native"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
-	"github.com/tsuru/tsuru/event"
-	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision/cluster"
 	kubeProv "github.com/tsuru/tsuru/provision/kubernetes"
-	tsuruv1 "github.com/tsuru/tsuru/provision/kubernetes/pkg/apis/tsuru/v1"
 	tsuruv1clientset "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned"
 	faketsuru "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned/fake"
 	kubeTesting "github.com/tsuru/tsuru/provision/kubernetes/testing"
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/servicemanager"
 	apptypes "github.com/tsuru/tsuru/types/app"
-	"github.com/tsuru/tsuru/types/quota"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/check.v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -139,50 +132,4 @@ func (s *S) TestMigrateAppsCRDs(c *check.C) {
 	c.Assert(len(appList.Items), check.Equals, 2)
 	c.Assert(appList.Items[0].Name, check.Equals, "app-kube")
 	c.Assert(appList.Items[1].Name, check.Equals, "app-kube2")
-}
-
-func (s *S) TestMigrateAppsCRDsDeployedApp(c *check.C) {
-	a, _, rollback := s.mock.DefaultReactions(c)
-	defer rollback()
-	err := s.conn.Apps().Insert(app.App{Name: a.GetName(), Pool: a.GetPool()})
-	c.Assert(err, check.IsNil)
-	nativeScheme := auth.ManagedScheme(native.NativeScheme{})
-	app.AuthScheme = nativeScheme
-	u := &auth.User{Email: "whiskeyjack@genabackis.com", Password: "123456", Quota: quota.UnlimitedQuota}
-	_, err = nativeScheme.Create(u)
-	c.Assert(err, check.IsNil)
-	token, err := nativeScheme.Login(map[string]string{"email": u.Email, "password": "123456"})
-	c.Assert(err, check.IsNil)
-	evt, err := event.New(&event.Opts{
-		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
-		Kind:    permission.PermAppDeploy,
-		Owner:   token,
-		Allowed: event.Allowed(permission.PermAppDeploy),
-	})
-	c.Assert(err, check.IsNil)
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
-			"web": "run mycmd arg1",
-		},
-	}
-	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
-	c.Assert(err, check.IsNil)
-	_, err = kubeProv.GetProvisioner().Deploy(a, "tsuru/app-myapp:v1", evt)
-	c.Assert(err, check.IsNil)
-	err = s.client.TsuruV1().Apps("tsuru").Delete(a.GetName(), &metav1.DeleteOptions{})
-	c.Assert(err, check.IsNil)
-	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
-	c.Assert(err, check.IsNil)
-	c.Assert(len(appList.Items), check.Equals, 0)
-	err = MigrateAppsCRDs()
-	c.Assert(err, check.IsNil)
-	appList, err = s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
-	c.Assert(err, check.IsNil)
-	c.Assert(len(appList.Items), check.Equals, 1)
-	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
-		NamespaceName:      "default",
-		ServiceAccountName: "app-myapp",
-		Deployments:        []string{"myapp-web"},
-		Services:           []string{"myapp-web", "myapp-web-units"},
-	})
 }

--- a/provision/kubernetes/migrate/migrate_test.go
+++ b/provision/kubernetes/migrate/migrate_test.go
@@ -109,10 +109,10 @@ func (s *S) SetUpSuite(c *check.C) {
 func (s *S) SetUpTest(c *check.C) {
 	err := s.conn.Apps().DropCollection()
 	c.Assert(err, check.IsNil)
-	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	for _, a := range appList.Items {
-		err = s.client.TsuruV1().Apps("default").Delete(a.GetName(), &metav1.DeleteOptions{})
+		err = s.client.TsuruV1().Apps("tsuru").Delete(a.GetName(), &metav1.DeleteOptions{})
 		c.Assert(err, check.IsNil)
 	}
 }
@@ -134,7 +134,7 @@ func (s *S) TestMigrateAppsCRDs(c *check.C) {
 	}
 	err := MigrateAppsCRDs()
 	c.Assert(err, check.NotNil)
-	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 2)
 	c.Assert(appList.Items[0].Name, check.Equals, "app-kube")
@@ -169,14 +169,14 @@ func (s *S) TestMigrateAppsCRDsDeployedApp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = kubeProv.GetProvisioner().Deploy(a, "tsuru/app-myapp:v1", evt)
 	c.Assert(err, check.IsNil)
-	err = s.client.TsuruV1().Apps("default").Delete(a.GetName(), &metav1.DeleteOptions{})
+	err = s.client.TsuruV1().Apps("tsuru").Delete(a.GetName(), &metav1.DeleteOptions{})
 	c.Assert(err, check.IsNil)
-	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 0)
 	err = MigrateAppsCRDs()
 	c.Assert(err, check.IsNil)
-	appList, err = s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err = s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -221,7 +221,6 @@ func (s *S) TestNodeUnits(c *check.C) {
 func (s *S) TestNodeUnitsUsingPoolNamespaces(c *check.C) {
 	config.Set("kubernetes:use-pool-namespaces", true)
 	defer config.Unset("kubernetes:use-pool-namespaces")
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.FormValue("labelSelector"), check.Equals, "tsuru.io/is-service=true,tsuru.io/app-pool")
 		output := `{"items": [
@@ -259,9 +258,9 @@ func (s *S) TestNodeUnitsUsingPoolNamespaces(c *check.C) {
 		c.Assert(errGet, check.IsNil)
 	}
 	for _, a := range []provision.App{app1, app2} {
-		ns := s.client.AppNamespace(a)
+		c.Assert(err, check.IsNil)
 		for i := 1; i <= numNodes; i++ {
-			_, err = s.client.CoreV1().Pods(ns).Create(&apiv1.Pod{
+			_, err = s.client.CoreV1().Pods("tsuru-test-default").Create(&apiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-%d", a.GetName(), i),
 					Labels: map[string]string{

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -328,7 +328,7 @@ func (s *S) TestNodeUnitsOnlyFromServices(c *check.C) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(output))
 	}
-	ns := s.client.Namespace("")
+	ns := s.client.PoolNamespace("")
 	_, err := s.client.CoreV1().Pods(ns).Create(&apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-pod-not-tsuru",

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -39,12 +39,12 @@ func (m *nodeContainerManager) DeployNodeContainer(config *nodecontainer.NodeCon
 }
 
 func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClient, config nodecontainer.NodeContainerConfig, pool string, filter servicecommon.PoolFilter, placementOnly bool) error {
-	err := ensureNamespaceForPool(client, pool)
+	err := ensurePoolNamespace(client, pool)
 	if err != nil {
 		return err
 	}
 	dsName := daemonSetName(config.Name, pool)
-	ns := client.Namespace(pool)
+	ns := client.PoolNamespace(pool)
 	oldDs, err := client.AppsV1beta2().DaemonSets(ns).Get(dsName, metav1.GetOptions{})
 	if err != nil {
 		if !k8sErrors.IsNotFound(err) {

--- a/provision/kubernetes/nodecontainer_test.go
+++ b/provision/kubernetes/nodecontainer_test.go
@@ -47,7 +47,7 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 	pool := "mypool"
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
-	ns := s.client.Namespace(pool)
+	ns := s.client.PoolNamespace(pool)
 	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
@@ -176,7 +176,7 @@ func (s *S) TestManagerDeployNodeContainerWithPoolNamespaces(c *check.C) {
 		s.client.AppsV1beta2()
 		ns, ok := action.(ktesting.CreateAction).GetObject().(*apiv1beta2.DaemonSet)
 		c.Assert(ok, check.Equals, true)
-		c.Assert(ns.ObjectMeta.Namespace, check.Equals, s.client.Namespace(pool))
+		c.Assert(ns.ObjectMeta.Namespace, check.Equals, s.client.PoolNamespace(pool))
 		return false, nil, nil
 	})
 	c1 := nodecontainer.NodeContainerConfig{
@@ -222,7 +222,7 @@ func (s *S) TestManagerDeployNodeContainerWithFilter(c *check.C) {
 	m := nodeContainerManager{}
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Exclude: []string{"p1", "p2"}}, false)
 	c.Assert(err, check.IsNil)
-	ns := s.client.Namespace("")
+	ns := s.client.PoolNamespace("")
 	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity := &apiv1.Affinity{
@@ -296,7 +296,7 @@ func (s *S) TestManagerDeployNodeContainerBSSpecialMount(c *check.C) {
 	pool := "main"
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
-	ns := s.client.Namespace(pool)
+	ns := s.client.PoolNamespace(pool)
 	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
@@ -358,7 +358,7 @@ func (s *S) TestManagerDeployNodeContainerBSMultiCluster(c *check.C) {
 	pool := "main"
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
-	ns := s.client.Namespace("pool")
+	ns := s.client.PoolNamespace("pool")
 	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
@@ -429,7 +429,7 @@ func (s *S) TestManagerDeployNodeContainerPlacementOnly(c *check.C) {
 	m := nodeContainerManager{}
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{}, true)
 	c.Assert(err, check.IsNil)
-	ns := s.client.Namespace("")
+	ns := s.client.PoolNamespace("")
 	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity := &apiv1.Affinity{

--- a/provision/kubernetes/pkg/apis/tsuru/v1/types.go
+++ b/provision/kubernetes/pkg/apis/tsuru/v1/types.go
@@ -21,9 +21,10 @@ type App struct {
 
 // AppSpec is the spec for a App resource
 type AppSpec struct {
-	NamespaceName string   `json:"namespaceName"`
-	Deployments   []string `json:"deployments"`
-	Services      []string `json:"services"`
+	NamespaceName      string   `json:"namespaceName"`
+	ServiceAccountName string   `json:"serviceAccountName"`
+	Deployments        []string `json:"deployments"`
+	Services           []string `json:"services"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/provision/kubernetes/pkg/apis/tsuru/v1/types.go
+++ b/provision/kubernetes/pkg/apis/tsuru/v1/types.go
@@ -21,10 +21,10 @@ type App struct {
 
 // AppSpec is the spec for a App resource
 type AppSpec struct {
-	NamespaceName      string   `json:"namespaceName"`
-	ServiceAccountName string   `json:"serviceAccountName"`
-	Deployments        []string `json:"deployments"`
-	Services           []string `json:"services"`
+	NamespaceName      string              `json:"namespaceName"`
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Deployments        map[string][]string `json:"deployments"`
+	Services           map[string][]string `json:"services"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/provision/kubernetes/pkg/apis/tsuru/v1/zz_generated.deepcopy.go
+++ b/provision/kubernetes/pkg/apis/tsuru/v1/zz_generated.deepcopy.go
@@ -77,13 +77,27 @@ func (in *AppSpec) DeepCopyInto(out *AppSpec) {
 	*out = *in
 	if in.Deployments != nil {
 		in, out := &in.Deployments, &out.Deployments
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				(*out)[key] = make([]string, len(val))
+				copy((*out)[key], val)
+			}
+		}
 	}
 	if in.Services != nil {
 		in, out := &in.Services, &out.Services
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				(*out)[key] = make([]string, len(val))
+				copy((*out)[key], val)
+			}
+		}
 	}
 	return
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -185,6 +185,10 @@ func (p *kubernetesProvisioner) removeResources(client *ClusterClient, app *tsur
 			multiErrors.Add(errors.WithStack(err))
 		}
 	}
+	err := client.CoreV1().ServiceAccounts(app.Spec.NamespaceName).Delete(app.Spec.ServiceAccountName, &metav1.DeleteOptions{})
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		multiErrors.Add(errors.WithStack(err))
+	}
 	return multiErrors.ToError()
 }
 
@@ -998,6 +1002,7 @@ func ensureAppCustomResourceSynced(client *ClusterClient, a provision.App) error
 	}
 	appCRD.Spec.Services = services
 	appCRD.Spec.Deployments = deployments
+	appCRD.Spec.ServiceAccountName = serviceAccountNameForApp(a)
 	_, err = tclient.TsuruV1().Apps(client.Namespace()).Update(appCRD)
 	return err
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -983,6 +983,7 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 		}
 		return action.NewPipeline(actions...).Execute(params)
 	}
+	// same cluster and it is not configured with per-pool-namespace, nothing to do.
 	if client.PoolNamespace(old.GetPool()) == newclient.PoolNamespace(new.GetPool()) {
 		return nil
 	}

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -960,7 +960,7 @@ func (p *kubernetesProvisioner) DeleteVolume(volumeName, pool string) error {
 	if err != nil {
 		return err
 	}
-	return deleteVolume(client, volumeName, client.PoolNamespace(pool))
+	return deleteVolume(client, volumeName)
 }
 
 func (p *kubernetesProvisioner) IsVolumeProvisioned(volumeName, pool string) (bool, error) {
@@ -968,7 +968,7 @@ func (p *kubernetesProvisioner) IsVolumeProvisioned(volumeName, pool string) (bo
 	if err != nil {
 		return false, err
 	}
-	return volumeExists(client, volumeName, client.PoolNamespace(pool))
+	return volumeExists(client, volumeName)
 }
 
 func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) error {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -983,14 +983,13 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 	if err != nil {
 		return err
 	}
-	sameCluster := client.GetCluster().Name == newclient.GetCluster().Name
 	params := updatePipelineParams{
 		old: old,
 		new: new,
 		w:   w,
 		p:   p,
 	}
-	if !sameCluster {
+	if !(client.GetCluster().Name == newclient.GetCluster().Name) {
 		actions := []*action.Action{
 			&provisionNewApp,
 			&restartApp,

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1030,8 +1030,8 @@ func (s *S) TestDeploy(c *check.C) {
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
 		NamespaceName:      "default",
 		ServiceAccountName: "app-myapp",
-		Deployments:        []string{"myapp-web"},
-		Services:           []string{"myapp-web", "myapp-web-units"},
+		Deployments:        map[string][]string{"web": {"myapp-web"}},
+		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-units"}},
 	})
 }
 
@@ -1077,8 +1077,8 @@ func (s *S) TestDeployWithPoolNamespaces(c *check.C) {
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
 		NamespaceName:      "tsuru-test-default",
 		ServiceAccountName: "app-myapp",
-		Deployments:        []string{"myapp-web"},
-		Services:           []string{"myapp-web", "myapp-web-units"},
+		Deployments:        map[string][]string{"web": {"myapp-web"}},
+		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-units"}},
 	})
 }
 

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -113,7 +113,7 @@ func (s *S) TestRemoveNodeWithRebalance(c *check.C) {
 	}))
 	defer srv.Close()
 	s.mock.MockfakeNodes(c, srv.URL)
-	ns := s.client.Namespace("")
+	ns := s.client.PoolNamespace("")
 	_, err := s.client.CoreV1().Pods(ns).Create(&apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: ns},
 	})
@@ -944,7 +944,7 @@ func (s *S) TestProvisionerDestroy(c *check.C) {
 	services, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(services.Items, check.HasLen, 0)
-	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 0)
 }
@@ -1018,7 +1018,7 @@ func (s *S) TestDeploy(c *check.C) {
 	units, err := s.p.Units(a)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(units, check.HasLen, 1)
-	appList, err := s.client.TsuruV1().Apps("").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
@@ -1060,7 +1060,7 @@ func (s *S) TestDeployWithPoolNamespaces(c *check.C) {
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
 	c.Assert(atomic.LoadInt32(&counter), check.Equals, int32(1))
-	appList, err := s.client.TsuruV1().Apps("").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
@@ -1247,13 +1247,13 @@ func (s *S) TestUpgradeNodeContainer(c *check.C) {
 	err = s.p.UpgradeNodeContainer("bs", "", buf)
 	c.Assert(err, check.IsNil)
 
-	daemons, err := s.client.AppsV1beta2().DaemonSets(s.client.Namespace("")).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.Namespace("p1")).List(metav1.ListOptions{})
+	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("p1")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.Namespace("p2")).List(metav1.ListOptions{})
+	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("p2")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
 }
@@ -1262,7 +1262,7 @@ func (s *S) TestRemoveNodeContainer(c *check.C) {
 	config.Set("kubernetes:use-pool-namespaces", true)
 	defer config.Unset("kubernetes:use-pool-namespaces")
 	s.mock.MockfakeNodes(c)
-	ns := s.client.Namespace("p1")
+	ns := s.client.PoolNamespace("p1")
 	_, err := s.client.AppsV1beta2().DaemonSets(ns).Create(&v1beta2.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-container-bs-pool-p1",
@@ -1621,7 +1621,7 @@ func (s *S) TestProvisionerProvision(c *check.C) {
 	crdList, err := s.client.ApiextensionsV1beta1().CustomResourceDefinitions().List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(crdList.Items[0].GetName(), check.DeepEquals, "apps.tsuru.io")
-	appList, err := s.client.TsuruV1().Apps("default").List(metav1.ListOptions{})
+	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].GetName(), check.DeepEquals, a.GetName())

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -938,6 +938,9 @@ func (s *S) TestProvisionerDestroy(c *check.C) {
 	services, err := s.client.CoreV1().Services(s.client.AppNamespace(a)).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(services.Items, check.HasLen, 0)
+	serviceAccounts, err := s.client.CoreV1().ServiceAccounts(s.client.AppNamespace(a)).List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(serviceAccounts.Items, check.HasLen, 0)
 	appList, err := s.client.TsuruV1().Apps("tsuru").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(appList.Items), check.Equals, 0)
@@ -1016,9 +1019,10 @@ func (s *S) TestDeploy(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
-		NamespaceName: "default",
-		Deployments:   []string{"myapp-web"},
-		Services:      []string{"myapp-web", "myapp-web-units"},
+		NamespaceName:      "default",
+		ServiceAccountName: "app-myapp",
+		Deployments:        []string{"myapp-web"},
+		Services:           []string{"myapp-web", "myapp-web-units"},
 	})
 }
 
@@ -1062,9 +1066,10 @@ func (s *S) TestDeployWithPoolNamespaces(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(len(appList.Items), check.Equals, 1)
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
-		NamespaceName: "tsuru-test-default",
-		Deployments:   []string{"myapp-web"},
-		Services:      []string{"myapp-web", "myapp-web-units"},
+		NamespaceName:      "tsuru-test-default",
+		ServiceAccountName: "app-myapp",
+		Deployments:        []string{"myapp-web"},
+		Services:           []string{"myapp-web", "myapp-web-units"},
 	})
 }
 

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -62,6 +62,9 @@ func (s *S) SetUpSuite(c *check.C) {
 	config.Set("database:driver", "mongodb")
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "provision_kubernetes_tests_s")
+	config.Set("queue:mongo-url", "127.0.0.1:27017?maxPoolSize=100")
+	config.Set("queue:mongo-database", "queue_provision_kubernetes_tests")
+	config.Set("queue:mongo-polling-interval", 0.01)
 	config.Set("routers:fake:type", "fake")
 	config.Set("routers:fake:default", true)
 	var err error

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -52,7 +52,7 @@ type ClusterInterface interface {
 	CoreV1() v1core.CoreV1Interface
 	RestConfig() *rest.Config
 	AppNamespace(provision.App) string
-	Namespace(string) string
+	PoolNamespace(string) string
 	GetCluster() *cluster.Cluster
 }
 

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -53,6 +53,7 @@ type ClusterInterface interface {
 	RestConfig() *rest.Config
 	AppNamespace(provision.App) string
 	PoolNamespace(string) string
+	Namespace() string
 	GetCluster() *cluster.Cluster
 }
 

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -393,6 +393,9 @@ func (s *KubeMock) deployPodReaction(a provision.App, c *check.C) (ktesting.Reac
 func (s *KubeMock) serviceWithPortReaction(c *check.C) ktesting.ReactionFunc {
 	return func(action ktesting.Action) (bool, runtime.Object, error) {
 		srv := action.(ktesting.CreateAction).GetObject().(*apiv1.Service)
+		if len(srv.Spec.Ports) > 0 && srv.Spec.Ports[0].NodePort != int32(0) {
+			return false, nil, nil
+		}
 		srv.Spec.Ports = []apiv1.ServicePort{
 			{
 				NodePort: int32(30000),

--- a/provision/kubernetes/volume.go
+++ b/provision/kubernetes/volume.go
@@ -225,7 +225,7 @@ func createVolume(client *ClusterClient, v *volume.Volume, opts *volumeOptions) 
 			StorageClassName: &opts.StorageClass,
 		},
 	}
-	_, err = client.CoreV1().PersistentVolumeClaims(client.Namespace(v.Pool)).Create(pvc)
+	_, err = client.CoreV1().PersistentVolumeClaims(client.PoolNamespace(v.Pool)).Create(pvc)
 	if err != nil && !k8sErrors.IsAlreadyExists(err) {
 		return err
 	}

--- a/provision/kubernetes/volume.go
+++ b/provision/kubernetes/volume.go
@@ -45,7 +45,7 @@ func createVolumesForApp(client *ClusterClient, app provision.App) ([]apiv1.Volu
 			return nil, nil, err
 		}
 		if opts.isPersistent() {
-			err = createVolume(client, &volumes[i], opts)
+			err = createVolume(client, &volumes[i], opts, app)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -148,8 +148,19 @@ func validateVolume(v *volume.Volume) (*volumeOptions, error) {
 	return &opts, nil
 }
 
-func deleteVolume(client *ClusterClient, name, namespace string) error {
-	err := client.CoreV1().PersistentVolumes().Delete(volumeName(name), &metav1.DeleteOptions{
+func deleteVolume(client *ClusterClient, name string) error {
+	v, err := volume.Load(name)
+	if err != nil {
+		if err == volume.ErrVolumeNotFound {
+			return nil
+		}
+		return err
+	}
+	namespace, err := getNamespaceForVolume(client, v)
+	if err != nil {
+		return err
+	}
+	err = client.CoreV1().PersistentVolumes().Delete(volumeName(name), &metav1.DeleteOptions{
 		PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 	})
 	if err != nil && !k8sErrors.IsNotFound(err) {
@@ -164,7 +175,11 @@ func deleteVolume(client *ClusterClient, name, namespace string) error {
 	return nil
 }
 
-func createVolume(client *ClusterClient, v *volume.Volume, opts *volumeOptions) error {
+func createVolume(client *ClusterClient, v *volume.Volume, opts *volumeOptions, app provision.App) error {
+	namespace, err := getNamespaceForVolume(client, v)
+	if err != nil {
+		return err
+	}
 	labelSet := provision.VolumeLabels(provision.VolumeLabelsOpts{
 		Name:        v.Name,
 		Provisioner: provisionerName,
@@ -225,14 +240,25 @@ func createVolume(client *ClusterClient, v *volume.Volume, opts *volumeOptions) 
 			StorageClassName: &opts.StorageClass,
 		},
 	}
-	_, err = client.CoreV1().PersistentVolumeClaims(client.PoolNamespace(v.Pool)).Create(pvc)
+	_, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
 	if err != nil && !k8sErrors.IsAlreadyExists(err) {
 		return err
 	}
 	return nil
 }
 
-func volumeExists(client *ClusterClient, name, namespace string) (bool, error) {
+func volumeExists(client *ClusterClient, name string) (bool, error) {
+	v, err := volume.Load(name)
+	if err != nil {
+		if err == volume.ErrVolumeNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	namespace, err := getNamespaceForVolume(client, v)
+	if err != nil {
+		return false, err
+	}
 	_, pvErr := client.CoreV1().PersistentVolumes().Get(volumeName(name), metav1.GetOptions{})
 	_, pvcErr := client.CoreV1().PersistentVolumeClaims(namespace).Get(volumeClaimName(name), metav1.GetOptions{})
 	if k8sErrors.IsNotFound(pvErr) && k8sErrors.IsNotFound(pvcErr) {
@@ -245,4 +271,29 @@ func volumeExists(client *ClusterClient, name, namespace string) (bool, error) {
 		return false, pvcErr
 	}
 	return true, nil
+}
+
+func getNamespaceForVolume(client *ClusterClient, v *volume.Volume) (string, error) {
+	binds, err := v.LoadBinds()
+	if err != nil {
+		return "", err
+	}
+	if len(binds) == 0 {
+		return client.PoolNamespace(v.Pool), nil
+	}
+	var namespace string
+	for _, b := range binds {
+		ns, err := client.appNamespaceByName(b.ID.App)
+		if err != nil {
+			return "", err
+		}
+		if namespace == "" {
+			namespace = ns
+			continue
+		}
+		if ns != namespace {
+			return "", errors.New("multiple namespaces for volume")
+		}
+	}
+	return namespace, nil
 }

--- a/provision/kubernetes/volume_test.go
+++ b/provision/kubernetes/volume_test.go
@@ -271,6 +271,7 @@ func (s *S) TestCreateVolumeAppNamespace(c *check.C) {
 	defer config.Unset("volume-plans")
 	a := provisiontest.NewFakeApp("myapp", "python", 0)
 	err := s.p.Provision(a)
+	c.Assert(err, check.IsNil)
 	appCR := tsuruv1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: a.GetName(),
@@ -341,6 +342,7 @@ func (s *S) TestCreateVolumeMultipleNamespacesFail(c *check.C) {
 	err = s.p.Provision(provisiontest.NewFakeAppWithPool("otherapp", "python", "otherpool", 0))
 	c.Assert(err, check.IsNil)
 	err = v.BindApp("otherapp", "/mnt", false)
+	c.Assert(err, check.IsNil)
 	_, _, err = createVolumesForApp(s.clusterClient, a)
 	c.Assert(err, check.ErrorMatches, `multiple namespaces for volume`)
 }

--- a/provision/kubernetes/volume_test.go
+++ b/provision/kubernetes/volume_test.go
@@ -181,6 +181,7 @@ func (s *S) TestCreateVolumesForAppPluginNonPersistent(c *check.C) {
 	_, err = s.client.CoreV1().PersistentVolumes().Get(volumeName(v.Name), metav1.GetOptions{})
 	c.Assert(k8sErrors.IsNotFound(err), check.Equals, true)
 	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
 	_, err = s.client.CoreV1().PersistentVolumeClaims(ns).Get(volumeClaimName(v.Name), metav1.GetOptions{})
 	c.Assert(k8sErrors.IsNotFound(err), check.Equals, true)
 	volumes, mounts, err = createVolumesForApp(s.clusterClient, a)

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -376,6 +376,12 @@ type SleepableProvisioner interface {
 	Sleep(App, string) error
 }
 
+// UpdatableProvisioner is a provisioner that stores data about applications
+// and must be notified when they are updated
+type UpdatableProvisioner interface {
+	UpdateApp(old, new App, w io.Writer) error
+}
+
 // MessageProvisioner is a provisioner that provides a welcome message for
 // logging.
 type MessageProvisioner interface {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -32,10 +32,11 @@ var (
 	errNotProvisioned         = &provision.Error{Reason: "App is not provisioned."}
 	uniqueIpCounter     int32 = 0
 
-	_ provision.NodeProvisioner = &FakeProvisioner{}
-	_ provision.Provisioner     = &FakeProvisioner{}
-	_ provision.App             = &FakeApp{}
-	_ bind.App                  = &FakeApp{}
+	_ provision.NodeProvisioner      = &FakeProvisioner{}
+	_ provision.UpdatableProvisioner = &FakeProvisioner{}
+	_ provision.Provisioner          = &FakeProvisioner{}
+	_ provision.App                  = &FakeApp{}
+	_ bind.App                       = &FakeApp{}
 )
 
 const fakeAppImage = "app-image"
@@ -1340,6 +1341,13 @@ func (p *FakeProvisioner) DeleteVolume(volName, pool string) error {
 
 func (p *FakeProvisioner) IsVolumeProvisioned(name, pool string) (bool, error) {
 	return false, nil
+}
+
+func (p *FakeProvisioner) UpdateApp(old, new provision.App, w io.Writer) error {
+	provApp := p.apps[old.GetName()]
+	provApp.app = new
+	p.apps[old.GetName()] = provApp
+	return nil
 }
 
 func stringInArray(value string, array []string) bool {

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -1437,3 +1437,15 @@ func (s *S) TestRebuildDeploy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(evt.Log, check.Equals, "Rebuild deploy called")
 }
+
+func (s *S) TestUpdateApp(c *check.C) {
+	app := NewFakeApp("myapp", "arch", 1)
+	p := NewFakeProvisioner()
+	err := p.Provision(app)
+	c.Assert(err, check.IsNil)
+	newApp := NewFakeApp("myapp", "python", 1)
+	err = p.UpdateApp(app, newApp, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(p.Provisioned(newApp), check.Equals, true)
+	c.Assert(p.apps["myapp"].app, check.DeepEquals, newApp)
+}


### PR DESCRIPTION
This PR adds support for app pool update accross different kubernetes clusters
and also accross a single cluster configured with per pool namespaces.
