### PR TITLE
app: provision app before adding backend to router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -422,8 +422,8 @@ func CreateApp(app *App, user *auth.User) error {
 		&createAppToken,
 		&exportEnvironmentsAction,
 		&createRepository,
-		&addRouterBackend,
 		&provisionApp,
+		&addRouterBackend,
 	}
 	pipeline := action.NewPipeline(actions...)
 	err = pipeline.Execute(app, user)


### PR DESCRIPTION
Some routers may require that the application is already provisioned
to be able to add the backend.