### PR TITLE
service: Adds plan schemas to service API responses

### DIFF
--- a/api/service_broker_test.go
+++ b/api/service_broker_test.go
@@ -62,12 +62,14 @@ func (s *S) TestServiceBrokerAdd(c *check.C) {
 	expectedBroker := service.Broker{
 		Name: "broker-name",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "username",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "username",
+					Password: "password",
+				},
+				BearerConfig: &service.BearerConfig{},
 			},
-			BearerConfig: &service.BearerConfig{},
 		},
 	}
 	bodyData, err := form.EncodeToString(expectedBroker)
@@ -113,18 +115,20 @@ func (s *S) TestServiceBrokerUpdate(c *check.C) {
 	broker := service.Broker{
 		Name: "broker-name",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "username",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "username",
+					Password: "password",
+				},
+				BearerConfig: &service.BearerConfig{},
 			},
-			BearerConfig: &service.BearerConfig{},
 		},
 	}
 	err := servicemanager.ServiceBroker.Create(broker)
 	c.Assert(err, check.IsNil)
 	broker.URL = "https://localhost:9090"
-	broker.AuthConfig.BasicAuthConfig.Username = "new-user"
+	broker.Config.AuthConfig.BasicAuthConfig.Username = "new-user"
 	bodyData, err := form.EncodeToString(broker)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -56,12 +56,17 @@ func createServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 		return err
 	}
 	instance := service.ServiceInstance{
-		Name:        r.FormValue("name"),
-		PlanName:    r.FormValue("plan"),
-		TeamOwner:   r.FormValue("owner"),
-		Description: r.FormValue("description"),
-		Tags:        r.Form["tag"],
+		ServiceName: serviceName,
+		PlanName:    r.FormValue("plan"), // for compatibility
 	}
