### PR TITLE
cmd: implements verbosity inside a custom RoundTripper

### DIFF
--- a/cmd/transport.go
+++ b/cmd/transport.go
@@ -1,0 +1,68 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+)
+
+var (
+	_                   http.RoundTripper = &VerboseRoundTripper{}
+	zero                                  = 0
+	defaultRoundTripper                   = http.DefaultTransport
+)
+
+// VerboseRoundTripper is a RoundTripper that dumps request and response
+// based on the Verbosity.
+// Verbosity >= 1 --> Dumps request
+// Verbosity >= 2 --> Dumps response
+type VerboseRoundTripper struct {
+	http.RoundTripper
+	Verbosity *int
+	Writer    io.Writer
+}
+
+func (v *VerboseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	roundTripper := v.RoundTripper
+	if roundTripper == nil {
+		roundTripper = defaultRoundTripper
+	}
+	verbosity := v.Verbosity
+	if verbosity == nil {
+		verbosity = &zero
+	}
+	req.Header.Add(VerbosityHeader, strconv.Itoa(*verbosity))
+	req.Close = true
+	if *verbosity >= 1 {
+		fmt.Fprintf(v.Writer, "*************************** <Request uri=%q> **********************************\n", req.URL.RequestURI())
+		requestDump, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(v.Writer, string(requestDump))
+		if requestDump[len(requestDump)-1] != '\n' {
+			fmt.Fprintln(v.Writer)
+		}
+		fmt.Fprintf(v.Writer, "*************************** </Request uri=%q> **********************************\n", req.URL.RequestURI())
+	}
+	response, err := roundTripper.RoundTrip(req)
+	if *verbosity >= 2 && response != nil {
+		fmt.Fprintf(v.Writer, "*************************** <Response uri=%q> **********************************\n", req.URL.RequestURI())
+		responseDump, errDump := httputil.DumpResponse(response, true)
+		if errDump != nil {
+			return nil, errDump
+		}
+		fmt.Fprintf(v.Writer, string(responseDump))
+		if responseDump[len(responseDump)-1] != '\n' {
+			fmt.Fprintln(v.Writer)
+		}
+		fmt.Fprintf(v.Writer, "*************************** </Response uri=%q> **********************************\n", req.URL.RequestURI())
+	}
+	return response, err
+}

--- a/cmd/transport_test.go
+++ b/cmd/transport_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/tsuru/tsuru/cmd/cmdtest"
+	check "gopkg.in/check.v1"
+)
+
+func (s *S) TestVerboseRoundTripperDumpRequest(c *check.C) {
+	verbosity := 1
+	out := new(bytes.Buffer)
+	r := VerboseRoundTripper{
+		Verbosity: &verbosity,
+		Writer:    out,
+		RoundTripper: &cmdtest.Transport{
+			Message: "Success!",
+			Status:  http.StatusOK,
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/users", nil)
+	c.Assert(err, check.IsNil)
+	_, err = r.RoundTrip(req)
+	c.Assert(err, check.IsNil)
+	c.Assert(out.String(), check.DeepEquals, "*************************** <Request uri=\"/users\"> **********************************\n"+
+		"GET /users HTTP/1.1\r\n"+
+		"Host: localhost\r\n"+
+		"Connection: close\r\n"+
+		"X-Tsuru-Verbosity: 1\r\n"+
+		"\r\n"+
+		"*************************** </Request uri=\"/users\"> **********************************\n")
+}
+
+func (s *S) TestVerboseRoundTripperDumpRequestResponse(c *check.C) {
+	verbosity := 2
+	out := new(bytes.Buffer)
+	r := VerboseRoundTripper{
+		Verbosity: &verbosity,
+		Writer:    out,
+		RoundTripper: &cmdtest.Transport{
+			Message: "Success!",
+			Status:  http.StatusOK,
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/users", nil)
+	c.Assert(err, check.IsNil)
+	_, err = r.RoundTrip(req)
+	c.Assert(err, check.IsNil)
+	c.Assert(out.String(), check.DeepEquals, "*************************** <Request uri=\"/users\"> **********************************\n"+
+		"GET /users HTTP/1.1\r\n"+
+		"Host: localhost\r\n"+
+		"Connection: close\r\n"+
+		"X-Tsuru-Verbosity: 2\r\n"+
+		"\r\n"+
+		"*************************** </Request uri=\"/users\"> **********************************\n"+
+		"*************************** <Response uri=\"/users\"> **********************************\n"+
+		"HTTP/0.0 200 OK\r\n"+
+		"\r\n"+
+		"Success!\n"+
+		"*************************** </Response uri=\"/users\"> **********************************\n")
+
+}


### PR DESCRIPTION
Prior to this change, the client object was responsible for providing
the request/response dumping according to the given verbosity level.
Commands using the new go-tsuruclient (generated from the spec) didn't
support the verbosity parameter because they do not use Client.

This change implements a custom RoundTripper that provides
request/response dumping according to a verbosity level. Commands
implemented with the new client simply have to pass down the http.Client
to the go-tsuruclient instance.