### PR TITLE
api: run shutdown handlers alongside server stop

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -548,13 +548,7 @@ func startServer(handler http.Handler) error {
 	}
 	go srvConf.handleSignals(shutdownTimeout)
 
-	defer func() {
-		srvConf.shutdown(shutdownTimeout)
-		fmt.Println("tsuru is running shutdown handlers")
-		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		shutdown.Do(ctx, os.Stdout)
-		cancel()
-	}()
+	defer srvConf.shutdown(shutdownTimeout)
 
 	shutdown.Register(&logTracker)
 	var startupMessage string
@@ -691,30 +685,53 @@ func createServers(handler http.Handler) (*srvConfig, error) {
 }
 
 type srvConfig struct {
-	httpSrv  *http.Server
-	httpsSrv *http.Server
-	certFile string
-	keyFile  string
+	sync.Mutex
+	httpSrv        *http.Server
+	httpsSrv       *http.Server
+	certFile       string
+	keyFile        string
+	shutdownCalled bool
+	once           sync.Once
+	wg             sync.WaitGroup
 }
 
 func (conf *srvConfig) shutdown(shutdownTimeout time.Duration) {
-	wg := sync.WaitGroup{}
+	conf.Lock()
+	defer conf.Unlock()
+	conf.once.Do(func() {
+		conf.onceShutdown(shutdownTimeout)
+	})
+	conf.wg.Wait()
+	conf.shutdownCalled = true
+}
+
+func (conf *srvConfig) onceShutdown(shutdownTimeout time.Duration) {
 	shutdownSrv := func(srv *http.Server) {
-		defer wg.Done()
-		fmt.Printf("tsuru is shutting down server %v, waiting for pending connections to finish.\n", srv.Addr)
+		defer conf.wg.Done()
+		fmt.Printf("[shutdown] tsuru is shutting down server %v, waiting for pending connections to finish.\n", srv.Addr)
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
-		srv.Shutdown(ctx)
+		err := srv.Shutdown(ctx)
+		if err != nil {
+			fmt.Printf("[shutdown] error while shutting down server %v: %v\n", srv.Addr, err)
+		}
 	}
 	if conf.httpSrv != nil {
-		wg.Add(1)
+		conf.wg.Add(1)
 		go shutdownSrv(conf.httpSrv)
 	}
 	if conf.httpsSrv != nil {
-		wg.Add(1)
+		conf.wg.Add(1)
 		go shutdownSrv(conf.httpsSrv)
 	}
-	wg.Wait()
+	conf.wg.Add(1)
+	go func() {
+		defer conf.wg.Done()
+		fmt.Println("[shutdown] tsuru is running shutdown handlers")
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		shutdown.Do(ctx, os.Stdout)
+		cancel()
+	}()
 }
 
 func (conf *srvConfig) handleSignals(shutdownTimeout time.Duration) {
@@ -725,7 +742,13 @@ func (conf *srvConfig) handleSignals(shutdownTimeout time.Duration) {
 }
 
 func (conf *srvConfig) start() <-chan error {
+	conf.Lock()
+	defer conf.Unlock()
 	errChan := make(chan error, 2)
+	if conf.shutdownCalled {
+		errChan <- errors.New("shutdown called")
+		return errChan
+	}
 	if conf.httpSrv != nil {
 		go func() {
 			fmt.Printf("tsuru HTTP server listening at %s...\n", conf.httpSrv.Addr)

--- a/api/shutdown/shutdown.go
+++ b/api/shutdown/shutdown.go
@@ -45,13 +45,13 @@ func Do(ctx context.Context, w io.Writer) error {
 			} else {
 				name = fmt.Sprintf("%T", h)
 			}
-			fmt.Fprintf(w, "running shutdown for %s...\n", name)
+			fmt.Fprintf(w, "[shutdown] running shutdown for %s...\n", name)
 			err := h.Shutdown(ctx)
 			if err != nil {
-				fmt.Fprintf(w, "running shutdown for %s. ERROED: %v", name, err)
+				fmt.Fprintf(w, "[shutdown] running shutdown for %s. ERROED: %v", name, err)
 				return
 			}
-			fmt.Fprintf(w, "running shutdown for %s. DONE.\n", name)
+			fmt.Fprintf(w, "[shutdown] running shutdown for %s. DONE.\n", name)
 		}(h)
 	}
 	go func() {


### PR DESCRIPTION
This is needed because some shutdown handlers are required for allowing a clean shutdown of the server. One suck example is the app-log -f shutdown handler which will close existing log connections.

This commit also fix a race where if a stop signal is triggered before the server is listening the shutdown handlers would run but the server would still start and listen for connections.

Fixes #2050.