+	dec := form.NewDecoder(nil)
+	dec.IgnoreCase(true)
+	dec.IgnoreUnknownKeys(true)
+	err = dec.DecodeValues(&instance, r.Form)
+	if err != nil {
+		return err
+	}
+	instance.Tags = append(instance.Tags, r.Form["tag"]...) // for compatibility
 	var teamOwner string
 	if instance.TeamOwner == "" {
 		teamOwner, err = permission.TeamForPermission(t, permission.PermServiceInstanceCreate)

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -57,7 +57,9 @@ func createServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	}
 	instance := service.ServiceInstance{
 		ServiceName: serviceName,
-		PlanName:    r.FormValue("plan"), // for compatibility
+		// for compatibility
+		PlanName:  r.FormValue("plan"),
+		TeamOwner: r.FormValue("owner"),
 	}
 	dec := form.NewDecoder(nil)
 	dec.IgnoreCase(true)

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -293,7 +293,7 @@ func (s *ServiceInstanceSuite) TestCreateInstance(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
 	c.Assert(recorder.Body.String(), check.Equals, "")
 	var si service.ServiceInstance
-	err := s.conn.ServiceInstances().Find(bson.M{"name": "brainsql", "service_name": "mysql"}).One(&si)
+	err := s.conn.ServiceInstances().Find(bson.M{"name": "brainsql", "service_name": "mysql", "teamowner": s.team.Name}).One(&si)
 	c.Assert(err, check.IsNil)
 	s.conn.ServiceInstances().Update(bson.M{"name": si.Name}, si)
 	c.Assert(si.Name, check.Equals, "brainsql")

--- a/service/broker.go
+++ b/service/broker.go
@@ -41,18 +41,19 @@ func newClient(b serviceTypes.Broker, service string) (*brokerClient, error) {
 	}
 	config := osb.DefaultClientConfiguration()
 	config.URL = b.URL
+	config.Insecure = b.Config.Insecure
 	var authConfig *osb.AuthConfig
-	if b.AuthConfig != nil {
+	if b.Config.AuthConfig != nil {
 		authConfig = &osb.AuthConfig{}
-		if b.AuthConfig.BasicAuthConfig != nil {
+		if b.Config.AuthConfig.BasicAuthConfig != nil {
 			authConfig.BasicAuthConfig = &osb.BasicAuthConfig{
-				Username: b.AuthConfig.BasicAuthConfig.Username,
-				Password: b.AuthConfig.BasicAuthConfig.Password,
+				Username: b.Config.AuthConfig.BasicAuthConfig.Username,
+				Password: b.Config.AuthConfig.BasicAuthConfig.Password,
 			}
 		}
-		if b.AuthConfig.BearerConfig != nil {
+		if b.Config.AuthConfig.BearerConfig != nil {
 			authConfig.BearerConfig = &osb.BearerConfig{
-				Token: b.AuthConfig.BearerConfig.Token,
+				Token: b.Config.AuthConfig.BearerConfig.Token,
 			}
 		}
 	}

--- a/service/broker.go
+++ b/service/broker.go
@@ -287,7 +287,14 @@ func (b *brokerClient) Status(instance *ServiceInstance, requestID string) (stri
 }
 
 func (b *brokerClient) Info(instance *ServiceInstance, requestID string) ([]map[string]string, error) {
-	return nil, fmt.Errorf("not implemented")
+	var params []map[string]string
+	for k, v := range instance.Parameters {
+		params = append(params, map[string]string{
+			"label": k,
+			"value": fmt.Sprintf("%v", v),
+		})
+	}
+	return params, nil
 }
 
 func (b *brokerClient) Plans(_ string) ([]Plan, error) {

--- a/service/broker.go
+++ b/service/broker.go
@@ -300,6 +300,7 @@ func (b *brokerClient) Plans(_ string) ([]Plan, error) {
 		plans[i] = Plan{
 			Name:        p.Name,
 			Description: p.Description,
+			Schemas:     p.Schemas,
 		}
 	}
 	return plans, nil

--- a/service/broker_service.go
+++ b/service/broker_service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/storage"
 	serviceTypes "github.com/tsuru/tsuru/types/service"
 )
@@ -60,10 +61,12 @@ func getBrokeredServices() ([]Service, error) {
 	for _, b := range brokers {
 		c, err := newClient(b, "")
 		if err != nil {
+			log.Errorf("[Broker=%v] error creating broker client: %v.", b.Name, err)
 			continue
 		}
 		cat, err := c.client.GetCatalog()
 		if err != nil {
+			log.Errorf("[Broker=%v] error getting catalog: %v.", b.Name, err)
 			continue
 		}
 		for _, s := range cat.Services {

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -398,3 +398,23 @@ func (s *S) TestBrokerClientUpdate(c *check.C) {
 	err = client.Update(&instance, ev, "request-id")
 	c.Assert(err, check.IsNil)
 }
+
+func (s *S) TestBrokerClientInfo(c *check.C) {
+	client, err := newClient(serviceTypes.Broker{Name: "broker"}, "service")
+	c.Assert(err, check.IsNil)
+	instance := ServiceInstance{
+		Name:      "my-instance",
+		PlanName:  "standard",
+		TeamOwner: "teamowner",
+		Parameters: map[string]interface{}{
+			"param1": "val1",
+			"param2": 4,
+		},
+	}
+	info, err := client.Info(&instance, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(info, check.DeepEquals, []map[string]string{
+		{"label": "param1", "value": "val1"},
+		{"label": "param2", "value": "4"},
+	})
+}

--- a/service/plan.go
+++ b/service/plan.go
@@ -4,10 +4,15 @@
 
 package service
 
+import (
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+)
+
 // Plan represents a service plan
 type Plan struct {
 	Name        string
 	Description string
+	Schemas     *osb.Schemas `json:",omitempty"`
 }
 
 func GetPlansByServiceName(serviceName, requestID string) ([]Plan, error) {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -193,7 +193,7 @@ func (si *ServiceInstance) BindApp(app bind.App, params BindAppParameters, shoul
 		app:             app,
 		writer:          writer,
 		shouldRestart:   shouldRestart,
-		params:          BindAppParameters{},
+		params:          params,
 		event:           evt,
 		requestID:       requestID,
 	}

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -163,7 +163,7 @@ func (s *InstanceSuite) TestBindApp(c *check.C) {
 		shouldRestart:   true,
 		event:           evt,
 		requestID:       "",
-		params:          BindAppParameters{},
+		params:          BindAppParameters(nil),
 	}}
 	c.Assert(calls, check.DeepEquals, expectedCalls)
 	c.Assert(params, check.DeepEquals, expectedParams)

--- a/storage/storagetest/service_broker_suite.go
+++ b/storage/storagetest/service_broker_suite.go
@@ -18,10 +18,12 @@ func (s *ServiceBrokerSuite) TestInsert(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}
@@ -36,10 +38,12 @@ func (s *ServiceBrokerSuite) TestInsertDuplicate(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}
@@ -53,31 +57,35 @@ func (s *ServiceBrokerSuite) TestUpdate(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}
 	err := s.ServiceBrokerStorage.Insert(broker)
 	c.Assert(err, check.IsNil)
-	broker.AuthConfig.BasicAuthConfig.Password = "new-password"
+	broker.Config.AuthConfig.BasicAuthConfig.Password = "new-password"
 	err = s.ServiceBrokerStorage.Update("broker", broker)
 	c.Assert(err, check.IsNil)
 	broker, err = s.ServiceBrokerStorage.Find("broker")
 	c.Assert(err, check.IsNil)
-	c.Assert(broker.AuthConfig.BasicAuthConfig.Password, check.Equals, "new-password")
+	c.Assert(broker.Config.AuthConfig.BasicAuthConfig.Password, check.Equals, "new-password")
 }
 
 func (s *ServiceBrokerSuite) TestUpdateNotFound(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}
@@ -89,10 +97,12 @@ func (s *ServiceBrokerSuite) TestDelete(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}
@@ -127,10 +137,12 @@ func (s *ServiceBrokerSuite) TestFind(c *check.C) {
 	broker := service.Broker{
 		Name: "broker",
 		URL:  "https://localhost:8080",
-		AuthConfig: &service.AuthConfig{
-			BasicAuthConfig: &service.BasicAuthConfig{
-				Username: "user",
-				Password: "password",
+		Config: service.BrokerConfig{
+			AuthConfig: &service.AuthConfig{
+				BasicAuthConfig: &service.BasicAuthConfig{
+					Username: "user",
+					Password: "password",
+				},
 			},
 		},
 	}

--- a/types/service/broker.go
+++ b/types/service/broker.go
@@ -20,8 +20,20 @@ type Broker struct {
 	Name string
 	// URL is the URL of the Service Broker API endpoint.
 	URL string
-	// AuthConfig is the credentials needed to interact with the API.
+	// Config is the configuration used to setup a client for the broker
+	Config BrokerConfig
+}
+
+// BrokerConfig exposes configuration used to talk to the broker API.
+// Most of the fields are copied from osb client definition.
+type BrokerConfig struct {
+	// AuthConfig is the auth configuration the client should use to authenticate
+	// to the broker.
 	AuthConfig *AuthConfig
+	// Insecure represents whether the 'InsecureSkipVerify' TLS configuration
+	// field should be set.  If the TLSConfig field is set and this field is
+	// set to true, it overrides the value in the TLSConfig field.
+	Insecure bool
 }
 
 // AuthConfig is a union-type representing the possible auth configurations a


### PR DESCRIPTION
Service from the Service Broker API support custom parameters for
instance creation and binding. This PR adds the parameters definition
to the Plan information and make it possible for the client to show them.


This PR continues the work done in #2086.