### PR TITLE
service/broker: Uses UUIDs for service broker operations

### DIFF
--- a/api/service_broker_test.go
+++ b/api/service_broker_test.go
@@ -36,8 +36,8 @@ func (s *S) TestServiceBrokerList(c *check.C) {
 	err = json.NewDecoder(recorder.Body).Decode(&response)
 	c.Assert(err, check.IsNil)
 	c.Assert(response["brokers"], check.DeepEquals, []service.Broker{
-		{Name: "broker-1", URL: "http://localhost:8080"},
-		{Name: "broker-2", URL: "http://localhost:8080"},
+		{Name: "broker-1", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
+		{Name: "broker-2", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
 	})
 }
 
@@ -70,6 +70,7 @@ func (s *S) TestServiceBrokerAdd(c *check.C) {
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
+			Context: map[string]interface{}{},
 		},
 	}
 	bodyData, err := form.EncodeToString(expectedBroker)
@@ -123,6 +124,7 @@ func (s *S) TestServiceBrokerUpdate(c *check.C) {
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
+			Context: map[string]interface{}{},
 		},
 	}
 	err := servicemanager.ServiceBroker.Create(broker)

--- a/app/app.go
+++ b/app/app.go
@@ -1347,16 +1347,16 @@ func (app *App) GetUUID() (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to generate uuid v4")
 	}
-	app.UUID = uuidV4.String()
 	conn, err := db.Conn()
 	if err != nil {
 		return "", err
 	}
 	defer conn.Close()
-	err = conn.Apps().Update(bson.M{"name": app.Name}, bson.M{"$set": bson.M{"uuid": app.UUID}})
+	err = conn.Apps().Update(bson.M{"name": app.Name}, bson.M{"$set": bson.M{"uuid": uuidV4.String()}})
 	if err != nil {
 		return "", err
 	}
+	app.UUID = uuidV4.String()
 	return app.UUID, nil
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5003,3 +5003,19 @@ func (s *S) TestUpdateAppUpdatableProvisioner(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(updatedApp.(*App).Description, check.Equals, "updated description")
 }
+
+func (s *S) TestGetUUID(c *check.C) {
+	app := App{Name: "test", TeamOwner: s.team.Name, Pool: s.Pool}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	c.Assert(app.UUID, check.DeepEquals, "")
+	uuid, err := app.GetUUID()
+	c.Assert(err, check.IsNil)
+	c.Assert(uuid, check.Not(check.DeepEquals), "")
+	c.Assert(uuid, check.DeepEquals, app.UUID)
+	var storedApp App
+	err = s.conn.Apps().Find(bson.M{"name": app.Name}).One(&storedApp)
+	c.Assert(err, check.IsNil)
+	c.Assert(storedApp.UUID, check.Not(check.DeepEquals), "")
+	c.Assert(storedApp.UUID, check.DeepEquals, uuid)
+}

