### PR TITLE
app,healer: try updating node status even if provisioner is unavailable

### DIFF
--- a/api/node_test.go
+++ b/api/node_test.go
@@ -1112,7 +1112,7 @@ func (s *S) TestInfoNodeHandler(c *check.C) {
 		{Name: "ok1", Successful: true},
 		{Name: "ok2", Successful: true},
 	}
-	err = nodeHealer.UpdateNodeData(node, checks)
+	err = nodeHealer.UpdateNodeData([]string{node.Address()}, checks)
 	c.Assert(err, check.IsNil)
 	factory, _ := iaasTesting.NewHealerIaaSConstructorWithInst(nodeAddr)
 	iaas.RegisterIaasProvider("test123", factory)

--- a/app/app.go
+++ b/app/app.go
@@ -890,6 +890,7 @@ func findNodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, err
 	if err != nil {
 		return nil, err
 	}
+	provErrors := tsuruErrors.NewMultiError()
 	for _, p := range provisioners {
 		if nodeProv, ok := p.(provision.NodeProvisioner); ok {
 			var node provision.Node
@@ -902,9 +903,12 @@ func findNodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, err
 				return node, nil
 			}
 			if errors.Cause(err) != provision.ErrNodeNotFound {
-				return nil, err
+				provErrors.Add(err)
 			}
 		}
+	}
+	if err = provErrors.ToError(); err != nil {
+		return nil, err
 	}
 	return nil, provision.ErrNodeNotFound
 }

--- a/provision/node/node_test.go
+++ b/provision/node/node_test.go
@@ -225,7 +225,7 @@ func (s *S) TestRemoveNode(c *check.C) {
 	c.Assert(err, check.IsNil)
 	node, err := p1.GetNode("http://addr1")
 	c.Assert(err, check.IsNil)
-	err = healer.HealerInstance.UpdateNodeData(node, []provision.NodeCheckResult{
+	err = healer.HealerInstance.UpdateNodeData([]string{node.Address()}, []provision.NodeCheckResult{
 		{Name: "x1", Successful: true},
 	})
 	c.Assert(err, check.IsNil)
@@ -256,7 +256,7 @@ func (s *S) TestRemoveNodeWithNodeInstance(c *check.C) {
 	c.Assert(err, check.IsNil)
 	node, err := p1.GetNode(machine.Address)
 	c.Assert(err, check.IsNil)
-	err = healer.HealerInstance.UpdateNodeData(node, []provision.NodeCheckResult{
+	err = healer.HealerInstance.UpdateNodeData([]string{node.Address()}, []provision.NodeCheckResult{
 		{Name: "x1", Successful: true},
 	})
 	c.Assert(err, check.IsNil)
@@ -288,7 +288,7 @@ func (s *S) TestRemoveNodeWithNodeInstanceRemoveIaaS(c *check.C) {
 	c.Assert(err, check.IsNil)
 	node, err := p1.GetNode(machine.Address)
 	c.Assert(err, check.IsNil)
-	err = healer.HealerInstance.UpdateNodeData(node, []provision.NodeCheckResult{
+	err = healer.HealerInstance.UpdateNodeData([]string{node.Address()}, []provision.NodeCheckResult{
 		{Name: "x1", Successful: true},
 	})
 	c.Assert(err, check.IsNil)

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -587,6 +587,9 @@ func (p *FakeProvisioner) ListNodes(addressFilter []string) ([]provision.Node, e
 }
 
 func (p *FakeProvisioner) NodeForNodeData(nodeData provision.NodeStatusData) (provision.Node, error) {
+	if err := p.getError("NodeForNodeData"); err != nil {
+		return nil, err
+	}
 	nodeAddrMap := map[string]provision.Node{}
 	for addr, n := range p.nodes {
 		n := n


### PR DESCRIPTION
This PR changes the healer to try finding an existing node with the received addrs if the provisioner errored when trying to find the node. This will ensure a provisioner outage doesn't impact its nodes.