### PR TITLE
Replace CacheExpiration field service broker catalog cache with CacheExpirationSeconds

### DIFF
--- a/api/service_broker.go
+++ b/api/service_broker.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/ajg/form"
 	"github.com/tsuru/tsuru/auth"
@@ -154,16 +153,6 @@ func decodeServiceBroker(request *http.Request) (*service.Broker, error) {
 	}
 	if err := dec.DecodeValues(&broker, request.Form); err != nil {
 		return nil, fmt.Errorf("unable to parse broker: %v", err)
-	}
-	cacheStr := request.FormValue("Config.CacheExpiration")
-	if len(cacheStr) > 0 {
-		cache, err := time.ParseDuration(cacheStr)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse cache expiration: %v", err)
-		}
-		broker.Config.CacheExpiration = &cache
-	} else {
-		broker.Config.CacheExpiration = nil
 	}
 	return &broker, nil
 }

--- a/api/service_broker_test.go
+++ b/api/service_broker_test.go
@@ -8,9 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"time"
 
-	"github.com/ajg/form"
 	"github.com/tsuru/tsuru/types/service"
 	check "gopkg.in/check.v1"
 )
@@ -71,19 +69,18 @@ func (s *S) TestServiceBrokerAdd(c *check.C) {
 		c.Assert(b, check.DeepEquals, expectedBroker)
 		return nil
 	}
-	bodyData, err := form.EncodeToString(expectedBroker)
+	bodyData, err := json.Marshal(expectedBroker)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("POST", "/1.7/brokers", strings.NewReader(bodyData))
+	request, err := http.NewRequest("POST", "/1.7/brokers", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
 }
 
 func (s *S) TestServiceBrokerAddWithCache(c *check.C) {
-	duration := 5 * time.Minute
 	expectedBroker := service.Broker{
 		Name: "broker-name",
 		URL:  "https://localhost:8080",
@@ -95,21 +92,21 @@ func (s *S) TestServiceBrokerAddWithCache(c *check.C) {
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
-			Context: nil,
+			CacheExpirationSeconds: 300,
+			Context:                nil,
 		},
 	}
 	s.mockService.ServiceBroker.OnCreate = func(b service.Broker) error {
-		expectedBroker.Config.CacheExpiration = &duration
 		c.Assert(b, check.DeepEquals, expectedBroker)
 		return nil
 	}
-	bodyData, err := form.EncodeToString(expectedBroker)
+	bodyData, err := json.Marshal(expectedBroker)
 	c.Assert(err, check.IsNil)
-	bodyData = "Config.CacheExpiration=5m&" + bodyData
-	request, err := http.NewRequest("POST", "/1.7/brokers", strings.NewReader(bodyData))
+	request, err := http.NewRequest("POST", "/1.7/brokers", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
+
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
@@ -132,11 +129,13 @@ func (s *S) TestServiceBrokerAddAlreadyExists(c *check.C) {
 		c.Assert(b.Name, check.Equals, broker.Name)
 		return service.ErrServiceBrokerAlreadyExists
 	}
-	body := strings.NewReader(`name=broker-name&url=https://localhost:8080`)
-	request, err := http.NewRequest("POST", "/1.7/brokers", body)
+	bodyData, err := json.Marshal(broker)
+	c.Assert(err, check.IsNil)
+	request, err := http.NewRequest("POST", "/1.7/brokers", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
+
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusConflict)
@@ -162,19 +161,18 @@ func (s *S) TestServiceBrokerUpdate(c *check.C) {
 		c.Assert(b, check.DeepEquals, broker)
 		return nil
 	}
-	bodyData, err := form.EncodeToString(broker)
+	bodyData, err := json.Marshal(broker)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
+	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 }
 
 func (s *S) TestServiceBrokerUpdateWithCache(c *check.C) {
-	duration := 2 * time.Hour
 	broker := service.Broker{
 		Name: "broker-name",
 		URL:  "https://localhost:9090",
@@ -186,22 +184,21 @@ func (s *S) TestServiceBrokerUpdateWithCache(c *check.C) {
 				},
 				BearerConfig: &service.BearerConfig{},
 			},
-			Context: nil,
+			CacheExpirationSeconds: 7200,
+			Context:                nil,
 		},
 	}
 	s.mockService.ServiceBroker.OnUpdate = func(name string, b service.Broker) error {
-		broker.Config.CacheExpiration = &duration
 		c.Assert(name, check.Equals, "broker-name")
 		c.Assert(b, check.DeepEquals, broker)
 		return nil
 	}
-	bodyData, err := form.EncodeToString(broker)
+	bodyData, err := json.Marshal(broker)
 	c.Assert(err, check.IsNil)
-	bodyData = "Config.CacheExpiration=2h&" + bodyData
-	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
+	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
@@ -214,12 +211,12 @@ func (s *S) TestServiceBrokerUpdateNotFound(c *check.C) {
 		c.Assert(b.Name, check.Equals, broker.Name)
 		return service.ErrServiceBrokerNotFound
 	}
