### PR TITLE
provision/kubernetes: replace invalid characters from pool name

### DIFF
--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -179,7 +178,8 @@ func (c *ClusterClient) PoolNamespace(pool string) string {
 	if c.CustomData != nil && c.CustomData[namespaceClusterKey] != "" {
 		prefix = c.CustomData[namespaceClusterKey]
 	}
-	nsPool := strings.Replace(pool, "_", "-", -1)
+	// Replace invalid characters from the pool name, to keep compatibility with older tsuru versions
+	nsPool := validKubeName(pool)
 	if usePoolNamespaces && len(nsPool) > 0 {
 		return fmt.Sprintf("%s-%s", prefix, nsPool)
 	}

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -178,8 +179,9 @@ func (c *ClusterClient) PoolNamespace(pool string) string {
 	if c.CustomData != nil && c.CustomData[namespaceClusterKey] != "" {
 		prefix = c.CustomData[namespaceClusterKey]
 	}
-	if usePoolNamespaces && len(pool) > 0 {
-		return fmt.Sprintf("%s-%s", prefix, pool)
+	nsPool := strings.Replace(pool, "_", "-", -1)
+	if usePoolNamespaces && len(nsPool) > 0 {
+		return fmt.Sprintf("%s-%s", prefix, nsPool)
 	}
 	return prefix
 }

--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -191,6 +191,15 @@ func (s *S) TestClusterNamespacePerPool(c *check.C) {
 	c.Assert(client.PoolNamespace(""), check.Equals, "tsuru")
 }
 
+func (s *S) TestClusterNamespacePerPoolWithUnderscores(c *check.C) {
+	config.Set("kubernetes:use-pool-namespaces", true)
+	defer config.Unset("kubernetes:use-pool-namespaces")
+	c1 := provTypes.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": "tsuru"}}
+	client, err := NewClusterClient(&c1)
+	c.Assert(err, check.IsNil)
+	c.Assert(client.PoolNamespace("my_pool"), check.Equals, "tsuru-my-pool")
+}
+
 func (s *S) TestClusterOvercommitFactor(c *check.C) {
 	c1 := provTypes.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{
 		"overcommit-factor":         "2",

--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -191,13 +191,13 @@ func (s *S) TestClusterNamespacePerPool(c *check.C) {
 	c.Assert(client.PoolNamespace(""), check.Equals, "tsuru")
 }
 
-func (s *S) TestClusterNamespacePerPoolWithUnderscores(c *check.C) {
+func (s *S) TestClusterNamespacePerPoolWithInvalidCharacters(c *check.C) {
 	config.Set("kubernetes:use-pool-namespaces", true)
 	defer config.Unset("kubernetes:use-pool-namespaces")
 	c1 := provTypes.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{"namespace": "tsuru"}}
 	client, err := NewClusterClient(&c1)
 	c.Assert(err, check.IsNil)
-	c.Assert(client.PoolNamespace("my_pool"), check.Equals, "tsuru-my-pool")
+	c.Assert(client.PoolNamespace("my_pool has *INVALID* chars"), check.Equals, "tsuru-my-pool-has--invalid--chars")
 }
 
 func (s *S) TestClusterOvercommitFactor(c *check.C) {

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -42,25 +42,29 @@ const (
 
 var kubeNameRegex = regexp.MustCompile(`(?i)[^a-z0-9.-]`)
 
+func validKubeName(name string) string {
+	return strings.ToLower(kubeNameRegex.ReplaceAllString(name, "-"))
+}
+
 func serviceAccountNameForApp(a provision.App) string {
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
+	name := validKubeName(a.GetName())
 	return fmt.Sprintf("app-%s", name)
 }
 
 func serviceAccountNameForNodeContainer(nodeContainer nodecontainer.NodeContainerConfig) string {
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(nodeContainer.Name, "-"))
+	name := validKubeName(nodeContainer.Name)
 	return fmt.Sprintf("node-container-%s", name)
 }
 
 func deploymentNameForApp(a provision.App, process string) string {
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
-	process = strings.ToLower(kubeNameRegex.ReplaceAllString(process, "-"))
+	name := validKubeName(a.GetName())
+	process = validKubeName(process)
 	return fmt.Sprintf("%s-%s", name, process)
 }
 
 func headlessServiceNameForApp(a provision.App, process string) string {
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
-	process = strings.ToLower(kubeNameRegex.ReplaceAllString(process, "-"))
+	name := validKubeName(a.GetName())
+	process = validKubeName(process)
 	return fmt.Sprintf("%s-%s-units", name, process)
 }
 
@@ -69,7 +73,7 @@ func deployPodNameForApp(a provision.App) (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to retrieve app current image version")
 	}
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
+	name := validKubeName(a.GetName())
 	return fmt.Sprintf("%s-%s-deploy", name, version), nil
 }
 
@@ -78,7 +82,7 @@ func buildPodNameForApp(a provision.App, suffix string) (string, error) {
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to retrieve app current image version")
 	}
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
+	name := validKubeName(a.GetName())
 	if suffix != "" {
 		return fmt.Sprintf("%s-%s-build-%s", name, version, suffix), nil
 	}
@@ -86,13 +90,13 @@ func buildPodNameForApp(a provision.App, suffix string) (string, error) {
 }
 
 func execCommandPodNameForApp(a provision.App) string {
-	name := strings.ToLower(kubeNameRegex.ReplaceAllString(a.GetName(), "-"))
+	name := validKubeName(a.GetName())
 	return fmt.Sprintf("%s-isolated-run", name)
 }
 
 func daemonSetName(name, pool string) string {
-	name = strings.ToLower(kubeNameRegex.ReplaceAllString(name, "-"))
-	pool = strings.ToLower(kubeNameRegex.ReplaceAllString(pool, "-"))
+	name = validKubeName(name)
+	pool = validKubeName(pool)
 	if pool == "" {
 		return fmt.Sprintf("node-container-%s-all", name)
 	}
@@ -108,7 +112,7 @@ func volumeClaimName(name string) string {
 }
 
 func registrySecretName(registry string) string {
-	registry = strings.ToLower(kubeNameRegex.ReplaceAllString(registry, "-"))
+	registry = validKubeName(registry)
 	return fmt.Sprintf("registry-%s", registry)
 }
 


### PR DESCRIPTION
Kubernetes namespaces don't allow underscores. Tsuru pool names don't either, but they did in previous versions. This PR avoids problems with pool names that contain this character.