### PR TITLE
router/galeb: ensure all resources are created even after a 409 response

### DIFF
--- a/router/galeb/client/galeb.go
+++ b/router/galeb/client/galeb.go
@@ -682,3 +682,11 @@ loop:
 	}
 	return nil
 }
+
+func IsErrExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := errors.Cause(err).(ErrItemAlreadyExists)
+	return ok
+}

--- a/router/galeb/client/galeb.go
+++ b/router/galeb/client/galeb.go
@@ -398,7 +398,15 @@ func (c *GalebClient) AddBackends(backends []*url.URL, poolName string) error {
 	return nil
 }
 
-func (c *GalebClient) AddRuleToID(name, poolID string) (string, error) {
+func (c *GalebClient) AddRuleToPool(name, poolName string) (string, error) {
+	id, err := c.findItemByName("pool", poolName)
+	if err != nil {
+		return "", err
+	}
+	return c.addRuleToID(name, id)
+}
+
+func (c *GalebClient) addRuleToID(name, poolID string) (string, error) {
 	var params Rule
 	c.fillDefaultRuleValues(&params)
 	params.Name = name
@@ -406,7 +414,7 @@ func (c *GalebClient) AddRuleToID(name, poolID string) (string, error) {
 	return c.doCreateResource("/rule", &params)
 }
 
-func (c *GalebClient) SetRuleVirtualHostIDs(ruleID, virtualHostID string) error {
+func (c *GalebClient) setRuleVirtualHostIDs(ruleID, virtualHostID string) error {
 	path := fmt.Sprintf("%s/parents", strings.TrimPrefix(ruleID, c.ApiURL))
 	rsp, err := c.doRequest("PATCH", path, virtualHostID)
 	if err != nil {
@@ -434,7 +442,7 @@ func (c *GalebClient) SetRuleVirtualHost(ruleName, virtualHostName string) error
 	if err != nil {
 		return err
 	}
-	return c.SetRuleVirtualHostIDs(ruleID, virtualHostID)
+	return c.setRuleVirtualHostIDs(ruleID, virtualHostID)
 }
 
 func (c *GalebClient) RemoveBackendByID(backendID string) error {

--- a/router/galeb/router.go
+++ b/router/galeb/router.go
@@ -124,7 +124,7 @@ func (r *galebRouter) AddBackend(app router.App) (err error) {
 		done(err)
 	}()
 	backendExists := false
-	backendPoolId, err := r.client.AddBackendPool(r.poolName(name))
+	_, err = r.client.AddBackendPool(r.poolName(name))
 	if galebClient.IsErrExists(err) {
 		backendExists = true
 	} else if err != nil {
@@ -140,7 +140,7 @@ func (r *galebRouter) AddBackend(app router.App) (err error) {
 		}
 		return err
 	}
-	_, err = r.client.AddRuleToID(r.ruleName(name), backendPoolId)
+	_, err = r.client.AddRuleToPool(r.ruleName(name), r.poolName(name))
 	if galebClient.IsErrExists(err) {
 		backendExists = true
 	} else if err != nil {

--- a/router/galeb/router_test.go
+++ b/router/galeb/router_test.go
@@ -224,6 +224,13 @@ func (s *fakeGalebServer) createRule(w http.ResponseWriter, r *http.Request) {
 	var rule galebClient.Rule
 	rule.Status = "OK"
 	json.NewDecoder(r.Body).Decode(&rule)
+	for _, rInt := range s.rules {
+		r := rInt.(*galebClient.Rule)
+		if r.Name == rule.Name {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+	}
 	s.idCounter++
 	rule.ID = s.idCounter
 	rule.Links.Self.Href = fmt.Sprintf("http://%s%s/%d", r.Host, r.URL.String(), rule.ID)
@@ -256,8 +263,13 @@ func (s *fakeGalebServer) addRuleVirtualhost(w http.ResponseWriter, r *http.Requ
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	s.ruleVh[id] = append(s.ruleVh[id], vhId)
 	w.WriteHeader(http.StatusNoContent)
+	for _, r := range s.ruleVh[id] {
+		if r == vhId {
+			return
+		}
+	}
+	s.ruleVh[id] = append(s.ruleVh[id], vhId)
 }
 
 func (s *fakeGalebServer) destroyRuleVirtualhost(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This change will ensure the routes rebuild routine always create missing
or partially created resources.