### PR TITLE
Improve resilience when talking with galeb router api and service APIs.

### DIFF
--- a/api/apitest/setup.go
+++ b/api/apitest/setup.go
@@ -76,3 +76,9 @@ func (h *MultiTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(h.Content))
 	}
 }
+
+func (h *MultiTestHandler) WithLock(fn func()) {
+	h.mu.Lock()
+	fn()
+	h.mu.Unlock()
+}

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -661,6 +661,12 @@ routers:<router name>:use-token (type: galeb)
 If true, tsuru will get an authentication token by calling the /token route and
 reuse it until it expires. (Defaults to false)
 
+routers:<router name>:max-requests (type: galeb)
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+Maximum number of parallel requests to the Galeb API when adding or removing
+routes. (Defaults to unlimited)
+
 routers:<router name>:headers (type: api)
 +++++++++++++++++++++++++++++++++++++++++
 

--- a/net/client.go
+++ b/net/client.go
@@ -47,7 +47,8 @@ var (
 	Dial5Full60ClientNoKeepAliveNoRedirectInsecure = insecure(*Dial5Full60ClientNoKeepAliveNoRedirect)
 	Dial5Full60ClientNoKeepAliveInsecure           = insecure(*Dial5Full60ClientNoKeepAlive)
 
-	Dial10Full60ClientWithPool, _ = makeTimeoutHTTPClient(10*time.Second, 1*time.Minute, 10, true)
+	Dial10Full60ClientWithPool, _  = makeTimeoutHTTPClient(10*time.Second, 1*time.Minute, 10, true)
+	Dial10Full300ClientWithPool, _ = makeTimeoutHTTPClient(1*time.Second, 5*time.Minute, 10, true)
 )
 
 func insecure(client http.Client) http.Client {

--- a/net/client.go
+++ b/net/client.go
@@ -48,7 +48,7 @@ var (
 	Dial5Full60ClientNoKeepAliveInsecure           = insecure(*Dial5Full60ClientNoKeepAlive)
 
 	Dial10Full60ClientWithPool, _  = makeTimeoutHTTPClient(10*time.Second, 1*time.Minute, 10, true)
-	Dial10Full300ClientWithPool, _ = makeTimeoutHTTPClient(1*time.Second, 5*time.Minute, 10, true)
+	Dial10Full300ClientWithPool, _ = makeTimeoutHTTPClient(10*time.Second, 5*time.Minute, 10, true)
 )
 
 func insecure(client http.Client) http.Client {

--- a/net/client.go
+++ b/net/client.go
@@ -22,6 +22,7 @@ func makeTimeoutHTTPClient(dialTimeout time.Duration, fullTimeout time.Duration,
 			Dial:                dialer.Dial,
 			TLSHandshakeTimeout: dialTimeout,
 			MaxIdleConnsPerHost: maxIdle,
+			IdleConnTimeout:     15 * time.Second,
 		},
 		Timeout: fullTimeout,
 	}
@@ -45,6 +46,8 @@ var (
 	Dial5Full60ClientNoKeepAliveNoRedirect, _      = makeTimeoutHTTPClient(5*time.Second, 1*time.Minute, -1, false)
 	Dial5Full60ClientNoKeepAliveNoRedirectInsecure = insecure(*Dial5Full60ClientNoKeepAliveNoRedirect)
 	Dial5Full60ClientNoKeepAliveInsecure           = insecure(*Dial5Full60ClientNoKeepAlive)
+
+	Dial10Full60ClientWithPool, _ = makeTimeoutHTTPClient(10*time.Second, 1*time.Minute, 10, true)
 )
 
 func insecure(client http.Client) http.Client {

--- a/router/galeb/client/galeb_test.go
+++ b/router/galeb/client/galeb_test.go
@@ -200,6 +200,32 @@ func (s *S) TestGalebAuthTokenExpiredMaxRetries(c *check.C) {
 	c.Assert(s.handler.Header[6].Get("x-auth-token"), check.Equals, "abc")
 }
 
+func (s *S) TestGalebGetMaxRetries(c *check.C) {
+	s.handler.Hook = func(w http.ResponseWriter, r *http.Request) bool {
+		hj, ok := w.(http.Hijacker)
+		c.Assert(ok, check.Equals, true)
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+		return true
+	}
+	_, err := s.client.doRequest("GET", "/", nil)
+	c.Assert(err, check.NotNil)
+	c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/", "/api/", "/api/", "/api/"})
+}
+
+func (s *S) TestGalebPostNoRetry(c *check.C) {
+	s.handler.Hook = func(w http.ResponseWriter, r *http.Request) bool {
+		hj, ok := w.(http.Hijacker)
+		c.Assert(ok, check.Equals, true)
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+		return true
+	}
+	_, err := s.client.doRequest("POST", "/", nil)
+	c.Assert(err, check.NotNil)
+	c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/"})
+}
+
 func (s *S) TestGalebAuthTokenConcurrentRequests(c *check.C) {
 	s.handler.RspHeader = http.Header{
 		"x-auth-token": []string{"xyz"},

--- a/router/galeb/client/galeb_test.go
+++ b/router/galeb/client/galeb_test.go
@@ -210,7 +210,9 @@ func (s *S) TestGalebGetMaxRetries(c *check.C) {
 	}
 	_, err := s.client.doRequest("GET", "/", nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/", "/api/", "/api/", "/api/"})
+	s.handler.WithLock(func() {
+		c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/", "/api/", "/api/", "/api/"})
+	})
 }
 
 func (s *S) TestGalebPostNoRetry(c *check.C) {
@@ -223,7 +225,9 @@ func (s *S) TestGalebPostNoRetry(c *check.C) {
 	}
 	_, err := s.client.doRequest("POST", "/", nil)
 	c.Assert(err, check.NotNil)
-	c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/"})
+	s.handler.WithLock(func() {
+		c.Assert(s.handler.URL, check.DeepEquals, []string{"/api/"})
+	})
 }
 
 func (s *S) TestGalebAuthTokenConcurrentRequests(c *check.C) {

--- a/router/galeb/router.go
+++ b/router/galeb/router.go
@@ -52,6 +52,7 @@ func getClient(configPrefix string) (*galebClient.GalebClient, error) {
 	if err != nil {
 		waitTimeoutSec = 10 * 60
 	}
+	maxRequests, _ := config.GetInt(configPrefix + ":max-requests")
 	client := &galebClient.GalebClient{
 		ApiURL:        apiURL,
 		Username:      username,
@@ -64,6 +65,7 @@ func getClient(configPrefix string) (*galebClient.GalebClient, error) {
 		RuleType:      ruleType,
 		WaitTimeout:   time.Duration(waitTimeoutSec) * time.Second,
 		Debug:         debug,
+		MaxRequests:   maxRequests,
 	}
 	clientCache.cache[configPrefix] = client
 	return client, nil

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -402,7 +402,7 @@ func (c *endpointClient) issueRequest(path, method string, params map[string][]s
 	req.SetBasicAuth(c.username, c.password)
 	req.Close = true
 	t0 := time.Now()
-	resp, err := net.Dial5Full300ClientNoKeepAlive.Do(req)
+	resp, err := net.Dial10Full300ClientWithPool.Do(req)
 	requestLatencies.WithLabelValues(c.serviceName).Observe(time.Since(t0).Seconds())
 	if err != nil {
 		requestErrors.WithLabelValues(c.serviceName).Inc()


### PR DESCRIPTION
We now use a connection pool to talk to both galeb and service APIs, also galeb API GETs are retried after errors.
Also a new config flag was added to the Galeb router to limit the number of parallel connections.

With @guilhermebr.