### PR TITLE
provision/kubernetes: only query tsuru database once in Units call

### DIFF
--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -232,11 +232,15 @@ func (s *S) TestClustersForApps(c *check.C) {
 		Pools:       []string{"p1", "p2"},
 		Provisioner: provisionerName,
 	}
-	s.mockService.Cluster.OnFindByPool = func(prov, pool string) (*provTypes.Cluster, error) {
-		if pool == "p1" || pool == "p2" {
-			return &c2, nil
-		}
-		return &c1, nil
+	s.mockService.Cluster.OnFindByPools = func(prov string, pools []string) (map[string]provTypes.Cluster, error) {
+		sort.Strings(pools)
+		c.Assert(pools, check.DeepEquals, []string{"abc", "p1", "p2", "xyz"})
+		return map[string]provTypes.Cluster{
+			"p1":  c2,
+			"p2":  c2,
+			"xyz": c1,
+			"abc": c1,
+		}, nil
 	}
 	a1 := provisiontest.NewFakeApp("myapp1", "python", 0)
 	a1.Pool = "xyz"

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -213,7 +213,7 @@ func (s *S) TestNodeUnits(c *check.C) {
 			Type:        "python",
 			IP:          "",
 			Status:      "started",
-			Address:     &url.URL{Scheme: "http", Host: ""},
+			Address:     &url.URL{Scheme: "http", Host: ":30000"},
 		},
 	})
 }
@@ -381,7 +381,7 @@ func (s *S) TestNodeUnitsOnlyFromServices(c *check.C) {
 			Type:        "python",
 			IP:          "",
 			Status:      "started",
-			Address:     &url.URL{Scheme: "http", Host: ""},
+			Address:     &url.URL{Scheme: "http", Host: ":30000"},
 		},
 	})
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -534,7 +534,7 @@ func (s *S) TestUnits(c *check.C) {
 			Type:        "python",
 			IP:          "192.168.99.1",
 			Status:      "started",
-			Address:     &url.URL{Scheme: "http", Host: "192.168.99.1"},
+			Address:     &url.URL{Scheme: "http", Host: "192.168.99.1:30000"},
 		},
 	})
 }

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -176,4 +176,11 @@ func (s *S) SetUpTest(c *check.C) {
 	s.mockService.Cluster.OnFindByPool = func(provName, poolName string) (*provision.Cluster, error) {
 		return clust, nil
 	}
+	s.mockService.Cluster.OnFindByPools = func(provName string, poolNames []string) (map[string]provision.Cluster, error) {
+		ret := make(map[string]provision.Cluster)
+		for _, pool := range poolNames {
+			ret[pool] = *clust
+		}
+		return ret, nil
+	}
 }

--- a/types/provision/cluster.go
+++ b/types/provision/cluster.go
@@ -27,6 +27,7 @@ type ClusterService interface {
 	FindByName(string) (*Cluster, error)
 	FindByProvisioner(string) ([]Cluster, error)
 	FindByPool(string, string) (*Cluster, error)
+	FindByPools(string, []string) (map[string]Cluster, error)
 	Delete(Cluster) error
 }
 

--- a/types/provision/cluster_mock.go
+++ b/types/provision/cluster_mock.go
@@ -66,6 +66,7 @@ type MockClusterService struct {
 	OnFindByName        func(string) (*Cluster, error)
 	OnFindByProvisioner func(string) ([]Cluster, error)
 	OnFindByPool        func(string, string) (*Cluster, error)
+	OnFindByPools       func(string, []string) (map[string]Cluster, error)
 	OnDelete            func(Cluster) error
 }
 
@@ -109,6 +110,13 @@ func (m *MockClusterService) FindByPool(prov, pool string) (*Cluster, error) {
 		return nil, nil
 	}
 	return m.OnFindByPool(prov, pool)
+}
+
+func (m *MockClusterService) FindByPools(provisioner string, pool []string) (map[string]Cluster, error) {
+	if m.OnFindByPools == nil {
+		return nil, nil
+	}
+	return m.OnFindByPools(provisioner, pool)
 }
 
 func (m *MockClusterService) Delete(c Cluster) error {


### PR DESCRIPTION
This was acomplished by creating a new FindByPools method in the cluster service and not filtering which units we show ports anymore, if a Unit has a service pointing to it we'll show the service port.