### PR TITLE
api,auth/native: remove smtp password from email tests

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -70,7 +70,6 @@ func (s *AuthSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 	config.Set("smtp:server", s.server.Addr())
 	config.Set("smtp:user", "root")
-	config.Set("smtp:password", "123456")
 	provision.DefaultProvisioner = "fake"
 	app.AuthScheme = nativeScheme
 	s.testServer = RunServer(true)

--- a/auth/native/suite_test.go
+++ b/auth/native/suite_test.go
@@ -43,7 +43,6 @@ func (s *S) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 	config.Set("smtp:server", s.server.Addr())
 	config.Set("smtp:user", "root")
-	config.Set("smtp:password", "123456")
 }
 
 func (s *S) SetUpTest(c *check.C) {

--- a/auth/native/user_test.go
+++ b/auth/native/user_test.go
@@ -42,21 +42,6 @@ func (s *S) TestSendEmailUndefinedUser(c *check.C) {
 	c.Assert(err.Error(), check.Equals, `Setting "smtp:user" is not defined`)
 }
 
-func (s *S) TestSendEmailUndefinedSMTPPassword(c *check.C) {
-	defer s.server.Reset()
-	old, _ := config.Get("smtp:password")
-	defer config.Set("smtp:password", old)
-	config.Unset("smtp:password")
-	err := sendEmail("something@tsuru.io", []byte("Hello world!"))
-	c.Assert(err, check.IsNil)
-	s.server.Lock()
-	defer s.server.Unlock()
-	m := s.server.MailBox[0]
-	c.Assert(m.To, check.DeepEquals, []string{"something@tsuru.io"})
-	c.Assert(m.From, check.Equals, "root")
-	c.Assert(m.Data, check.DeepEquals, []byte("Hello world!\r\n"))
-}
-
 func (s *S) TestSMTPServer(c *check.C) {
 	var tests = []struct {
 		input   string

--- a/auth/suite_test.go
+++ b/auth/suite_test.go
@@ -45,7 +45,6 @@ func (s *S) SetUpSuite(c *check.C) {
 	s.gitPort, _ = config.GetString("git:port")
 	s.gitProt, _ = config.GetString("git:protocol")
 	config.Set("smtp:user", "root")
-	config.Set("smtp:password", "123456")
 	config.Set("repo-manager", "fake")
 	var err error
 	servicemanager.TeamToken, err = TeamTokenService()


### PR DESCRIPTION
Our test server does not support AUTH messages and after https://go-review.googlesource.com/c/go/+/79776 introduced in Go 1.11, sending AUTH messages to a server that does not support them returns an error.