### PR TITLE
provision/kubernetes: updates default deploy-agent to 0.5.0

### DIFF
--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1076,7 +1076,7 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 	runAsUser := int64(1000)
 	c.Assert(containers[0], check.DeepEquals, apiv1.Container{
 		Name:  "committer-cont",
-		Image: "tsuru/deploy-agent:0.4.0",
+		Image: "tsuru/deploy-agent:0.5.0",
 		VolumeMounts: []apiv1.VolumeMount{
 			{Name: "dockersock", MountPath: dockerSockPath},
 			{Name: "intercontainer", MountPath: buildIntercontainerPath},
@@ -1186,7 +1186,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 	c.Assert(containers, check.DeepEquals, []apiv1.Container{
 		{
 			Name:  "committer-cont",
-			Image: "tsuru/deploy-agent:0.4.0",
+			Image: "tsuru/deploy-agent:0.5.0",
 			VolumeMounts: []apiv1.VolumeMount{
 				{Name: "dockersock", MountPath: dockerSockPath},
 				{Name: "intercontainer", MountPath: buildIntercontainerPath},
@@ -1459,7 +1459,7 @@ func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 	c.Assert(containers, check.DeepEquals, []apiv1.Container{
 		{
 			Name:  "committer-cont",
-			Image: "tsuru/deploy-agent:0.4.0",
+			Image: "tsuru/deploy-agent:0.5.0",
 			VolumeMounts: []apiv1.VolumeMount{
 				{Name: "dockersock", MountPath: dockerSockPath},
 				{Name: "intercontainer", MountPath: buildIntercontainerPath},

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -44,7 +44,7 @@ const (
 	defaultPodReadyTimeout           = time.Minute
 	defaultPodRunningTimeout         = 10 * time.Minute
 	defaultDeploymentProgressTimeout = 10 * time.Minute
-	defaultSidecarImageName          = "tsuru/deploy-agent:0.4.0"
+	defaultSidecarImageName          = "tsuru/deploy-agent:0.5.0"
 )
 
 type kubernetesProvisioner struct{}

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1602,8 +1602,8 @@ func (s *S) TestGetKubeConfigDefaults(c *check.C) {
 	config.Unset("kubernetes")
 	kubeConf := getKubeConfig()
 	c.Assert(kubeConf, check.DeepEquals, kubernetesConfig{
-		DeploySidecarImage:        "tsuru/deploy-agent:0.4.0",
-		DeployInspectImage:        "tsuru/deploy-agent:0.4.0",
+		DeploySidecarImage:        "tsuru/deploy-agent:0.5.0",
+		DeployInspectImage:        "tsuru/deploy-agent:0.5.0",
 		APITimeout:                60 * time.Second,
 		APIShortTimeout:           5 * time.Second,
 		PodReadyTimeout:           time.Minute,


### PR DESCRIPTION
This change updates the default deploy-agent to 0.5.0. This version
contains better handling of environment variables, fixing parsing of
environment variables that contain quotes.