### PR TITLE
Defining ResourceCPU from CpuShare() on app deploy spec

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -525,6 +525,11 @@ func createAppDeployment(client *ClusterClient, oldDeployment *v1beta2.Deploymen
 		resourceLimits[apiv1.ResourceMemory] = *resource.NewQuantity(memory, resource.BinarySI)
 		resourceRequests[apiv1.ResourceMemory] = *resource.NewQuantity(memory/overcommit, resource.BinarySI)
 	}
+	cpu := int64(a.GetCpuShare())
+	if cpu != 0 {
+		resourceLimits[apiv1.ResourceCPU] = *resource.NewMilliQuantity(cpu, resource.BinarySI)
+		resourceRequests[apiv1.ResourceCPU] = *resource.NewMilliQuantity(cpu/overcommit, resource.BinarySI)
+	}
 	volumes, mounts, err := createVolumesForApp(client, a)
 	if err != nil {
 		return nil, nil, nil, err

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -990,7 +990,10 @@ func (s *S) TestServiceManagerDeployServiceWithResourceRequirements(c *check.C) 
 	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err := app.CreateApp(a, s.user)
 	c.Assert(err, check.IsNil)
-	a.Plan = appTypes.Plan{Memory: 1024}
+	a.Plan = appTypes.Plan{
+		Memory:   1024,
+		CpuShare: 200,
+	}
 	err = image.SaveImageCustomData("myimg", map[string]interface{}{
 		"processes": map[string]interface{}{
 			"p1": "cm1",
@@ -1006,12 +1009,15 @@ func (s *S) TestServiceManagerDeployServiceWithResourceRequirements(c *check.C) 
 	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedMemory := resource.NewQuantity(1024, resource.BinarySI)
+	expectedCPU := resource.NewMilliQuantity(200, resource.BinarySI)
 	c.Assert(dep.Spec.Template.Spec.Containers[0].Resources, check.DeepEquals, apiv1.ResourceRequirements{
 		Limits: apiv1.ResourceList{
 			apiv1.ResourceMemory: *expectedMemory,
+			apiv1.ResourceCPU:    *expectedCPU,
 		},
 		Requests: apiv1.ResourceList{
 			apiv1.ResourceMemory: *expectedMemory,
+			apiv1.ResourceCPU:    *expectedCPU,
 		},
 	})
 }

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -168,8 +168,12 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 								{Name: "PORT", Value: "8888"},
 							},
 							Resources: apiv1.ResourceRequirements{
-								Limits:   apiv1.ResourceList{},
-								Requests: apiv1.ResourceList{},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU: resource.NewMilliQuantity(100, resource.BinarySI),
+								},
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU: resource.NewMilliQuantity(100, resource.BinarySI),
+								},
 							},
 							Ports: []apiv1.ContainerPort{
 								{ContainerPort: 8888},

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -169,10 +169,10 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 							},
 							Resources: apiv1.ResourceRequirements{
 								Limits: apiv1.ResourceList{
-									apiv1.ResourceCPU: resource.NewMilliQuantity(100, resource.BinarySI),
+									apiv1.ResourceCPU: *resource.NewMilliQuantity(100, resource.BinarySI),
 								},
 								Requests: apiv1.ResourceList{
-									apiv1.ResourceCPU: resource.NewMilliQuantity(100, resource.BinarySI),
+									apiv1.ResourceCPU: *resource.NewMilliQuantity(100, resource.BinarySI),
 								},
 							},
 							Ports: []apiv1.ContainerPort{


### PR DESCRIPTION
Add ResourceCPU on Kubernetes deployment spec. 
A plan with cpushare of 200 will result in 200m or 0.2.