### PR TITLE
Service broker catalog cache

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -44,6 +44,7 @@ import (
 	apiTypes "github.com/tsuru/tsuru/types/api"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/quota"
 	"gopkg.in/check.v1"
 )
@@ -500,8 +501,8 @@ func (s *S) TestAppList(c *check.C) {
 }
 
 func (s *S) TestAppListAfterAppInfoHasAddr(c *check.C) {
-	s.mockService.Cache.OnList = func(keys ...string) ([]appTypes.CacheEntry, error) {
-		return []appTypes.CacheEntry{{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"}}, nil
+	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
+		return []cache.CacheEntry{{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"}}, nil
 	}
 	p := pool.Pool{Name: "pool1"}
 	opts := pool.AddPoolOptions{Name: p.Name, Public: true}
@@ -548,8 +549,8 @@ func (s *S) TestAppListAfterAppInfoHasAddr(c *check.C) {
 }
 
 func (s *S) TestAppListAfterAppInfoHasAddrLegacyRouter(c *check.C) {
-	s.mockService.Cache.OnList = func(keys ...string) ([]appTypes.CacheEntry, error) {
-		return []appTypes.CacheEntry{{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"}}, nil
+	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
+		return []cache.CacheEntry{{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"}}, nil
 	}
 	p := pool.Pool{Name: "pool1"}
 	opts := pool.AddPoolOptions{Name: p.Name, Public: true}

--- a/api/server.go
+++ b/api/server.go
@@ -95,7 +95,7 @@ func setupServices() error {
 	if err != nil {
 		return err
 	}
-	servicemanager.Cache, err = app.CacheService()
+	servicemanager.AppCache, err = app.CacheService()
 	if err != nil {
 		return err
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -132,6 +132,10 @@ func setupServices() error {
 		return err
 	}
 	servicemanager.ServiceBroker, err = service.BrokerService()
+	if err != nil {
+		return err
+	}
+	servicemanager.ServiceBrokerCatalogCache, err = service.CatalogCacheService()
 	return err
 }
 

--- a/api/service_broker_test.go
+++ b/api/service_broker_test.go
@@ -10,22 +10,18 @@ import (
 	"strings"
 
 	"github.com/ajg/form"
-	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/types/service"
 	check "gopkg.in/check.v1"
 )
 
 func (s *S) TestServiceBrokerList(c *check.C) {
-	err := servicemanager.ServiceBroker.Create(service.Broker{
-		Name: "broker-1",
-		URL:  "http://localhost:8080",
-	})
-	c.Assert(err, check.IsNil)
-	err = servicemanager.ServiceBroker.Create(service.Broker{
-		Name: "broker-2",
-		URL:  "http://localhost:8080",
-	})
-	c.Assert(err, check.IsNil)
+	brokers := []service.Broker{
+		{Name: "broker-1", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
+		{Name: "broker-2", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
+	}
+	s.mockService.ServiceBroker.OnList = func() ([]service.Broker, error) {
+		return brokers, nil
+	}
 	request, err := http.NewRequest("GET", "/1.7/brokers", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -35,10 +31,7 @@ func (s *S) TestServiceBrokerList(c *check.C) {
 	var response map[string][]service.Broker
 	err = json.NewDecoder(recorder.Body).Decode(&response)
 	c.Assert(err, check.IsNil)
-	c.Assert(response["brokers"], check.DeepEquals, []service.Broker{
-		{Name: "broker-1", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
-		{Name: "broker-2", URL: "http://localhost:8080", Config: service.BrokerConfig{Context: map[string]interface{}{}}},
-	})
+	c.Assert(response["brokers"], check.DeepEquals, brokers)
 }
 
 func (s *S) TestServiceBrokerListEmpty(c *check.C) {
@@ -70,8 +63,12 @@ func (s *S) TestServiceBrokerAdd(c *check.C) {
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
-			Context: map[string]interface{}{},
+			Context: nil,
 		},
+	}
+	s.mockService.ServiceBroker.OnCreate = func(b service.Broker) error {
+		c.Assert(b, check.DeepEquals, expectedBroker)
+		return nil
 	}
 	bodyData, err := form.EncodeToString(expectedBroker)
 	c.Assert(err, check.IsNil)
@@ -82,9 +79,6 @@ func (s *S) TestServiceBrokerAdd(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
-	broker, err := servicemanager.ServiceBroker.Find("broker-name")
-	c.Assert(err, check.IsNil)
-	c.Assert(broker, check.DeepEquals, expectedBroker)
 }
 
 func (s *S) TestServiceBrokerAddUnauthorized(c *check.C) {
@@ -100,8 +94,10 @@ func (s *S) TestServiceBrokerAddAlreadyExists(c *check.C) {
 		Name: "broker-name",
 		URL:  "http://localhost:8080",
 	}
-	err := servicemanager.ServiceBroker.Create(broker)
-	c.Assert(err, check.IsNil)
+	s.mockService.ServiceBroker.OnCreate = func(b service.Broker) error {
+		c.Assert(b.Name, check.Equals, broker.Name)
+		return service.ErrServiceBrokerAlreadyExists
+	}
 	body := strings.NewReader(`name=broker-name&url=https://localhost:8080`)
 	request, err := http.NewRequest("POST", "/1.7/brokers", body)
 	c.Assert(err, check.IsNil)
@@ -115,22 +111,23 @@ func (s *S) TestServiceBrokerAddAlreadyExists(c *check.C) {
 func (s *S) TestServiceBrokerUpdate(c *check.C) {
 	broker := service.Broker{
 		Name: "broker-name",
-		URL:  "https://localhost:8080",
+		URL:  "https://localhost:9090",
 		Config: service.BrokerConfig{
 			AuthConfig: &service.AuthConfig{
 				BasicAuthConfig: &service.BasicAuthConfig{
-					Username: "username",
+					Username: "new-user",
 					Password: "password",
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
-			Context: map[string]interface{}{},
+			Context: nil,
 		},
 	}
-	err := servicemanager.ServiceBroker.Create(broker)
-	c.Assert(err, check.IsNil)
-	broker.URL = "https://localhost:9090"
-	broker.Config.AuthConfig.BasicAuthConfig.Username = "new-user"
+	s.mockService.ServiceBroker.OnUpdate = func(name string, b service.Broker) error {
+		c.Assert(name, check.Equals, "broker-name")
+		c.Assert(b, check.DeepEquals, broker)
+		return nil
+	}
 	bodyData, err := form.EncodeToString(broker)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
@@ -140,13 +137,15 @@ func (s *S) TestServiceBrokerUpdate(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	newBroker, err := servicemanager.ServiceBroker.Find("broker-name")
-	c.Assert(err, check.IsNil)
-	c.Assert(newBroker, check.DeepEquals, broker)
 }
 
 func (s *S) TestServiceBrokerUpdateNotFound(c *check.C) {
 	broker := service.Broker{Name: "not-found"}
+	s.mockService.ServiceBroker.OnUpdate = func(name string, b service.Broker) error {
+		c.Assert(name, check.Equals, "broker-name")
+		c.Assert(b.Name, check.Equals, broker.Name)
+		return service.ErrServiceBrokerNotFound
+	}
 	bodyData, err := form.EncodeToString(broker)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
@@ -172,12 +171,10 @@ func (s *S) TestServiceBrokerUpdateUnauthorized(c *check.C) {
 }
 
 func (s *S) TestServiceBrokerDelete(c *check.C) {
-	broker := service.Broker{
-		Name: "broker-name",
-		URL:  "http://localhost:8080",
+	s.mockService.ServiceBroker.OnDelete = func(name string) error {
+		c.Assert(name, check.Equals, "broker-name")
+		return nil
 	}
-	err := servicemanager.ServiceBroker.Create(broker)
-	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -185,11 +182,13 @@ func (s *S) TestServiceBrokerDelete(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	_, err = servicemanager.ServiceBroker.Find("broker-name")
-	c.Assert(err, check.DeepEquals, service.ErrServiceBrokerNotFound)
 }
 
 func (s *S) TestServiceBrokerDeleteNotFound(c *check.C) {
+	s.mockService.ServiceBroker.OnDelete = func(name string) error {
+		c.Assert(name, check.Equals, "broker-name")
+		return service.ErrServiceBrokerNotFound
+	}
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
@@ -200,12 +199,6 @@ func (s *S) TestServiceBrokerDeleteNotFound(c *check.C) {
 }
 
 func (s *S) TestServiceBrokerDeleteUnauthorized(c *check.C) {
-	broker := service.Broker{
-		Name: "broker-name",
-		URL:  "http://localhost:8080",
-	}
-	err := servicemanager.ServiceBroker.Create(broker)
-	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer 12345")
@@ -213,7 +206,4 @@ func (s *S) TestServiceBrokerDeleteUnauthorized(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusUnauthorized)
-	foundBroker, err := servicemanager.ServiceBroker.Find("broker-name")
-	c.Assert(err, check.IsNil)
-	c.Assert(foundBroker.Name, check.DeepEquals, "broker-name")
 }

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -436,6 +436,10 @@ type serviceInstanceInfo struct {
 func serviceInstance(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	instanceName := r.URL.Query().Get(":instance")
 	serviceName := r.URL.Query().Get(":service")
+	svc, err := getService(serviceName)
+	if err != nil {
+		return err
+	}
 	serviceInstance, err := getServiceInstanceOrError(serviceName, instanceName)
 	if err != nil {
 		return err
@@ -451,7 +455,7 @@ func serviceInstance(w http.ResponseWriter, r *http.Request, t auth.Token) error
 	if err != nil {
 		return err
 	}
-	plan, err := service.GetPlanByServiceNameAndPlanName(serviceName, serviceInstance.PlanName, requestID)
+	plan, err := service.GetPlanByServiceAndPlanName(svc, serviceInstance.PlanName, requestID)
 	if err != nil {
 		return err
 	}
@@ -561,7 +565,7 @@ func servicePlans(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		}
 	}
 	requestID := requestIDHeader(r)
-	plans, err := service.GetPlansByServiceName(serviceName, requestID)
+	plans, err := service.GetPlansByService(s, requestID)
 	if err != nil {
 		return err
 	}

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -944,7 +944,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWithAssociatedAppsShould
 }
 
 func makeRequestToRemoveServiceInstanceWithUnbind(service, instance string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
-	url := fmt.Sprintf("/services/%s/instances/%s?:service=%s&:instance=%s&unbindall=%s", service, instance, service, instance, "true")
+	url := fmt.Sprintf("/services/%[1]s/instances/%[2]s?:service=%[1]s&:instance=%[2]s&unbindall=true", service, instance)
 	request, err := http.NewRequest("DELETE", url, nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
@@ -995,7 +995,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceInstanceWIthAssociatedAppsWithUn
 }
 
 func makeRequestToRemoveServiceInstanceWithNoUnbind(service, instance string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
-	url := fmt.Sprintf("/services/%s/instances/%s?:service=%s&:instance=%s&unbindall=%s", service, instance, service, instance, "false")
+	url := fmt.Sprintf("/services/%[1]s/instances/%[2]s?:service=%[1]s&:instance=%[2]s&unbindall=false", service, instance)
 	request, err := http.NewRequest("DELETE", url, nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
@@ -1384,7 +1384,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesFilterInstancesPerService
 }
 
 func makeRequestToServiceInstanceStatus(service string, instance string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
-	url := fmt.Sprintf("/services/%s/instances/%s/status/?:instance=%s&:service=%s", service, instance, instance, service)
+	url := fmt.Sprintf("/services/%[1]s/instances/%[2]s/status/?:instance=%[2]s&:service=%[1]s", service, instance)
 	request, err := http.NewRequest("GET", url, nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
@@ -1697,7 +1697,7 @@ func (s *ServiceInstanceSuite) TestServiceInfoShouldReturnOnlyInstancesOfTheSame
 	}
 	err = s.conn.ServiceInstances().Insert(si2)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("GET", fmt.Sprintf("/services/%s?:name=%s", "mongodb", "mongodb"), nil)
+	request, err := http.NewRequest("GET", fmt.Sprintf("/services/%[1]s?:name=%[1]s", "mongodb"), nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
 	err = serviceInfo(recorder, request, s.token)
@@ -1719,7 +1719,7 @@ func (s *ServiceInstanceSuite) TestServiceInfoShouldReturnOnlyInstancesOfTheSame
 }
 
 func (s *ServiceInstanceSuite) TestServiceInfoReturns404WhenTheServiceDoesNotExist(c *check.C) {
-	request, err := http.NewRequest("GET", fmt.Sprintf("/services/%s?:name=%s", "mongodb", "mongodb"), nil)
+	request, err := http.NewRequest("GET", fmt.Sprintf("/services/%[1]s?:name=%[1]s", "mongodb"), nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
 	err = serviceInfo(recorder, request, s.token)
@@ -1731,7 +1731,7 @@ func (s *ServiceInstanceSuite) TestServiceInfoReturns404WhenTheServiceDoesNotExi
 }
 
 func (s *ServiceInstanceSuite) makeRequestToGetServiceDoc(name string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
-	url := fmt.Sprintf("/services/%s/doc/?:name=%s", name, name)
+	url := fmt.Sprintf("/services/%[1]s/doc/?:name=%[1]s", name)
 	request, err := http.NewRequest("GET", url, nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")

--- a/app/app.go
+++ b/app/app.go
@@ -42,6 +42,7 @@ import (
 	"github.com/tsuru/tsuru/servicemanager"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/quota"
 	"github.com/tsuru/tsuru/validation"
 	"github.com/tsuru/tsuru/volume"
@@ -1938,7 +1939,7 @@ func loadCachedAddrsInApps(apps []App) error {
 	if err != nil {
 		return err
 	}
-	entryMap := make(map[string]appTypes.CacheEntry, len(entries))
+	entryMap := make(map[string]cache.CacheEntry, len(entries))
 	for _, e := range entries {
 		entryMap[e.Key] = e
 	}
@@ -2209,7 +2210,7 @@ func (app *App) GetRoutersWithAddr() ([]appTypes.AppRouter, error) {
 			routers[i].Status = string(status)
 			routers[i].StatusDetail = detail
 		}
-		servicemanager.Cache.Create(appTypes.CacheEntry{
+		servicemanager.Cache.Create(cache.CacheEntry{
 			Key:   appRouterAddrKey(app.Name, routerName),
 			Value: addr,
 		})

--- a/app/app.go
+++ b/app/app.go
@@ -1935,7 +1935,7 @@ func loadCachedAddrsInApps(apps []App) error {
 			keys = append(keys, appRouterAddrKey(a.Name, a.Routers[j].Name))
 		}
 	}
-	entries, err := servicemanager.Cache.List(keys...)
+	entries, err := servicemanager.AppCache.List(keys...)
 	if err != nil {
 		return err
 	}
@@ -2210,7 +2210,7 @@ func (app *App) GetRoutersWithAddr() ([]appTypes.AppRouter, error) {
 			routers[i].Status = string(status)
 			routers[i].StatusDetail = detail
 		}
-		servicemanager.Cache.Create(cache.CacheEntry{
+		servicemanager.AppCache.Create(cache.CacheEntry{
 			Key:   appRouterAddrKey(app.Name, routerName),
 			Value: addr,
 		})

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/tsuru/tsuru/tsurutest"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/quota"
 	"github.com/tsuru/tsuru/volume"
 	"gopkg.in/check.v1"
@@ -3202,8 +3203,8 @@ func (s *S) TestListUsesCachedRouterAddrs(c *check.C) {
 			Quota: quota.UnlimitedQuota,
 		},
 	})
-	s.mockService.Cache.OnList = func(keys ...string) ([]appTypes.CacheEntry, error) {
-		return []appTypes.CacheEntry{
+	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
+		return []cache.CacheEntry{
 			{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"},
 			{Key: "app-router-addr\x00app2\x00fake", Value: "app2.fakerouter.com"},
 		}, nil
@@ -3256,8 +3257,8 @@ func (s *S) TestListUsesCachedRouterAddrsWithLegacyRouter(c *check.C) {
 			},
 		},
 	})
-	s.mockService.Cache.OnList = func(keys ...string) ([]appTypes.CacheEntry, error) {
-		return []appTypes.CacheEntry{
+	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
+		return []cache.CacheEntry{
 			{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"},
 		}, nil
 	}
@@ -3696,7 +3697,7 @@ func (s *S) TestSwap(c *check.C) {
 	app1 := &App{Name: "app1", CName: []string{"cname"}, TeamOwner: s.team.Name}
 	err := CreateApp(app1, s.user)
 	c.Assert(err, check.IsNil)
-	s.mockService.Cache.OnCreate = func(entry appTypes.CacheEntry) error {
+	s.mockService.Cache.OnCreate = func(entry cache.CacheEntry) error {
 		if entry.Value != "app1.fakerouter.com" && entry.Value != "app2.fakerouter.com" {
 			c.Errorf("unexpected cache entry: %v", entry)
 		}
@@ -5036,7 +5037,7 @@ func (s *S) TestGetRoutersWithAddr(c *check.C) {
 		Name: "fake-tls",
 	})
 	c.Assert(err, check.IsNil)
-	s.mockService.Cache.OnCreate = func(entry appTypes.CacheEntry) error {
+	s.mockService.Cache.OnCreate = func(entry cache.CacheEntry) error {
 		if entry.Value != "myapp.fakerouter.com" && entry.Value != "myapp.faketlsrouter.com" {
 			c.Errorf("unexpected cache entry: %v", entry)
 		}
@@ -5059,7 +5060,7 @@ func (s *S) TestGetRoutersWithAddrError(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	routertest.FakeRouter.FailForIp("fakemyapp")
-	s.mockService.Cache.OnCreate = func(entry appTypes.CacheEntry) error {
+	s.mockService.Cache.OnCreate = func(entry cache.CacheEntry) error {
 		if entry.Value != "myapp.faketlsrouter.com" {
 			c.Errorf("unexpected cache entry: %v", entry)
 		}
@@ -5086,7 +5087,7 @@ func (s *S) TestGetRoutersWithAddrWithStatus(c *check.C) {
 		Name: "mystatus",
 	})
 	c.Assert(err, check.IsNil)
-	s.mockService.Cache.OnCreate = func(entry appTypes.CacheEntry) error {
+	s.mockService.Cache.OnCreate = func(entry cache.CacheEntry) error {
 		if entry.Value != "myapp.fakerouter.com" {
 			c.Errorf("unexpected cache entry: %v", entry)
 		}

--- a/app/cache.go
+++ b/app/cache.go
@@ -6,16 +6,16 @@ package app
 
 import (
 	"github.com/tsuru/tsuru/storage"
-	appTypes "github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/cache"
 )
 
-var _ appTypes.CacheService = &cacheService{}
+var _ cache.CacheService = &cacheService{}
 
 type cacheService struct {
-	storage appTypes.CacheStorage
+	storage cache.CacheStorage
 }
 
-func CacheService() (appTypes.CacheService, error) {
+func CacheService() (cache.CacheService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()
@@ -23,17 +23,17 @@ func CacheService() (appTypes.CacheService, error) {
 			return nil, err
 		}
 	}
-	return &cacheService{dbDriver.CacheStorage}, nil
+	return &cacheService{dbDriver.AppCacheStorage}, nil
 }
 
-func (s *cacheService) Create(entry appTypes.CacheEntry) error {
+func (s *cacheService) Create(entry cache.CacheEntry) error {
 	return s.storage.Put(entry)
 }
 
-func (s *cacheService) List(keys ...string) ([]appTypes.CacheEntry, error) {
+func (s *cacheService) List(keys ...string) ([]cache.CacheEntry, error) {
 	return s.storage.GetAll(keys...)
 }
 
-func (s *cacheService) FindByName(key string) (appTypes.CacheEntry, error) {
+func (s *cacheService) FindByName(key string) (cache.CacheEntry, error) {
 	return s.storage.Get(key)
 }

--- a/app/cache.go
+++ b/app/cache.go
@@ -9,13 +9,13 @@ import (
 	"github.com/tsuru/tsuru/types/cache"
 )
 
-var _ cache.CacheService = &cacheService{}
+var _ cache.AppCacheService = &cacheService{}
 
 type cacheService struct {
 	storage cache.CacheStorage
 }
 
-func CacheService() (cache.CacheService, error) {
+func CacheService() (cache.AppCacheService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()

--- a/app/cache_test.go
+++ b/app/cache_test.go
@@ -5,18 +5,18 @@
 package app
 
 import (
-	appTypes "github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/cache"
 	"gopkg.in/check.v1"
 )
 
 func (s *S) TestCacheCreate(c *check.C) {
-	e := appTypes.CacheEntry{
+	e := cache.CacheEntry{
 		Key:   "k1",
 		Value: "v1",
 	}
 	service := &cacheService{
-		storage: &appTypes.MockCacheStorage{
-			OnPut: func(entry appTypes.CacheEntry) error {
+		storage: &cache.MockCacheStorage{
+			OnPut: func(entry cache.CacheEntry) error {
 				c.Assert(e, check.Equals, entry)
 				return nil
 			},
@@ -28,9 +28,9 @@ func (s *S) TestCacheCreate(c *check.C) {
 
 func (s *S) TestCacheList(c *check.C) {
 	service := &cacheService{
-		storage: &appTypes.MockCacheStorage{
-			OnGetAll: func(keys ...string) ([]appTypes.CacheEntry, error) {
-				return []appTypes.CacheEntry{
+		storage: &cache.MockCacheStorage{
+			OnGetAll: func(keys ...string) ([]cache.CacheEntry, error) {
+				return []cache.CacheEntry{
 					{Key: "k1", Value: "v1"},
 					{Key: "k2", Value: "v2"},
 				}, nil
@@ -44,10 +44,10 @@ func (s *S) TestCacheList(c *check.C) {
 
 func (s *S) TestCacheFindByName(c *check.C) {
 	service := &cacheService{
-		storage: &appTypes.MockCacheStorage{
-			OnGet: func(key string) (appTypes.CacheEntry, error) {
+		storage: &cache.MockCacheStorage{
+			OnGet: func(key string) (cache.CacheEntry, error) {
 				c.Check(key, check.Equals, "k1")
-				return appTypes.CacheEntry{
+				return cache.CacheEntry{
 					Key:   "k1",
 					Value: "v1",
 				}, nil

--- a/app/routerupdater_test.go
+++ b/app/routerupdater_test.go
@@ -7,13 +7,13 @@ package app
 import (
 	"context"
 
-	appTypes "github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/cache"
 	"gopkg.in/check.v1"
 )
 
 func (s *S) TestAppRouterUpdaterUpdateWait(c *check.C) {
-	s.mockService.Cache.OnList = func(keys ...string) ([]appTypes.CacheEntry, error) {
-		return []appTypes.CacheEntry{
+	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
+		return []cache.CacheEntry{
 			{Key: "app-router-addr\x00app1\x00fake", Value: "app1.fakerouter.com"},
 		}, nil
 	}

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -2827,3 +2827,5 @@ definitions:
                 properties:
                   token:
                     type: string
+          CacheExpiration:
+            type: string

--- a/service/broker.go
+++ b/service/broker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
 	serviceTypes "github.com/tsuru/tsuru/types/service"
 )
@@ -399,7 +400,10 @@ func (b *brokerClient) getCatalog(name string) (*osb.CatalogResponse, error) {
 				cat.Services[i].Plans[j].Description = p.Description
 			}
 		}
-		servicemanager.ServiceBrokerCatalogCache.Save(name, cat)
+		err = servicemanager.ServiceBrokerCatalogCache.Save(name, cat)
+		if err != nil {
+			log.Errorf("[Broker=%v] error caching catalog: %v.", name, err)
+		}
 		return response, nil
 	}
 

--- a/service/broker.go
+++ b/service/broker.go
@@ -390,8 +390,8 @@ func (b *brokerClient) Info(instance *ServiceInstance, requestID string) ([]map[
 	return params, nil
 }
 
-func (b *brokerClient) Plans(catalogName string) ([]Plan, error) {
-	_, s, err := b.getService(b.service, catalogName)
+func (b *brokerClient) Plans(_ string) ([]Plan, error) {
+	_, s, err := b.getService(b.service, b.broker.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/service/broker.go
+++ b/service/broker.go
@@ -87,6 +87,9 @@ func convertResponseToCatalog(response osb.CatalogResponse) serviceTypes.BrokerC
 			cat.Services[i].Plans[j].ID = p.ID
 			cat.Services[i].Plans[j].Name = p.Name
 			cat.Services[i].Plans[j].Description = p.Description
+			if p.Schemas != nil {
+				cat.Services[i].Plans[j].Schemas = *p.Schemas
+			}
 		}
 	}
 	return cat
@@ -105,6 +108,9 @@ func convertCatalogToResponse(catalog serviceTypes.BrokerCatalog) osb.CatalogRes
 			cat.Services[i].Plans[j].ID = p.ID
 			cat.Services[i].Plans[j].Name = p.Name
 			cat.Services[i].Plans[j].Description = p.Description
+			if schemas, ok := p.Schemas.(osb.Schemas); ok {
+				cat.Services[i].Plans[j].Schemas = &schemas
+			}
 		}
 	}
 	return cat

--- a/service/broker.go
+++ b/service/broker.go
@@ -417,7 +417,7 @@ func (b *brokerClient) BindUnit(instance *ServiceInstance, app bind.App, unit bi
 
 func (b *brokerClient) getCatalog(name string) (*osb.CatalogResponse, error) {
 	catalog, err := servicemanager.ServiceBrokerCatalogCache.Load(name)
-	if err != nil {
+	if err != nil || catalog == nil {
 		response, err := b.client.GetCatalog()
 		if err != nil {
 			return nil, err

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"time"
 
-	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/tsuru/tsuru/storage"
 	"github.com/tsuru/tsuru/types/cache"
+	"github.com/tsuru/tsuru/types/service"
 )
 
 const defaultExpiration = 15 * time.Minute
@@ -18,8 +18,8 @@ const defaultExpiration = 15 * time.Minute
 var _ ServiceBrokerCatalogCacheService = &serviceBrokerCatalogCacheService{}
 
 type ServiceBrokerCatalogCacheService interface {
-	Save(string, osb.CatalogResponse) error
-	Load(string) (*osb.CatalogResponse, error)
+	Save(string, service.BrokerCatalog) error
+	Load(string) (*service.BrokerCatalog, error)
 }
 
 type serviceBrokerCatalogCacheService struct {
@@ -37,7 +37,7 @@ func CatalogCacheService() (ServiceBrokerCatalogCacheService, error) {
 	return &serviceBrokerCatalogCacheService{dbDriver.ServiceBrokerCatalogCacheStorage}, nil
 }
 
-func (s *serviceBrokerCatalogCacheService) Save(brokerName string, catalog osb.CatalogResponse) error {
+func (s *serviceBrokerCatalogCacheService) Save(brokerName string, catalog service.BrokerCatalog) error {
 	b, err := json.Marshal(catalog)
 	if err != nil {
 		return err
@@ -50,13 +50,13 @@ func (s *serviceBrokerCatalogCacheService) Save(brokerName string, catalog osb.C
 	return s.storage.Put(entry)
 }
 
-func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*osb.CatalogResponse, error) {
+func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*service.BrokerCatalog, error) {
 	entry, err := s.storage.Get(brokerName)
 	if err != nil {
 		return nil, err
 	}
 
-	var catalog osb.CatalogResponse
+	var catalog service.BrokerCatalog
 	err = json.Unmarshal([]byte(entry.Value), &catalog)
 	if err != nil {
 		return nil, err

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"time"
 
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/storage"
 	"github.com/tsuru/tsuru/types/cache"
@@ -52,11 +53,12 @@ func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*service.Bro
 		return nil, err
 	}
 
-	var catalog service.BrokerCatalog
-	err = json.Unmarshal([]byte(entry.Value), &catalog)
+	var response osb.CatalogResponse
+	err = json.Unmarshal([]byte(entry.Value), &response)
 	if err != nil {
 		return nil, err
 	}
+	catalog := convertResponseToCatalog(response)
 	return &catalog, nil
 }
 

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -1,0 +1,65 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+import (
+	"encoding/json"
+	"time"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	"github.com/tsuru/tsuru/storage"
+	"github.com/tsuru/tsuru/types/cache"
+)
+
+const defaultExpiration = 15 * time.Minute
+
+var _ ServiceBrokerCatalogCacheService = &serviceBrokerCatalogCacheService{}
+
+type ServiceBrokerCatalogCacheService interface {
+	Save(string, osb.CatalogResponse) error
+	Load(string) (*osb.CatalogResponse, error)
+}
+
+type serviceBrokerCatalogCacheService struct {
+	storage cache.CacheStorage
+}
+
+func CatalogCacheService() (ServiceBrokerCatalogCacheService, error) {
+	dbDriver, err := storage.GetCurrentDbDriver()
+	if err != nil {
+		dbDriver, err = storage.GetDefaultDbDriver()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &serviceBrokerCatalogCacheService{dbDriver.ServiceBrokerCatalogCacheStorage}, nil
+}
+
+func (s *serviceBrokerCatalogCacheService) Save(brokerName string, catalog osb.CatalogResponse) error {
+	b, err := json.Marshal(catalog)
+	if err != nil {
+		return err
+	}
+	entry := cache.CacheEntry{
+		Key:      brokerName,
+		Value:    string(b),
+		ExpireAt: time.Now().Add(defaultExpiration),
+	}
+	return s.storage.Put(entry)
+}
+
+func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*osb.CatalogResponse, error) {
+	entry, err := s.storage.Get(brokerName)
+	if err != nil {
+		return nil, err
+	}
+
+	var catalog osb.CatalogResponse
+	err = json.Unmarshal([]byte(entry.Value), &catalog)
+	if err != nil {
+		return nil, err
+	}
+	return &catalog, nil
+}

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tsuru/tsuru/types/service"
 )
 
-const defaultExpiration = 15 * time.Minute
+const defaultExpiration = 1 * time.Hour
 
 var _ service.ServiceBrokerCatalogCacheService = &serviceBrokerCatalogCacheService{}
 

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -15,18 +15,13 @@ import (
 
 const defaultExpiration = 15 * time.Minute
 
-var _ ServiceBrokerCatalogCacheService = &serviceBrokerCatalogCacheService{}
-
-type ServiceBrokerCatalogCacheService interface {
-	Save(string, service.BrokerCatalog) error
-	Load(string) (*service.BrokerCatalog, error)
-}
+var _ service.ServiceBrokerCatalogCacheService = &serviceBrokerCatalogCacheService{}
 
 type serviceBrokerCatalogCacheService struct {
 	storage cache.CacheStorage
 }
 
-func CatalogCacheService() (ServiceBrokerCatalogCacheService, error) {
+func CatalogCacheService() (service.ServiceBrokerCatalogCacheService, error) {
 	dbDriver, err := storage.GetCurrentDbDriver()
 	if err != nil {
 		dbDriver, err = storage.GetDefaultDbDriver()

--- a/service/broker_catalog_cache_test.go
+++ b/service/broker_catalog_cache_test.go
@@ -66,7 +66,7 @@ func (s *S) TestCacheSaveCustomExpiration(c *check.C) {
 		storage: &cache.MockCacheStorage{
 			OnPut: func(entry cache.CacheEntry) error {
 				atomic.AddInt32(&calls, 1)
-				c.Assert(entry.ExpireAt.Sub(time.Now()) <= time.Duration(5*time.Minute), check.Equals, true)
+				c.Assert(time.Until(entry.ExpireAt) <= time.Duration(5*time.Minute), check.Equals, true)
 				return nil
 			},
 		},

--- a/service/broker_catalog_cache_test.go
+++ b/service/broker_catalog_cache_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
+	"github.com/tsuru/tsuru/types/cache"
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestCacheSave(c *check.C) {
+	catalog := osb.CatalogResponse{
+		Services: []osb.Service{{
+			ID:          "123",
+			Name:        "service1",
+			Description: "my service",
+		}},
+	}
+	service := &serviceBrokerCatalogCacheService{
+		storage: &cache.MockCacheStorage{
+			OnPut: func(entry cache.CacheEntry) error {
+				c.Assert(entry.Key, check.Equals, "my-catalog")
+				var cat osb.CatalogResponse
+				err := json.Unmarshal([]byte(entry.Value), &cat)
+				c.Assert(err, check.IsNil)
+				c.Assert(cat.Services, check.HasLen, 1)
+				c.Assert(cat.Services[0].ID, check.Equals, catalog.Services[0].ID)
+				c.Assert(cat.Services[0].Name, check.Equals, catalog.Services[0].Name)
+				c.Assert(cat.Services[0].Description, check.Equals, catalog.Services[0].Description)
+				return nil
+			},
+		},
+	}
+	err := service.Save("my-catalog", catalog)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestCacheLoad(c *check.C) {
+	catalog := osb.CatalogResponse{
+		Services: []osb.Service{{
+			ID:          "123",
+			Name:        "service1",
+			Description: "my service",
+		}},
+	}
+	service := &serviceBrokerCatalogCacheService{
+		storage: &cache.MockCacheStorage{
+			OnGet: func(key string) (cache.CacheEntry, error) {
+				c.Assert(key, check.Equals, "my-catalog")
+				b, err := json.Marshal(catalog)
+				c.Assert(err, check.IsNil)
+				return cache.CacheEntry{Key: key, Value: string(b)}, nil
+			},
+		},
+	}
+	cat, err := service.Load("my-catalog")
+	c.Assert(err, check.IsNil)
+	c.Assert(cat.Services, check.HasLen, 1)
+	c.Assert(cat.Services[0].ID, check.Equals, catalog.Services[0].ID)
+	c.Assert(cat.Services[0].Name, check.Equals, catalog.Services[0].Name)
+	c.Assert(cat.Services[0].Description, check.Equals, catalog.Services[0].Description)
+}
+
+func (s *S) TestCacheLoadNotFound(c *check.C) {
+	service := &serviceBrokerCatalogCacheService{
+		storage: &cache.MockCacheStorage{
+			OnGet: func(key string) (cache.CacheEntry, error) {
+				c.Assert(key, check.Equals, "unknown-catalog")
+				return cache.CacheEntry{}, fmt.Errorf("not found")
+			},
+		},
+	}
+	cat, err := service.Load("unknown-catalog")
+	c.Assert(err, check.NotNil)
+	c.Assert(cat, check.IsNil)
+}

--- a/service/broker_service.go
+++ b/service/broker_service.go
@@ -64,7 +64,7 @@ func getBrokeredServices() ([]Service, error) {
 			log.Errorf("[Broker=%v] error creating broker client: %v.", b.Name, err)
 			continue
 		}
-		cat, err := c.client.GetCatalog()
+		cat, err := c.getCatalog(b.Name)
 		if err != nil {
 			log.Errorf("[Broker=%v] error getting catalog: %v.", b.Name, err)
 			continue

--- a/service/broker_service.go
+++ b/service/broker_service.go
@@ -79,7 +79,7 @@ func getBrokeredServices() ([]Service, error) {
 // getBrokeredService retrieves the service information from a service that is
 // offered by a broker. name is in the format "<broker>serviceNameBrokerSep<service>".
 func getBrokeredService(name string) (Service, error) {
-	_, serviceName, err := splitBrokerService(name)
+	catalogName, serviceName, err := splitBrokerService(name)
 	if err != nil {
 		return Service{}, err
 	}
@@ -87,7 +87,7 @@ func getBrokeredService(name string) (Service, error) {
 	if err != nil {
 		return Service{}, err
 	}
-	s, _, err := client.getService(serviceName)
+	s, _, err := client.getService(serviceName, catalogName)
 	return s, err
 }
 

--- a/service/broker_service.go
+++ b/service/broker_service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/tsuru/tsuru/log"
+	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/storage"
 	serviceTypes "github.com/tsuru/tsuru/types/service"
 )
@@ -108,11 +109,7 @@ func newBrokeredServiceClient(service string) (*brokerClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	brokerService, err := BrokerService()
-	if err != nil {
-		return nil, err
-	}
-	broker, err := brokerService.Find(brokerName)
+	broker, err := servicemanager.ServiceBroker.Find(brokerName)
 	if err != nil {
 		return nil, err
 	}

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -30,7 +30,7 @@ func (s *S) TestBrokerClientPlans(c *check.C) {
 	ClientFactory = osbfake.NewFakeClientFunc(config)
 	client, err := newClient(serviceTypes.Broker{Name: "broker"}, "service")
 	c.Assert(err, check.IsNil)
-	plans, err := client.Plans("aws")
+	plans, err := client.Plans("")
 	c.Assert(err, check.IsNil)
 	c.Assert(plans, check.DeepEquals, []Plan{
 		{Name: "plan1", Description: "First plan"},

--- a/service/broker_test.go
+++ b/service/broker_test.go
@@ -30,7 +30,7 @@ func (s *S) TestBrokerClientPlans(c *check.C) {
 	ClientFactory = osbfake.NewFakeClientFunc(config)
 	client, err := newClient(serviceTypes.Broker{Name: "broker"}, "service")
 	c.Assert(err, check.IsNil)
-	plans, err := client.Plans("")
+	plans, err := client.Plans("aws")
 	c.Assert(err, check.IsNil)
 	c.Assert(plans, check.DeepEquals, []Plan{
 		{Name: "plan1", Description: "First plan"},

--- a/service/plan.go
+++ b/service/plan.go
@@ -15,12 +15,8 @@ type Plan struct {
 	Schemas     *osb.Schemas `json:",omitempty"`
 }
 
-func GetPlansByServiceName(serviceName, requestID string) ([]Plan, error) {
-	s, err := Get(serviceName)
-	if err != nil {
-		return nil, err
-	}
-	endpoint, err := s.getClient("production")
+func GetPlansByService(svc Service, requestID string) ([]Plan, error) {
+	endpoint, err := svc.getClient("production")
 	if err != nil {
 		return []Plan{}, nil
 	}
@@ -31,8 +27,8 @@ func GetPlansByServiceName(serviceName, requestID string) ([]Plan, error) {
 	return plans, nil
 }
 
-func GetPlanByServiceNameAndPlanName(serviceName, planName, requestID string) (Plan, error) {
-	plans, err := GetPlansByServiceName(serviceName, requestID)
+func GetPlanByServiceAndPlanName(svc Service, planName, requestID string) (Plan, error) {
+	plans, err := GetPlansByService(svc, requestID)
 	if err != nil {
 		return Plan{}, err
 	}

--- a/service/plan_test.go
+++ b/service/plan_test.go
@@ -29,8 +29,7 @@ func (s *S) TestGetPlansByServiceName(c *check.C) {
 	srvc := Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}}
 	err := s.conn.Services().Insert(&srvc)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Services().RemoveId(srvc.Name)
-	plans, err := GetPlansByServiceName("mysql", "")
+	plans, err := GetPlansByService(srvc, "")
 	c.Assert(err, check.IsNil)
 	expected := []Plan{
 		{Name: "ignite", Description: "some value"},
@@ -48,8 +47,7 @@ func (s *S) TestGetPlanByServiceNameAndPlanName(c *check.C) {
 	srvc := Service{Name: "mysql", Endpoint: map[string]string{"production": ts.URL}}
 	err := s.conn.Services().Insert(&srvc)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Services().RemoveId(srvc.Name)
-	plan, err := GetPlanByServiceNameAndPlanName("mysql", "small", "")
+	plan, err := GetPlanByServiceAndPlanName(srvc, "small", "")
 	c.Assert(err, check.IsNil)
 	expected := Plan{
 		Name:        "small",
@@ -62,8 +60,7 @@ func (s *S) TestGetPlansByServiceNameWithoutEndpoint(c *check.C) {
 	srvc := Service{Name: "mysql"}
 	err := s.conn.Services().Insert(&srvc)
 	c.Assert(err, check.IsNil)
-	defer s.conn.Services().RemoveId(srvc.Name)
-	plans, err := GetPlansByServiceName("mysql", "")
+	plans, err := GetPlansByService(srvc, "")
 	c.Assert(err, check.IsNil)
 	expected := []Plan{}
 	c.Assert(plans, check.DeepEquals, expected)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -61,7 +61,9 @@ func (s *S) TestGetServiceBrokered(c *check.C) {
 		}},
 	}
 	ClientFactory = osbfake.NewFakeClientFunc(config)
-	err := servicemanager.ServiceBroker.Create(serviceTypes.Broker{Name: "aws"})
+	sb, err := BrokerService()
+	c.Assert(err, check.IsNil)
+	err = sb.Create(serviceTypes.Broker{Name: "aws"})
 	c.Assert(err, check.IsNil)
 	serv, err := Get("aws::service")
 	c.Assert(err, check.IsNil)
@@ -86,7 +88,9 @@ func (s *S) TestGetServiceBrokeredFromCache(c *check.C) {
 			}, nil
 		},
 	}
-	err := servicemanager.ServiceBroker.Create(serviceTypes.Broker{Name: "aws"})
+	sb, err := BrokerService()
+	c.Assert(err, check.IsNil)
+	err = sb.Create(serviceTypes.Broker{Name: "aws"})
 	c.Assert(err, check.IsNil)
 	serv, err := Get("aws::service")
 	c.Assert(err, check.IsNil)
@@ -113,7 +117,9 @@ func (s *S) TestGetServiceBrokeredServiceNotFound(c *check.C) {
 		CatalogReaction: &osbfake.CatalogReaction{Response: &osb.CatalogResponse{}},
 	}
 	ClientFactory = osbfake.NewFakeClientFunc(config)
-	err := servicemanager.ServiceBroker.Create(serviceTypes.Broker{Name: "aws"})
+	sb, err := BrokerService()
+	c.Assert(err, check.IsNil)
+	err = sb.Create(serviceTypes.Broker{Name: "aws"})
 	c.Assert(err, check.IsNil)
 	serv, err := Get("aws::service")
 	c.Assert(err, check.DeepEquals, ErrServiceNotFound)
@@ -301,6 +307,10 @@ func (s *S) TestUpdateServiceReturnErrorIfServiceDoesNotExist(c *check.C) {
 
 func (s *S) TestGetServices(c *check.C) {
 	s.createService(c)
+	sb, err := BrokerService()
+	c.Assert(err, check.IsNil)
+	err = sb.Create(serviceTypes.Broker{Name: "aws"})
+	c.Assert(err, check.IsNil)
 	config := osbfake.FakeClientConfiguration{
 		CatalogReaction: &osbfake.CatalogReaction{Response: &osb.CatalogResponse{
 			Services: []osb.Service{
@@ -310,8 +320,6 @@ func (s *S) TestGetServices(c *check.C) {
 		}},
 	}
 	ClientFactory = osbfake.NewFakeClientFunc(config)
-	err := servicemanager.ServiceBroker.Create(serviceTypes.Broker{Name: "aws"})
-	c.Assert(err, check.IsNil)
 	services, err := GetServices()
 	c.Assert(err, check.IsNil)
 	c.Assert(services, check.DeepEquals, []Service{

--- a/service/suite_test.go
+++ b/service/suite_test.go
@@ -5,6 +5,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
@@ -13,6 +15,7 @@ import (
 	"github.com/tsuru/tsuru/servicemanager"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	serviceTypes "github.com/tsuru/tsuru/types/service"
 	"gopkg.in/check.v1"
 )
 
@@ -76,6 +79,12 @@ func (s *S) SetUpTest(c *check.C) {
 	servicemanager.Team = s.mockTeamService
 	servicemanager.ServiceBroker, err = BrokerService()
 	c.Assert(err, check.IsNil)
+
+	servicemanager.ServiceBrokerCatalogCache = &serviceTypes.MockServiceBrokerCatalogCacheService{
+		OnLoad: func(_ string) (*serviceTypes.BrokerCatalog, error) {
+			return nil, fmt.Errorf("not found")
+		},
+	}
 }
 
 func (s *S) TearDownSuite(c *check.C) {

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -9,13 +9,14 @@ import (
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/app/image"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 )
 
 // MockService is a struct to use in tests
 type MockService struct {
-	Cache         *app.MockCacheService
+	Cache         *cache.MockCacheService
 	Plan          *app.MockPlanService
 	Platform      *app.MockPlatformService
 	PlatformImage *image.MockPlatformImageService
@@ -27,7 +28,7 @@ type MockService struct {
 
 // SetMockService return a new MockService and set as a servicemanager
 func SetMockService(m *MockService) {
-	m.Cache = &app.MockCacheService{}
+	m.Cache = &cache.MockCacheService{}
 	m.Plan = &app.MockPlanService{}
 	m.Platform = &app.MockPlatformService{}
 	m.PlatformImage = &image.MockPlatformImageService{}

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -12,23 +12,26 @@ import (
 	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
+	"github.com/tsuru/tsuru/types/service"
 )
 
 // MockService is a struct to use in tests
 type MockService struct {
-	Cache         *cache.MockCacheService
-	Plan          *app.MockPlanService
-	Platform      *app.MockPlatformService
-	PlatformImage *image.MockPlatformImageService
-	Team          *auth.MockTeamService
-	UserQuota     *quota.MockQuotaService
-	AppQuota      *quota.MockQuotaService
-	Cluster       *provision.MockClusterService
+	Cache                     *cache.MockAppCacheService
+	Plan                      *app.MockPlanService
+	Platform                  *app.MockPlatformService
+	PlatformImage             *image.MockPlatformImageService
+	Team                      *auth.MockTeamService
+	UserQuota                 *quota.MockQuotaService
+	AppQuota                  *quota.MockQuotaService
+	Cluster                   *provision.MockClusterService
+	ServiceBroker             *service.MockServiceBrokerService
+	ServiceBrokerCatalogCache *service.MockServiceBrokerCatalogCacheService
 }
 
 // SetMockService return a new MockService and set as a servicemanager
 func SetMockService(m *MockService) {
-	m.Cache = &cache.MockCacheService{}
+	m.Cache = &cache.MockAppCacheService{}
 	m.Plan = &app.MockPlanService{}
 	m.Platform = &app.MockPlatformService{}
 	m.PlatformImage = &image.MockPlatformImageService{}
@@ -36,6 +39,8 @@ func SetMockService(m *MockService) {
 	m.UserQuota = &quota.MockQuotaService{}
 	m.AppQuota = &quota.MockQuotaService{}
 	m.Cluster = &provision.MockClusterService{}
+	m.ServiceBroker = &service.MockServiceBrokerService{}
+	m.ServiceBrokerCatalogCache = &service.MockServiceBrokerCatalogCacheService{}
 	servicemanager.AppCache = m.Cache
 	servicemanager.Plan = m.Plan
 	servicemanager.Platform = m.Platform
@@ -44,6 +49,8 @@ func SetMockService(m *MockService) {
 	servicemanager.UserQuota = m.UserQuota
 	servicemanager.AppQuota = m.AppQuota
 	servicemanager.Cluster = m.Cluster
+	servicemanager.ServiceBroker = m.ServiceBroker
+	servicemanager.ServiceBrokerCatalogCache = m.ServiceBrokerCatalogCache
 }
 
 func (m *MockService) ResetCache() {
@@ -107,4 +114,17 @@ func (m *MockService) ResetCluster() {
 	m.Cluster.OnFindByProvisioner = nil
 	m.Cluster.OnFindByPool = nil
 	m.Cluster.OnDelete = nil
+}
+
+func (m *MockService) ResetServiceBroker() {
+	m.ServiceBroker.OnCreate = nil
+	m.ServiceBroker.OnUpdate = nil
+	m.ServiceBroker.OnDelete = nil
+	m.ServiceBroker.OnFind = nil
+	m.ServiceBroker.OnList = nil
+}
+
+func (m *MockService) ResetServiceBrokerCatalogCache() {
+	m.ServiceBrokerCatalogCache.OnSave = nil
+	m.ServiceBrokerCatalogCache.OnLoad = nil
 }

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -36,7 +36,7 @@ func SetMockService(m *MockService) {
 	m.UserQuota = &quota.MockQuotaService{}
 	m.AppQuota = &quota.MockQuotaService{}
 	m.Cluster = &provision.MockClusterService{}
-	servicemanager.Cache = m.Cache
+	servicemanager.AppCache = m.Cache
 	servicemanager.Plan = m.Plan
 	servicemanager.Platform = m.Platform
 	servicemanager.PlatformImage = m.PlatformImage

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	AppCache                  cache.CacheService
+	AppCache                  cache.AppCacheService
 	Plan                      app.PlanService
 	Platform                  app.PlatformService
 	PlatformImage             image.PlatformImageService

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -27,5 +27,5 @@ var (
 	UserQuota                 quota.QuotaService
 	Cluster                   provision.ClusterService
 	ServiceBroker             service.ServiceBrokerService
-	ServiceBrokerCatalogCache cache.CacheService
+	ServiceBrokerCatalogCache service.ServiceBrokerCatalogCacheService
 )

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/app/image"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/event"
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
@@ -15,7 +16,7 @@ import (
 )
 
 var (
-	Cache         app.CacheService
+	Cache         cache.CacheService
 	Plan          app.PlanService
 	Platform      app.PlatformService
 	PlatformImage image.PlatformImageService

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	Cache         cache.CacheService
+	AppCache      cache.CacheService
 	Plan          app.PlanService
 	Platform      app.PlatformService
 	PlatformImage image.PlatformImageService

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -16,15 +16,16 @@ import (
 )
 
 var (
-	AppCache      cache.CacheService
-	Plan          app.PlanService
-	Platform      app.PlatformService
-	PlatformImage image.PlatformImageService
-	Team          auth.TeamService
-	TeamToken     auth.TeamTokenService
-	Webhook       event.WebhookService
-	AppQuota      quota.QuotaService
-	UserQuota     quota.QuotaService
-	Cluster       provision.ClusterService
-	ServiceBroker service.ServiceBrokerService
+	AppCache                  cache.CacheService
+	Plan                      app.PlanService
+	Platform                  app.PlatformService
+	PlatformImage             image.PlatformImageService
+	Team                      auth.TeamService
+	TeamToken                 auth.TeamTokenService
+	Webhook                   event.WebhookService
+	AppQuota                  quota.QuotaService
+	UserQuota                 quota.QuotaService
+	Cluster                   provision.ClusterService
+	ServiceBroker             service.ServiceBrokerService
+	ServiceBrokerCatalogCache cache.CacheService
 )

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tsuru/tsuru/types/app"
 	"github.com/tsuru/tsuru/types/app/image"
 	"github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/event"
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
@@ -22,7 +23,7 @@ type DbDriver struct {
 	TeamStorage          auth.TeamStorage
 	PlatformStorage      app.PlatformStorage
 	PlanStorage          app.PlanStorage
-	CacheStorage         app.CacheStorage
+	AppCacheStorage      cache.CacheStorage
 	TeamTokenStorage     auth.TeamTokenStorage
 	UserQuotaStorage     quota.QuotaStorage
 	AppQuotaStorage      quota.QuotaStorage

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -20,17 +20,18 @@ import (
 )
 
 type DbDriver struct {
-	TeamStorage          auth.TeamStorage
-	PlatformStorage      app.PlatformStorage
-	PlanStorage          app.PlanStorage
-	AppCacheStorage      cache.CacheStorage
-	TeamTokenStorage     auth.TeamTokenStorage
-	UserQuotaStorage     quota.QuotaStorage
-	AppQuotaStorage      quota.QuotaStorage
-	WebhookStorage       event.WebhookStorage
-	ClusterStorage       provision.ClusterStorage
-	ServiceBrokerStorage service.ServiceBrokerStorage
-	PlatformImageStorage image.PlatformImageStorage
+	TeamStorage                      auth.TeamStorage
+	PlatformStorage                  app.PlatformStorage
+	PlanStorage                      app.PlanStorage
+	AppCacheStorage                  cache.CacheStorage
+	TeamTokenStorage                 auth.TeamTokenStorage
+	UserQuotaStorage                 quota.QuotaStorage
+	AppQuotaStorage                  quota.QuotaStorage
+	WebhookStorage                   event.WebhookStorage
+	ClusterStorage                   provision.ClusterStorage
+	ServiceBrokerStorage             service.ServiceBrokerStorage
+	ServiceBrokerCatalogCacheStorage cache.CacheStorage
+	PlatformImageStorage             image.PlatformImageStorage
 }
 
 var (

--- a/storage/mongodb/app_cache.go
+++ b/storage/mongodb/app_cache.go
@@ -1,0 +1,13 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import "github.com/tsuru/tsuru/types/cache"
+
+func appCacheStorage() cache.CacheStorage {
+	return &cacheStorage{
+		collection: "cache",
+	}
+}

--- a/storage/mongodb/cache.go
+++ b/storage/mongodb/cache.go
@@ -7,11 +7,11 @@ package mongodb
 import (
 	"time"
 
-	mgo "github.com/globalsign/mgo"
+	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/tsuru/tsuru/db"
 	dbStorage "github.com/tsuru/tsuru/db/storage"
-	"github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/cache"
 )
 
 type cacheStorage struct {
@@ -32,7 +32,7 @@ func (s *cacheStorage) cacheCollection(conn *db.Storage) *dbStorage.Collection {
 	return c
 }
 
-func (s *cacheStorage) GetAll(keys ...string) ([]app.CacheEntry, error) {
+func (s *cacheStorage) GetAll(keys ...string) ([]cache.CacheEntry, error) {
 	conn, err := db.Conn()
 	if err != nil {
 		return nil, err
@@ -43,31 +43,31 @@ func (s *cacheStorage) GetAll(keys ...string) ([]app.CacheEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entries := make([]app.CacheEntry, len(dbEntries))
+	entries := make([]cache.CacheEntry, len(dbEntries))
 	for i := range dbEntries {
-		entries[i] = app.CacheEntry(dbEntries[i])
+		entries[i] = cache.CacheEntry(dbEntries[i])
 	}
 	return entries, nil
 }
 
-func (s *cacheStorage) Get(key string) (app.CacheEntry, error) {
+func (s *cacheStorage) Get(key string) (cache.CacheEntry, error) {
 	conn, err := db.Conn()
 	if err != nil {
-		return app.CacheEntry{}, err
+		return cache.CacheEntry{}, err
 	}
 	defer conn.Close()
 	var dbEntry mongoCacheEntry
 	err = s.cacheCollection(conn).FindId(key).One(&dbEntry)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return app.CacheEntry{}, app.ErrEntryNotFound
+			return cache.CacheEntry{}, cache.ErrEntryNotFound
 		}
-		return app.CacheEntry{}, err
+		return cache.CacheEntry{}, err
 	}
-	return app.CacheEntry(dbEntry), nil
+	return cache.CacheEntry(dbEntry), nil
 }
 
-func (s *cacheStorage) Put(entry app.CacheEntry) error {
+func (s *cacheStorage) Put(entry cache.CacheEntry) error {
 	conn, err := db.Conn()
 	if err != nil {
 		return err

--- a/storage/mongodb/cache_test.go
+++ b/storage/mongodb/cache_test.go
@@ -10,6 +10,6 @@ import (
 )
 
 var _ = check.Suite(&storagetest.CacheSuite{
-	CacheStorage: &cacheStorage{},
+	CacheStorage: &cacheStorage{collection: "cache"},
 	SuiteHooks:   &mongodbBaseTest{name: "cache"},
 })

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -10,17 +10,18 @@ import (
 
 func init() {
 	mongodbDriver := storage.DbDriver{
-		TeamStorage:          &TeamStorage{},
-		PlatformStorage:      &PlatformStorage{},
-		PlatformImageStorage: &PlatformImageStorage{},
-		PlanStorage:          &PlanStorage{},
-		AppCacheStorage:      appCacheStorage(),
-		TeamTokenStorage:     &teamTokenStorage{},
-		UserQuotaStorage:     authQuotaStorage(),
-		AppQuotaStorage:      appQuotaStorage(),
-		WebhookStorage:       &webhookStorage{},
-		ClusterStorage:       &clusterStorage{},
-		ServiceBrokerStorage: &serviceBrokerStorage{},
+		TeamStorage:                      &TeamStorage{},
+		PlatformStorage:                  &PlatformStorage{},
+		PlatformImageStorage:             &PlatformImageStorage{},
+		PlanStorage:                      &PlanStorage{},
+		AppCacheStorage:                  appCacheStorage(),
+		TeamTokenStorage:                 &teamTokenStorage{},
+		UserQuotaStorage:                 authQuotaStorage(),
+		AppQuotaStorage:                  appQuotaStorage(),
+		WebhookStorage:                   &webhookStorage{},
+		ClusterStorage:                   &clusterStorage{},
+		ServiceBrokerStorage:             &serviceBrokerStorage{},
+		ServiceBrokerCatalogCacheStorage: serviceBrokerCatalogCacheStorage(),
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -14,7 +14,7 @@ func init() {
 		PlatformStorage:      &PlatformStorage{},
 		PlatformImageStorage: &PlatformImageStorage{},
 		PlanStorage:          &PlanStorage{},
-		CacheStorage:         &cacheStorage{},
+		AppCacheStorage:      appCacheStorage(),
 		TeamTokenStorage:     &teamTokenStorage{},
 		UserQuotaStorage:     authQuotaStorage(),
 		AppQuotaStorage:      appQuotaStorage(),

--- a/storage/mongodb/service_broker_cache.go
+++ b/storage/mongodb/service_broker_cache.go
@@ -1,0 +1,13 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import "github.com/tsuru/tsuru/types/cache"
+
+func serviceBrokerCatalogCacheStorage() cache.CacheStorage {
+	return &cacheStorage{
+		collection: "service_broker_catalog_cache",
+	}
+}

--- a/storage/storagetest/cache_suite.go
+++ b/storage/storagetest/cache_suite.go
@@ -8,24 +8,24 @@ import (
 	"sort"
 	"time"
 
-	"github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/cache"
 	check "gopkg.in/check.v1"
 )
 
 type CacheSuite struct {
 	SuiteHooks
-	CacheStorage app.CacheStorage
+	CacheStorage cache.CacheStorage
 }
 
 func (s *CacheSuite) TestCachePut(c *check.C) {
-	err := s.CacheStorage.Put(app.CacheEntry{
+	err := s.CacheStorage.Put(cache.CacheEntry{
 		Key:   "k1",
 		Value: "v1",
 	})
 	c.Assert(err, check.IsNil)
 	entry, err := s.CacheStorage.Get("k1")
 	c.Assert(err, check.IsNil)
-	c.Assert(entry, check.DeepEquals, app.CacheEntry{
+	c.Assert(entry, check.DeepEquals, cache.CacheEntry{
 		Key:   "k1",
 		Value: "v1",
 	})
@@ -33,22 +33,22 @@ func (s *CacheSuite) TestCachePut(c *check.C) {
 
 func (s *CacheSuite) TestCacheGetNotFound(c *check.C) {
 	entry, err := s.CacheStorage.Get("k1")
-	c.Assert(err, check.Equals, app.ErrEntryNotFound)
-	c.Assert(entry, check.DeepEquals, app.CacheEntry{})
+	c.Assert(err, check.Equals, cache.ErrEntryNotFound)
+	c.Assert(entry, check.DeepEquals, cache.CacheEntry{})
 }
 
 func (s *CacheSuite) TestCacheGetAll(c *check.C) {
-	err := s.CacheStorage.Put(app.CacheEntry{
+	err := s.CacheStorage.Put(cache.CacheEntry{
 		Key:   "k1",
 		Value: "v1",
 	})
 	c.Assert(err, check.IsNil)
-	err = s.CacheStorage.Put(app.CacheEntry{
+	err = s.CacheStorage.Put(cache.CacheEntry{
 		Key:   "k2",
 		Value: "v2",
 	})
 	c.Assert(err, check.IsNil)
-	err = s.CacheStorage.Put(app.CacheEntry{
+	err = s.CacheStorage.Put(cache.CacheEntry{
 		Key:   "k3",
 		Value: "v3",
 	})
@@ -58,7 +58,7 @@ func (s *CacheSuite) TestCacheGetAll(c *check.C) {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Key < entries[j].Key
 	})
-	c.Assert(entries, check.DeepEquals, []app.CacheEntry{
+	c.Assert(entries, check.DeepEquals, []cache.CacheEntry{
 		{Key: "k1", Value: "v1"},
 		{Key: "k3", Value: "v3"},
 	})
@@ -68,7 +68,7 @@ func (s *CacheSuite) TestCacheGetAll(c *check.C) {
 }
 
 func (s *CacheSuite) TestCacheExpiration(c *check.C) {
-	err := s.CacheStorage.Put(app.CacheEntry{
+	err := s.CacheStorage.Put(cache.CacheEntry{
 		Key:      "k1",
 		Value:    "v1",
 		ExpireAt: time.Now().Add(time.Second),
@@ -81,7 +81,7 @@ func (s *CacheSuite) TestCacheExpiration(c *check.C) {
 	for {
 		_, err = s.CacheStorage.Get("k1")
 		if err != nil {
-			c.Assert(err, check.Equals, app.ErrEntryNotFound)
+			c.Assert(err, check.Equals, cache.ErrEntryNotFound)
 			break
 		}
 		select {

--- a/types/cache/cache.go
+++ b/types/cache/cache.go
@@ -20,7 +20,7 @@ type CacheEntry struct {
 	ExpireAt time.Time
 }
 
-type CacheService interface {
+type AppCacheService interface {
 	Create(entry CacheEntry) error
 	List(keys ...string) ([]CacheEntry, error)
 	FindByName(key string) (CacheEntry, error)

--- a/types/cache/cache.go
+++ b/types/cache/cache.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package app
+package cache
 
 import (
 	"time"

--- a/types/cache/cache_mock.go
+++ b/types/cache/cache_mock.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package app
+package cache
 
 var _ CacheStorage = &MockCacheStorage{}
 var _ CacheService = &MockCacheService{}

--- a/types/cache/cache_mock.go
+++ b/types/cache/cache_mock.go
@@ -5,7 +5,7 @@
 package cache
 
 var _ CacheStorage = &MockCacheStorage{}
-var _ CacheService = &MockCacheService{}
+var _ AppCacheService = &MockAppCacheService{}
 
 // MockCacheStorage implements CacheStorage interface
 type MockCacheStorage struct {
@@ -26,28 +26,28 @@ func (m *MockCacheStorage) Get(key string) (CacheEntry, error) {
 	return m.OnGet(key)
 }
 
-// MockCacheService implements CacheService interface
-type MockCacheService struct {
+// MockAppCacheService implements AppCacheService interface
+type MockAppCacheService struct {
 	OnCreate     func(CacheEntry) error
 	OnList       func(...string) ([]CacheEntry, error)
 	OnFindByName func(string) (CacheEntry, error)
 }
 
-func (m *MockCacheService) Create(e CacheEntry) error {
+func (m *MockAppCacheService) Create(e CacheEntry) error {
 	if m.OnCreate == nil {
 		return nil
 	}
 	return m.OnCreate(e)
 }
 
-func (m *MockCacheService) List(keys ...string) ([]CacheEntry, error) {
+func (m *MockAppCacheService) List(keys ...string) ([]CacheEntry, error) {
 	if m.OnList == nil {
 		return []CacheEntry{}, nil
 	}
 	return m.OnList(keys...)
 }
 
-func (m *MockCacheService) FindByName(k string) (CacheEntry, error) {
+func (m *MockAppCacheService) FindByName(k string) (CacheEntry, error) {
 	if m.OnFindByName == nil {
 		return CacheEntry{}, nil
 	}

--- a/types/service/broker.go
+++ b/types/service/broker.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"errors"
+	"time"
 )
 
 var (
@@ -37,6 +38,9 @@ type BrokerConfig struct {
 	// Context is a set of key/value pairs that are going to be added to every
 	// request to the Service Broker
 	Context map[string]interface{}
+	// CacheExpiration is a time period that the Service Broker catalog is kept
+	// in cache
+	CacheExpiration *time.Duration
 }
 
 // AuthConfig is a union-type representing the possible auth configurations a

--- a/types/service/broker_mock.go
+++ b/types/service/broker_mock.go
@@ -1,0 +1,51 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+var _ ServiceBrokerService = &MockServiceBrokerService{}
+
+// MockServiceBrokerService implements ServiceBrokerService interface
+type MockServiceBrokerService struct {
+	OnCreate func(Broker) error
+	OnUpdate func(string, Broker) error
+	OnDelete func(string) error
+	OnFind   func(string) (Broker, error)
+	OnList   func() ([]Broker, error)
+}
+
+func (m *MockServiceBrokerService) Create(broker Broker) error {
+	if m.OnCreate == nil {
+		return nil
+	}
+	return m.OnCreate(broker)
+}
+
+func (m *MockServiceBrokerService) Update(name string, broker Broker) error {
+	if m.OnUpdate == nil {
+		return nil
+	}
+	return m.OnUpdate(name, broker)
+}
+
+func (m *MockServiceBrokerService) Delete(name string) error {
+	if m.OnDelete == nil {
+		return nil
+	}
+	return m.OnDelete(name)
+}
+
+func (m *MockServiceBrokerService) Find(name string) (Broker, error) {
+	if m.OnFind == nil {
+		return Broker{}, nil
+	}
+	return m.OnFind(name)
+}
+
+func (m *MockServiceBrokerService) List() ([]Broker, error) {
+	if m.OnList == nil {
+		return nil, nil
+	}
+	return m.OnList()
+}

--- a/types/service/catalog.go
+++ b/types/service/catalog.go
@@ -34,3 +34,8 @@ type BrokerPlan struct {
 	// printing by a CLI.
 	Description string
 }
+
+type ServiceBrokerCatalogCacheService interface {
+	Save(string, BrokerCatalog) error
+	Load(string) (*BrokerCatalog, error)
+}

--- a/types/service/catalog.go
+++ b/types/service/catalog.go
@@ -33,6 +33,7 @@ type BrokerPlan struct {
 	// Description is a brief description of the plan, suitable for
 	// printing by a CLI.
 	Description string
+	Schemas     interface{}
 }
 
 type ServiceBrokerCatalogCacheService interface {

--- a/types/service/catalog.go
+++ b/types/service/catalog.go
@@ -1,0 +1,36 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package service
+
+// BrokerCatalog contains the data required to request services to a
+// Service Broker API.
+// Most of the fields are copied from osb client definition.
+type BrokerCatalog struct {
+	Services []BrokerService
+}
+
+// BrokerService is an available service listed in a broker's catalog.
+type BrokerService struct {
+	// ID is a globally unique ID that identifies the service.
+	ID string
+	// Name is the service's display name.
+	Name string
+	// Description is a brief description of the service, suitable for
+	// printing by a CLI.
+	Description string
+	// Plans is the list of the Plans for a service.  Plans represent
+	// different tiers.
+	Plans []BrokerPlan
+}
+
+// BrokerPlan is a plan (or tier) within a service offering.
+type BrokerPlan struct {
+	// ID is a globally unique ID that identifies the plan.
+	ID string
+	// Name is the plan's display name.
+	Name string
+	// Description is a brief description of the plan, suitable for
+	// printing by a CLI.
+	Description string
+}

--- a/types/service/catalog_mock.go
+++ b/types/service/catalog_mock.go
@@ -1,0 +1,27 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+var _ ServiceBrokerCatalogCacheService = &MockServiceBrokerCatalogCacheService{}
+
+// MockServiceBrokerCatalogCacheService implements ServiceBrokerCatalogCacheService interface
+type MockServiceBrokerCatalogCacheService struct {
+	OnSave func(string, BrokerCatalog) error
+	OnLoad func(string) (*BrokerCatalog, error)
+}
+
+func (m *MockServiceBrokerCatalogCacheService) Save(brokerName string, catalog BrokerCatalog) error {
+	if m.OnSave == nil {
+		return nil
+	}
+	return m.OnSave(brokerName, catalog)
+}
+
+func (m *MockServiceBrokerCatalogCacheService) Load(brokerName string) (*BrokerCatalog, error) {
+	if m.OnLoad == nil {
+		return nil, nil
+	}
+	return m.OnLoad(brokerName)
+}


### PR DESCRIPTION
In this PR, I've created a new service to handle caching service broker catalogs. The default cache time is 1 hour, but you can customize it per broker, with the `Config.CacheExpiration` flag in the api.

I also wanted to merge `ServiceBrokerService` and `ServiceBrokerCatalogCacheService` in a single service, but this PR is already too large.