-	bodyData, err := form.EncodeToString(broker)
+	bodyData, err := json.Marshal(broker)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
+	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
@@ -227,12 +224,12 @@ func (s *S) TestServiceBrokerUpdateNotFound(c *check.C) {
 
 func (s *S) TestServiceBrokerUpdateUnauthorized(c *check.C) {
 	broker := service.Broker{Name: "broker"}
-	bodyData, err := form.EncodeToString(broker)
+	bodyData, err := json.Marshal(broker)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(bodyData))
+	request, err := http.NewRequest("PUT", "/1.7/brokers/broker-name", strings.NewReader(string(bodyData)))
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer 12345")
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusUnauthorized)
@@ -246,7 +243,7 @@ func (s *S) TestServiceBrokerDelete(c *check.C) {
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
@@ -260,7 +257,7 @@ func (s *S) TestServiceBrokerDeleteNotFound(c *check.C) {
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
@@ -270,7 +267,7 @@ func (s *S) TestServiceBrokerDeleteUnauthorized(c *check.C) {
 	request, err := http.NewRequest("DELETE", "/1.7/brokers/broker-name", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer 12345")
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusUnauthorized)

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -2827,5 +2827,5 @@ definitions:
                 properties:
                   token:
                     type: string
-          CacheExpiration:
-            type: string
+          CacheExpirationSeconds:
+            type: integer

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -65,7 +65,7 @@ func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*service.Bro
 func (s *serviceBrokerCatalogCacheService) expirationTime(brokerName string) time.Time {
 	expiration := defaultExpiration
 	sb, err := servicemanager.ServiceBroker.Find(brokerName)
-	if err == nil && sb.Config.CacheExpirationSeconds != 0 {
+	if err == nil && sb.Config.CacheExpirationSeconds > 0 {
 		expiration = time.Duration(sb.Config.CacheExpirationSeconds) * time.Second
 	}
 	return time.Now().Add(expiration)

--- a/service/broker_catalog_cache.go
+++ b/service/broker_catalog_cache.go
@@ -65,8 +65,8 @@ func (s *serviceBrokerCatalogCacheService) Load(brokerName string) (*service.Bro
 func (s *serviceBrokerCatalogCacheService) expirationTime(brokerName string) time.Time {
 	expiration := defaultExpiration
 	sb, err := servicemanager.ServiceBroker.Find(brokerName)
-	if err == nil && sb.Config.CacheExpiration != nil {
-		expiration = *sb.Config.CacheExpiration
+	if err == nil && sb.Config.CacheExpirationSeconds != 0 {
+		expiration = time.Duration(sb.Config.CacheExpirationSeconds) * time.Second
 	}
 	return time.Now().Add(expiration)
 }

--- a/service/broker_catalog_cache_test.go
+++ b/service/broker_catalog_cache_test.go
@@ -46,13 +46,13 @@ func (s *S) TestCacheSaveDefaultExpiration(c *check.C) {
 
 func (s *S) TestCacheSaveCustomExpiration(c *check.C) {
 	var calls int32
+	duration := 300
 	s.mockService.ServiceBroker.OnFind = func(name string) (service.Broker, error) {
 		atomic.AddInt32(&calls, 1)
-		duration := time.Duration(5 * time.Minute)
 		return service.Broker{
 			Name: name,
 			Config: service.BrokerConfig{
-				CacheExpiration: &duration,
+				CacheExpirationSeconds: duration,
 			},
 		}, nil
 	}
@@ -66,7 +66,7 @@ func (s *S) TestCacheSaveCustomExpiration(c *check.C) {
 		storage: &cache.MockCacheStorage{
 			OnPut: func(entry cache.CacheEntry) error {
 				atomic.AddInt32(&calls, 1)
-				c.Assert(time.Until(entry.ExpireAt) <= time.Duration(5*time.Minute), check.Equals, true)
+				c.Assert(time.Until(entry.ExpireAt) <= time.Duration(time.Duration(duration)*time.Second), check.Equals, true)
 				return nil
 			},
 		},

--- a/service/broker_service.go
+++ b/service/broker_service.go
@@ -34,6 +34,15 @@ func (b *brokerService) Create(broker serviceTypes.Broker) error {
 }
 
 func (b *brokerService) Update(name string, broker serviceTypes.Broker) error {
+	if broker.Config.CacheExpirationSeconds == 0 {
+		sb, err := b.Find(name)
+		if err != nil {
+			return err
+		}
+		broker.Config.CacheExpirationSeconds = sb.Config.CacheExpirationSeconds
+	} else if broker.Config.CacheExpirationSeconds < 0 {
+		broker.Config.CacheExpirationSeconds = 0
+	}
 	return b.storage.Update(name, broker)
 }
 

--- a/types/service/broker.go
+++ b/types/service/broker.go
@@ -6,7 +6,6 @@ package service
 
 import (
 	"errors"
-	"time"
 )
 
 var (
@@ -38,9 +37,9 @@ type BrokerConfig struct {
 	// Context is a set of key/value pairs that are going to be added to every
 	// request to the Service Broker
 	Context map[string]interface{}
-	// CacheExpiration is a time period that the Service Broker catalog is kept
-	// in cache
-	CacheExpiration *time.Duration
+	// CacheExpirationSeconds is a time duration in seconds that the Service
+	// Broker catalog is kept in cache
+	CacheExpirationSeconds int
 }
 
 // AuthConfig is a union-type representing the possible auth configurations a


### PR DESCRIPTION
The previous `CacheExpiration *time.Duration` field was hard to manipulate in the api. In this PR, this field is replaced with `CacheExpirationSeconds int`. The logic to convert strings like `5m` to seconds will be done in the client.

Also, change the service broker update logic to keep the previous value when `CacheExpirationSeconds` is zero, and change to the default value when it's negative.