### PR TITLE
api,service: fix compatibility of /services/{name} api route

### DIFF
--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -479,7 +479,15 @@ func serviceInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
-	return json.NewEncoder(w).Encode(instances)
+	var result []service.ServiceInstanceWithInfo
+	for _, instance := range instances {
+		infoData, err := instance.ToInfo()
+		if err != nil {
+			return err
+		}
+		result = append(result, infoData)
+	}
+	return json.NewEncoder(w).Encode(result)
 }
 
 // title: service doc

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -1665,14 +1665,27 @@ func (s *ServiceInstanceSuite) TestServiceInfo(c *check.C) {
 	recorder := httptest.NewRecorder()
 	err = serviceInfo(recorder, request, s.token)
 	c.Assert(err, check.IsNil)
-	var instances []service.ServiceInstance
+	var instances []service.ServiceInstanceWithInfo
 	err = json.Unmarshal(recorder.Body.Bytes(), &instances)
 	c.Assert(err, check.IsNil)
 	si1.BoundUnits = []service.Unit{}
 	si1.Tags = []string{}
 	si2.BoundUnits = []service.Unit{}
 	si2.Tags = []string{}
-	expected := []service.ServiceInstance{si1, si2}
+	expected := []service.ServiceInstanceWithInfo{
+		{
+			Name:        "my_nosql",
+			ServiceName: srv.Name,
+			Apps:        []string{},
+			Teams:       []string{s.team.Name},
+		},
+		{
+			Name:        "your_nosql",
+			ServiceName: srv.Name,
+			Apps:        []string{"wordpress"},
+			Teams:       []string{s.team.Name},
+		},
+	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
 
@@ -1706,12 +1719,19 @@ func (s *ServiceInstanceSuite) TestServiceInfoShouldReturnOnlyInstancesOfTheSame
 	recorder := httptest.NewRecorder()
 	err = serviceInfo(recorder, request, s.token)
 	c.Assert(err, check.IsNil)
-	var instances []service.ServiceInstance
+	var instances []service.ServiceInstanceWithInfo
 	err = json.Unmarshal(recorder.Body.Bytes(), &instances)
 	c.Assert(err, check.IsNil)
 	si1.BoundUnits = []service.Unit{}
 	si1.Tags = []string{}
-	expected := []service.ServiceInstance{si1}
+	expected := []service.ServiceInstanceWithInfo{
+		{
+			Name:        "my_nosql",
+			ServiceName: srv.Name,
+			Apps:        []string{},
+			Teams:       []string{s.team.Name},
+		},
+	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
 

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -89,6 +89,36 @@ func (si *ServiceInstance) GetIdentifier() string {
 	return si.Name
 }
 
+type ServiceInstanceWithInfo struct {
+	Id          int
+	Name        string
+	Teams       []string
+	PlanName    string
+	Apps        []string
+	ServiceName string
+	Info        map[string]string
+	TeamOwner   string
+}
+
+// ToInfo returns the service instance as a struct compatible with the return
+// of the service info api call.
+func (si *ServiceInstance) ToInfo() (ServiceInstanceWithInfo, error) {
+	info, err := si.Info("")
+	if err != nil {
+		info = nil
+	}
+	return ServiceInstanceWithInfo{
+		Id:          si.Id,
+		Name:        si.Name,
+		Teams:       si.Teams,
+		PlanName:    si.PlanName,
+		Apps:        si.Apps,
+		ServiceName: si.ServiceName,
+		Info:        info,
+		TeamOwner:   si.TeamOwner,
+	}, nil
+}
+
 func (si *ServiceInstance) Info(requestID string) (map[string]string, error) {
 	endpoint, err := si.Service().getClient("production")
 	if err != nil {


### PR DESCRIPTION
This route returns a modified service instance struct containing the
Info map returned by the service API