### PR TITLE
provisioner/kubernetes: sync app CR before changing state

### DIFF
--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -782,6 +782,9 @@ func (p *kubernetesProvisioner) Deploy(a provision.App, buildImageID string, evt
 	if err != nil {
 		return "", err
 	}
+	if err := ensureAppCustomResourceSynced(client, a); err != nil {
+		return "", err
+	}
 	newImage := buildImageID
 	if strings.HasSuffix(buildImageID, "-builder") {
 		newImage, err = image.AppNewImageName(a.GetName())

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -213,6 +213,9 @@ func changeState(a provision.App, process string, state servicecommon.ProcessSta
 	if err != nil {
 		return err
 	}
+	if err := ensureAppCustomResourceSynced(client, a); err != nil {
+		return err
+	}
 	return servicecommon.ChangeAppState(&serviceManager{
 		client: client,
 		writer: w,
@@ -222,6 +225,9 @@ func changeState(a provision.App, process string, state servicecommon.ProcessSta
 func changeUnits(a provision.App, units int, processName string, w io.Writer) error {
 	client, err := clusterForPool(a.GetPool())
 	if err != nil {
+		return err
+	}
+	if err := ensureAppCustomResourceSynced(client, a); err != nil {
 		return err
 	}
 	return servicecommon.ChangeUnits(&serviceManager{


### PR DESCRIPTION
This change introduces a sync that makes sure the app custom resource is
properly synced before doing any operation inside the Kubernetes
cluster.