### PR TITLE
provision/kubernetes: add 'app' label to tsuru deployments

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -573,11 +573,16 @@ func createAppDeployment(client *ClusterClient, oldDeployment *v1beta2.Deploymen
 		return nil, nil, nil, err
 	}
 	labels, annotations := provision.SplitServiceLabelsAnnotations(labels)
+	expandedLabels := labels.ToLabels()
+	expandedLabelsNoReplicas := labels.WithoutAppReplicas().ToLabels()
+	rawAppLabel := appLabelForApp(a, process)
+	expandedLabels["app"] = rawAppLabel
+	expandedLabelsNoReplicas["app"] = rawAppLabel
 	deployment := v1beta2.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        depName,
 			Namespace:   ns,
-			Labels:      labels.ToLabels(),
+			Labels:      expandedLabels,
 			Annotations: annotations.ToLabels(),
 		},
 		Spec: v1beta2.DeploymentSpec{
@@ -595,7 +600,7 @@ func createAppDeployment(client *ClusterClient, oldDeployment *v1beta2.Deploymen
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels.WithoutAppReplicas().ToLabels(),
+					Labels:      expandedLabelsNoReplicas,
 					Annotations: annotations.ToLabels(),
 				},
 				Spec: apiv1.PodSpec{

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -95,6 +95,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		"tsuru.io/app-pool":             "test-default",
 		"tsuru.io/provisioner":          "kubernetes",
 		"tsuru.io/builder":              "",
+		"app":                           "tsuru-app-myapp-p1",
 	}
 	podLabels := make(map[string]string)
 	for k, v := range depLabels {

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -89,6 +89,12 @@ func buildPodNameForApp(a provision.App, suffix string) (string, error) {
 	return fmt.Sprintf("%s-%s-build", name, version), nil
 }
 
+func appLabelForApp(a provision.App, process string) string {
+	name := validKubeName(a.GetName())
+	process = validKubeName(process)
+	return fmt.Sprintf("tsuru-app-%s-%s", name, process)
+}
+
 func execCommandPodNameForApp(a provision.App) string {
 	name := validKubeName(a.GetName())
 	return fmt.Sprintf("%s-isolated-run", name)

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -139,6 +139,20 @@ func (s *S) TestRegistrySecretName(c *check.C) {
 	}
 }
 
+func (s *S) TestAppLabelForApp(c *check.C) {
+	var tests = []struct {
+		name, process, expected string
+	}{
+		{"myapp", "p1", "tsuru-app-myapp-p1"},
+		{"MYAPP", "p-1", "tsuru-app-myapp-p-1"},
+		{"my-app_app", "P_1-1", "tsuru-app-my-app-app-p-1-1"},
+	}
+	for i, tt := range tests {
+		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
+		c.Assert(appLabelForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
+	}
+}
+
 func (s *S) TestWaitFor(c *check.C) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err := waitFor(ctx, func() (bool, error) {


### PR DESCRIPTION
The 'app' label has become an unofficial standard, its used on many deployments in the wild and some tools have come rely on it, such as Istio. Reference https://istio.io/docs/setup/kubernetes/spec-requirements/.