### PR TITLE
provision/kubernetes: use informers for service and nodes

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -467,6 +467,9 @@ func appPodsFromNode(client *ClusterClient, nodeName string) ([]apiv1.Pod, error
 }
 
 func getServicePort(svcInformer v1informers.ServiceInformer, srvName, namespace string) (int32, error) {
+	if namespace == "" {
+		namespace = "default"
+	}
 	srv, err := svcInformer.Lister().Services(namespace).Get(srvName)
 	if err != nil {
 		return 0, errors.WithStack(err)

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	v1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -465,8 +466,8 @@ func appPodsFromNode(client *ClusterClient, nodeName string) ([]apiv1.Pod, error
 	return podsFromNode(client, nodeName, labelFilter)
 }
 
-func getServicePort(client *ClusterClient, srvName, namespace string) (int32, error) {
-	srv, err := client.CoreV1().Services(namespace).Get(srvName, metav1.GetOptions{})
+func getServicePort(svcInformer v1informers.ServiceInformer, srvName, namespace string) (int32, error) {
+	srv, err := svcInformer.Lister().Services(namespace).Get(srvName)
 	if err != nil {
 		return 0, errors.WithStack(err)
 	}

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -323,7 +323,8 @@ func (p *kubernetesProvisioner) podsToUnitsMultiple(client *ClusterClient, pods 
 		appMap[baseApp.GetName()] = baseApp
 	}
 	if len(baseNodes) == 0 {
-		nodeInformer, err := p.nodeInformerForCluster(client)
+		var nodeInformer v1informers.NodeInformer
+		nodeInformer, err = p.nodeInformerForCluster(client)
 		if err != nil {
 			return nil, err
 		}

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -551,7 +551,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 	s.mock.MockfakeNodes(c, srv.URL)
 	for _, a := range []provision.App{a1, a2} {
 		for i := 1; i <= 2; i++ {
-			err := s.podInformer.Informer().GetStore().Add(&apiv1.Pod{
+			_, err := s.client.CoreV1().Pods("default").Create(&apiv1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-%d", a.GetName(), i),
 					Labels: map[string]string{
@@ -649,7 +649,7 @@ func (s *S) TestUnitsSkipTerminating(c *check.C) {
 		if p.Labels["tsuru.io/app-process"] == "worker" {
 			deadline := int64(10)
 			p.Spec.ActiveDeadlineSeconds = &deadline
-			err = s.podInformer.Informer().GetStore().Update(&p)
+			_, err = s.client.CoreV1().Pods("default").Update(&p)
 			c.Assert(err, check.IsNil)
 		}
 	}
@@ -684,7 +684,7 @@ func (s *S) TestUnitsSkipEvicted(c *check.C) {
 		if p.Labels["tsuru.io/app-process"] == "worker" {
 			p.Status.Phase = apiv1.PodFailed
 			p.Status.Reason = "Evicted"
-			err = s.podInformer.Informer().GetStore().Update(&p)
+			_, err = s.client.CoreV1().Pods("default").Update(&p)
 			c.Assert(err, check.IsNil)
 		}
 	}


### PR DESCRIPTION
Now on a normal app-list operation it's not expected for any api call to the Kubernetes API.