--- a/app/bind/binder.go
+++ b/app/bind/binder.go
@@ -34,6 +34,9 @@ type App interface {
 	// GetName returns the app name.
 	GetName() string
 
+	// GetUUID returns the App v4 UUID
+	GetUUID() (string, error)
+
 	// GetUnits returns the app units.
 	GetUnits() ([]Unit, error)
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
+	uuid "github.com/nu7hatch/gouuid"
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/app/bind"
@@ -51,6 +52,7 @@ func init() {
 // Fake implementation for provision.App.
 type FakeApp struct {
 	name           string
+	uuid           string
 	cname          []string
 	IP             string
 	platform       string
@@ -247,6 +249,17 @@ func (a *FakeApp) Log(message, source, unit string) error {
 
 func (a *FakeApp) GetName() string {
 	return a.name
+}
+
+func (a *FakeApp) GetUUID() (string, error) {
+	if a.uuid != "" {
+		return a.uuid, nil
+	}
+	uuidV4, err := uuid.NewV4()
+	if err != nil {
+		return "", errors.WithMessage(err, "failed to generate uuid v4")
+	}
+	return uuidV4.String(), nil
 }
 
 func (a *FakeApp) GetPool() string {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -259,7 +259,8 @@ func (a *FakeApp) GetUUID() (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to generate uuid v4")
 	}
-	return uuidV4.String(), nil
+	a.uuid = uuidV4.String()
+	return a.uuid, nil
 }
 
 func (a *FakeApp) GetPool() string {

--- a/service/actions.go
+++ b/service/actions.go
@@ -37,9 +37,9 @@ var notifyCreateServiceInstance = action.Action{
 		if err != nil {
 			return nil, err
 		}
-		instance, ok := ctx.Params[1].(ServiceInstance)
+		instance, ok := ctx.Params[1].(*ServiceInstance)
 		if !ok {
-			return nil, errors.New("Second parameter must be a ServiceInstance.")
+			return nil, errors.New("Second parameter must be a *ServiceInstance.")
 		}
 		evt, ok := ctx.Params[2].(*event.Event)
 		if !ok {
@@ -49,7 +49,7 @@ var notifyCreateServiceInstance = action.Action{
 		if !ok {
 			return nil, errors.New("RequestID should be a string.")
 		}
-		err = endpoint.Create(&instance, evt, requestID)
+		err = endpoint.Create(instance, evt, requestID)
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +64,7 @@ var notifyCreateServiceInstance = action.Action{
 		if err != nil {
 			return
 		}
-		instance, ok := ctx.Params[1].(ServiceInstance)
+		instance, ok := ctx.Params[1].(*ServiceInstance)
 		if !ok {
 			return
 		}
@@ -76,7 +76,7 @@ var notifyCreateServiceInstance = action.Action{
 		if !ok {
 			return
 		}
-		endpoint.Destroy(&instance, evt, requestID)
+		endpoint.Destroy(instance, evt, requestID)
 	},
 	MinParams: 3,
 }
@@ -87,19 +87,19 @@ var notifyCreateServiceInstance = action.Action{
 var createServiceInstance = action.Action{
 	Name: "create-service-instance",
 	Forward: func(ctx action.FWContext) (action.Result, error) {
-		instance, ok := ctx.Params[1].(ServiceInstance)
+		instance, ok := ctx.Params[1].(*ServiceInstance)
 		if !ok {
-			return nil, errors.New("Second parameter must be a ServiceInstance.")
+			return nil, errors.New("Second parameter must be a *ServiceInstance.")
 		}
 		conn, err := db.Conn()
 		if err != nil {
 			return nil, err
 		}
 		defer conn.Close()
-		return nil, conn.ServiceInstances().Insert(&instance)
+		return nil, conn.ServiceInstances().Insert(instance)
 	},
 	Backward: func(ctx action.BWContext) {
-		instance, ok := ctx.Params[1].(ServiceInstance)
+		instance, ok := ctx.Params[1].(*ServiceInstance)
 		if !ok {
 			return
 		}

--- a/service/actions_test.go
+++ b/service/actions_test.go
@@ -40,11 +40,11 @@ func (s *S) TestNotifyCreateServiceInstanceForward(c *check.C) {
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{srv, instance, evt, ""},
+		Params: []interface{}{srv, &instance, evt, ""},
 	}
 	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
-	a, ok := r.(ServiceInstance)
+	a, ok := r.(*ServiceInstance)
 	c.Assert(ok, check.Equals, true)
 	c.Assert(a.Name, check.Equals, instance.Name)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
@@ -67,9 +67,9 @@ func (s *S) TestNotifyCreateServiceInstanceForwardInvalidParams(c *check.C) {
 	ctx = action.FWContext{Params: []interface{}{srv, "", ""}}
 	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
+	c.Assert(err.Error(), check.Equals, "Second parameter must be a *ServiceInstance.")
 	instance := ServiceInstance{Name: "mysql"}
-	ctx = action.FWContext{Params: []interface{}{srv, instance, 1}}
+	ctx = action.FWContext{Params: []interface{}{srv, &instance, 1}}
 	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Third parameter must be an event.")
@@ -87,7 +87,7 @@ func (s *S) TestNotifyCreateServiceInstanceBackward(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
-	ctx := action.BWContext{Params: []interface{}{srv, instance, evt, "test"}}
+	ctx := action.BWContext{Params: []interface{}{srv, &instance, evt, "test"}}
 	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
 }
@@ -122,7 +122,7 @@ func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 	srv := Service{Name: "mongodb"}
 	instance := ServiceInstance{Name: "mysql"}
 	ctx := action.FWContext{
-		Params: []interface{}{srv, instance},
+		Params: []interface{}{srv, &instance},
 	}
 	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -134,7 +134,7 @@ func (s *S) TestCreateServiceInstanceForwardParams(c *check.C) {
 	ctx := action.FWContext{Params: []interface{}{"", ""}}
 	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
+	c.Assert(err.Error(), check.Equals, "Second parameter must be a *ServiceInstance.")
 }
 
 func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
@@ -143,7 +143,7 @@ func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
 	err := s.conn.ServiceInstances().Insert(&instance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
-		Params: []interface{}{srv, instance},
+		Params: []interface{}{srv, &instance},
 	}
 	createServiceInstance.Backward(ctx)
 	err = s.conn.ServiceInstances().Find(bson.M{"name": instance.Name}).One(&instance)
@@ -254,11 +254,11 @@ func (s *S) TestNotifyUpdateServiceInstanceForward(c *check.C) {
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{srv, instance, evt, ""},
+		Params: []interface{}{srv, &instance, evt, ""},
 	}
 	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
-	a, ok := r.(ServiceInstance)
+	a, ok := r.(*ServiceInstance)
 	c.Assert(ok, check.Equals, true)
 	c.Assert(a.Name, check.Equals, instance.Name)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))

--- a/service/broker.go
+++ b/service/broker.go
@@ -111,8 +111,8 @@ func (b *brokerClient) Create(instance *ServiceInstance, evt *event.Event, reque
 		Context: map[string]interface{}{
 			"request_id":        requestID,
 			"event_id":          evt.UniqueID.Hex(),
-			"organization_guid": instance.TeamOwner,
-			"space_guid":        instance.TeamOwner,
+			"organization_guid": instance.BrokerData.OrgID,
+			"space_guid":        instance.BrokerData.SpaceID,
 		},
 	}
 	resp, err := b.client.ProvisionInstance(&req)

--- a/service/broker.go
+++ b/service/broker.go
@@ -89,17 +89,23 @@ func (b *brokerClient) Create(instance *ServiceInstance, evt *event.Event, reque
 	if err != nil {
 		return errors.WithMessage(err, "failed to generate instance uuid")
 	}
+	orgID, err := uuid.NewV4()
+	if err != nil {
+		return errors.WithMessage(err, "failed to generate org/space uuid")
+	}
 	instance.BrokerData = &BrokerInstanceData{
 		UUID:      uid.String(),
 		ServiceID: s.ID,
 		PlanID:    plan.ID,
+		OrgID:     orgID.String(),
+		SpaceID:   orgID.String(),
 	}
 	req := osb.ProvisionRequest{
 		InstanceID:          instance.BrokerData.UUID,
 		ServiceID:           instance.BrokerData.ServiceID,
 		PlanID:              instance.BrokerData.PlanID,
-		OrganizationGUID:    instance.TeamOwner,
-		SpaceGUID:           instance.TeamOwner,
+		OrganizationGUID:    instance.BrokerData.OrgID,
+		SpaceGUID:           instance.BrokerData.SpaceID,
 		Parameters:          instance.Parameters,
 		OriginatingIdentity: id,
 		Context: map[string]interface{}{
@@ -154,6 +160,8 @@ func (b *brokerClient) Update(instance *ServiceInstance, evt *event.Event, reque
 		PreviousValues: &osb.PreviousValues{
 			PlanID:    instance.BrokerData.PlanID,
 			ServiceID: instance.BrokerData.ServiceID,
+			OrgID:     instance.BrokerData.OrgID,
+			SpaceID:   instance.BrokerData.SpaceID,
 		},
 	}
 	instance.BrokerData.PlanID = plan.ID

--- a/service/broker.go
+++ b/service/broker.go
@@ -115,6 +115,9 @@ func (b *brokerClient) Create(instance *ServiceInstance, evt *event.Event, reque
 			"space_guid":        instance.BrokerData.SpaceID,
 		},
 	}
+	for k, v := range b.broker.Config.Context {
+		req.Context[k] = v
+	}
 	resp, err := b.client.ProvisionInstance(&req)
 	if osb.IsAsyncRequiredError(err) {
 		// We only set AcceptsIncomplete when it is required because some Brokers fail when
@@ -163,6 +166,9 @@ func (b *brokerClient) Update(instance *ServiceInstance, evt *event.Event, reque
 			OrgID:     instance.BrokerData.OrgID,
 			SpaceID:   instance.BrokerData.SpaceID,
 		},
+	}
+	for k, v := range b.broker.Config.Context {
+		req.Context[k] = v
 	}
 	instance.BrokerData.PlanID = plan.ID
 	instance.BrokerData.ServiceID = s.ID
@@ -249,6 +255,9 @@ func (b *brokerClient) BindApp(instance *ServiceInstance, app bind.App, params B
 			"event_id":   evt.UniqueID.Hex(),
 		},
 		AcceptsIncomplete: true,
+	}
+	for k, v := range b.broker.Config.Context {
+		req.Context[k] = v
 	}
 	resp, err := b.client.Bind(&req)
 	if osb.IsAsyncBindingOperationsNotAllowedError(err) {

--- a/service/broker.go
+++ b/service/broker.go
@@ -421,10 +421,6 @@ func newService(broker serviceTypes.Broker, osbservice osb.Service) Service {
 	}
 }
 
-func getBindingID(instance *ServiceInstance, app bind.App) string {
-	return fmt.Sprintf("%s-%s", instance.Name, app.GetName())
-}
-
 func idForEvent(evt *event.Event) (*osb.OriginatingIdentity, error) {
 	identity, err := json.Marshal(map[string]interface{}{
 		"user": evt.Owner.Name,

--- a/service/broker.go
+++ b/service/broker.go
@@ -179,8 +179,11 @@ func (b *brokerClient) BindApp(instance *ServiceInstance, app bind.App, params B
 	if err != nil {
 		return nil, err
 	}
-	appName := app.GetName()
 	id, err := idForEvent(evt)
+	if err != nil {
+		return nil, err
+	}
+	appGUID, err := app.GetUUID()
 	if err != nil {
 		return nil, err
 	}
@@ -189,11 +192,11 @@ func (b *brokerClient) BindApp(instance *ServiceInstance, app bind.App, params B
 		InstanceID:          instance.Name,
 		PlanID:              plan.ID,
 		BindingID:           getBindingID(instance, app),
-		AppGUID:             &appName,
+		AppGUID:             &appGUID,
 		Parameters:          params,
 		OriginatingIdentity: id,
 		BindResource: &osb.BindResource{
-			AppGUID: &appName,
+			AppGUID: &appGUID,
 		},
 		Context: map[string]interface{}{
 			"request_id": requestID,

--- a/service/broker_service_test.go
+++ b/service/broker_service_test.go
@@ -105,7 +105,19 @@ func (s *BrokerSuite) TestServiceBrokerList(c *check.C) {
 	brokers, err := s.service.List()
 	c.Assert(err, check.IsNil)
 	c.Assert(brokers, check.DeepEquals, []service.Broker{
-		{Name: "broker-name", URL: "https://localhost:8080"},
-		{Name: "broker-2", URL: "https://localhost:9090"},
+		{
+			Name: "broker-name",
+			URL:  "https://localhost:8080",
+			Config: service.BrokerConfig{
+				Context: map[string]interface{}{},
+			},
+		},
+		{
+			Name: "broker-2",
+			URL:  "https://localhost:9090",
+			Config: service.BrokerConfig{
+				Context: map[string]interface{}{},
+			},
+		},
 	})
 }

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -130,6 +130,7 @@ func (s *S) TestBrokerClientStatus(c *check.C) {
 			"team": "teamOwner",
 		})
 		c.Assert(err, check.IsNil)
+		opKey := osb.OperationKey("")
 		c.Assert(req, check.DeepEquals, &osb.LastOperationRequest{
 			InstanceID: "e7252f14-54be-45df-bd40-e988a0e41059",
 			ServiceID:  &sID,
@@ -138,6 +139,7 @@ func (s *S) TestBrokerClientStatus(c *check.C) {
 				Platform: "tsuru",
 				Value:    string(exID),
 			},
+			OperationKey: &opKey,
 		})
 		alldone := "last operation done!"
 		return &osb.LastOperationResponse{
@@ -353,7 +355,8 @@ func (s *S) TestBrokerClientUpdate(c *check.C) {
 				PlanID:    "p1",
 			},
 		})
-		return nil, nil
+		opKey := osb.OperationKey("Provisioning")
+		return &osb.UpdateInstanceResponse{OperationKey: &opKey}, nil
 	}
 	config := osbfake.FakeClientConfiguration{
 		UpdateInstanceReaction: osbfake.DynamicUpdateInstanceReaction(reaction),
@@ -379,9 +382,10 @@ func (s *S) TestBrokerClientUpdate(c *check.C) {
 	storedInstance, err := GetServiceInstance(instance.ServiceName, instance.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(storedInstance.BrokerData, check.DeepEquals, &BrokerInstanceData{
-		UUID:      "e7252f14-54be-45df-bd40-e988a0e41059",
-		ServiceID: "serviceid",
-		PlanID:    "planid",
+		UUID:             "e7252f14-54be-45df-bd40-e988a0e41059",
+		ServiceID:        "serviceid",
+		PlanID:           "planid",
+		LastOperationKey: "Provisioning",
 	})
 }
 

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -48,12 +48,14 @@ func (s *S) TestBrokerClientCreate(c *check.C) {
 		})
 		c.Assert(err, check.IsNil)
 		c.Assert(req.InstanceID, check.Not(check.DeepEquals), "")
+		c.Assert(req.OrganizationGUID, check.Not(check.DeepEquals), "")
+		c.Assert(req.SpaceGUID, check.Not(check.DeepEquals), "")
 		req.InstanceID = ""
+		req.OrganizationGUID = ""
+		req.SpaceGUID = ""
 		c.Assert(req, check.DeepEquals, &osb.ProvisionRequest{
-			PlanID:           "planid",
-			ServiceID:        "serviceid",
-			OrganizationGUID: "teamOwner",
-			SpaceGUID:        "teamOwner",
+			PlanID:    "planid",
+			ServiceID: "serviceid",
 			OriginatingIdentity: &osb.OriginatingIdentity{
 				Platform: "tsuru",
 				Value:    string(exID),

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -47,6 +47,7 @@ func (s *S) TestBrokerClientCreate(c *check.C) {
 			"user": "my@user",
 		})
 		c.Assert(err, check.IsNil)
+		orgID := req.OrganizationGUID
 		c.Assert(req.InstanceID, check.Not(check.DeepEquals), "")
 		c.Assert(req.OrganizationGUID, check.Not(check.DeepEquals), "")
 		c.Assert(req.SpaceGUID, check.Not(check.DeepEquals), "")
@@ -63,8 +64,8 @@ func (s *S) TestBrokerClientCreate(c *check.C) {
 			Context: map[string]interface{}{
 				"request_id":        "request-id",
 				"event_id":          ev.UniqueID.Hex(),
-				"organization_guid": "teamOwner",
-				"space_guid":        "teamOwner",
+				"organization_guid": orgID,
+				"space_guid":        orgID,
 			},
 		})
 		return nil, nil

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -230,7 +230,9 @@ func (s *S) TestBrokerClientDestroy(c *check.C) {
 
 func (s *S) TestBrokerClientBindApp(c *check.C) {
 	ev := createEvt(c)
-	appName := "theapp"
+	a := provisiontest.NewFakeApp("theapp", "python", 1)
+	appGUID, err := a.GetUUID()
+	c.Assert(err, check.IsNil)
 	reaction := func(req *osb.BindRequest) (*osb.BindResponse, error) {
 		exID, err := json.Marshal(map[string]interface{}{
 			"user": "my@user",
@@ -242,9 +244,9 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 			ServiceID:         "s1",
 			PlanID:            "p1",
 			BindingID:         "instance-theapp",
-			AppGUID:           &appName,
+			AppGUID:           &appGUID,
 			BindResource: &osb.BindResource{
-				AppGUID: &appName,
+				AppGUID: &appGUID,
 			},
 			OriginatingIdentity: &osb.OriginatingIdentity{
 				Platform: "tsuru",
@@ -287,7 +289,6 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 		PlanName:    "plan1",
 		TeamOwner:   "teamOwner",
 	}
-	a := provisiontest.NewFakeApp("theapp", "python", 1)
 	params := BindAppParameters(map[string]interface{}{
 		"param1": "val1",
 	})

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -66,6 +66,7 @@ func (s *S) TestBrokerClientCreate(c *check.C) {
 				"event_id":          ev.UniqueID.Hex(),
 				"organization_guid": orgID,
 				"space_guid":        orgID,
+				"Namespace":         "broker-namespace",
 			},
 		})
 		return nil, nil
@@ -81,7 +82,14 @@ func (s *S) TestBrokerClientCreate(c *check.C) {
 		},
 	}
 	ClientFactory = osbfake.NewFakeClientFunc(config)
-	client, err := newClient(serviceTypes.Broker{Name: "broker"}, "service")
+	client, err := newClient(serviceTypes.Broker{
+		Name: "broker",
+		Config: serviceTypes.BrokerConfig{
+			Context: map[string]interface{}{
+				"Namespace": "broker-namespace",
+			},
+		},
+	}, "service")
 	c.Assert(err, check.IsNil)
 	instance := createTestInstance()
 	err = client.Create(&instance, ev, "request-id")
@@ -249,6 +257,7 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 			Context: map[string]interface{}{
 				"request_id": "request-id",
 				"event_id":   ev.UniqueID.Hex(),
+				"Namespace":  "broker-namespace",
 			},
 			Parameters: map[string]interface{}{
 				"param1": "val1",
@@ -278,7 +287,14 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 		BindReaction: osbfake.DynamicBindReaction(reaction),
 	}
 	ClientFactory = osbfake.NewFakeClientFunc(config)
-	client, err := newClient(serviceTypes.Broker{Name: "broker"}, "service")
+	client, err := newClient(serviceTypes.Broker{
+		Name: "broker",
+		Config: serviceTypes.BrokerConfig{
+			Context: map[string]interface{}{
+				"Namespace": "broker-namespace",
+			},
+		},
+	}, "service")
 	c.Assert(err, check.IsNil)
 	instance := createTestInstance()
 	err = s.conn.ServiceInstances().Insert(&instance)

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -234,10 +234,10 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	var bindID string
 	reaction := func(req *osb.BindRequest) (*osb.BindResponse, error) {
-		exID, err := json.Marshal(map[string]interface{}{
+		exID, errMarshal := json.Marshal(map[string]interface{}{
 			"user": "my@user",
 		})
-		c.Assert(err, check.IsNil)
+		c.Assert(errMarshal, check.IsNil)
 		c.Assert(req.BindingID, check.Not(check.DeepEquals), "")
 		bindID = req.BindingID
 		req.BindingID = ""
@@ -317,7 +317,7 @@ func (s *S) TestBrokerClientBindApp(c *check.C) {
 		PlanID:           "p1",
 		LastOperationKey: "Binding",
 		Binds: map[string]BrokerInstanceBind{
-			"theapp": BrokerInstanceBind{
+			"theapp": {
 				UUID:         bindID,
 				OperationKey: "Binding",
 				Parameters:   params,
@@ -366,7 +366,7 @@ func (s *S) TestBrokerClientUnbindApp(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instance := createTestInstance()
 	instance.BrokerData.Binds = map[string]BrokerInstanceBind{
-		"theapp": BrokerInstanceBind{
+		"theapp": {
 			UUID: "xxxx-xxxx",
 		},
 	}

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -61,6 +61,15 @@ type BrokerInstanceData struct {
 	ServiceID        string
 	PlanID           string
 	LastOperationKey string
+
+	Binds map[string]BrokerInstanceBind
+}
+
+type BrokerInstanceBind struct {
+	// UUID is a v4 UUID generated when binding
+	UUID         string
+	OperationKey string
+	Parameters   map[string]interface{}
 }
 
 type Unit struct {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -60,6 +60,8 @@ type BrokerInstanceData struct {
 	UUID             string
 	ServiceID        string
 	PlanID           string
+	OrgID            string
+	SpaceID          string
 	LastOperationKey string
 
 	Binds map[string]BrokerInstanceBind

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -57,10 +57,10 @@ type ServiceInstance struct {
 
 type BrokerInstanceData struct {
 	// UUID is a v4 UUID generated for this Instance on creation
-	UUID string
-
-	ServiceID string
-	PlanID    string
+	UUID             string
+	ServiceID        string
+	PlanID           string
+	LastOperationKey string
 }
 
 type Unit struct {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -50,6 +50,14 @@ type ServiceInstance struct {
 	Description string                 `json:"description"`
 	Tags        []string               `json:"tags"`
 	Parameters  map[string]interface{} `json:"parameters,omitempty"`
+
+	// BrokerData stores data used by Instances provisioned by Brokers
+	BrokerData *BrokerInstanceData `json:"broker_data,omitempty" bson:"broker_data"`
+}
+
+type BrokerInstanceData struct {
+	// UUID is a v4 UUID generated for this Instance on creation
+	UUID string
 }
 
 type Unit struct {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -456,7 +456,7 @@ func CreateServiceInstance(instance ServiceInstance, service *Service, evt *even
 	instance.Tags = processTags(instance.Tags)
 	actions := []*action.Action{&notifyCreateServiceInstance, &createServiceInstance}
 	pipeline := action.NewPipeline(actions...)
-	return pipeline.Execute(*service, instance, evt, requestID)
+	return pipeline.Execute(*service, &instance, evt, requestID)
 }
 
 func GetServiceInstancesByServices(services []Service) ([]ServiceInstance, error) {

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -58,6 +58,9 @@ type ServiceInstance struct {
 type BrokerInstanceData struct {
 	// UUID is a v4 UUID generated for this Instance on creation
 	UUID string
+
+	ServiceID string
+	PlanID    string
 }
 
 type Unit struct {

--- a/storage/storagetest/service_broker_suite.go
+++ b/storage/storagetest/service_broker_suite.go
@@ -25,6 +25,9 @@ func (s *ServiceBrokerSuite) TestInsert(c *check.C) {
 					Password: "password",
 				},
 			},
+			Context: map[string]interface{}{
+				"Namespace": "broker-namespace",
+			},
 		},
 	}
 	err := s.ServiceBrokerStorage.Insert(broker)
@@ -143,6 +146,9 @@ func (s *ServiceBrokerSuite) TestFind(c *check.C) {
 					Username: "user",
 					Password: "password",
 				},
+			},
+			Context: map[string]interface{}{
+				"Namespace": "broker-namespace",
 			},
 		},
 	}

--- a/types/service/broker.go
+++ b/types/service/broker.go
@@ -34,6 +34,9 @@ type BrokerConfig struct {
 	// field should be set.  If the TLSConfig field is set and this field is
 	// set to true, it overrides the value in the TLSConfig field.
 	Insecure bool
+	// Context is a set of key/value pairs that are going to be added to every
+	// request to the Service Broker
+	Context map[string]interface{}
 }
 
 // AuthConfig is a union-type representing the possible auth configurations a


### PR DESCRIPTION
Service Brokers requires that GUIDs and IDs are actual v4 UUIDs.
This PR creates a UUID field that is lazily generated for apps,
generates UUIDs for service instances and also stores broker instances
data inside the service instance data structure.