### PR TITLE
Add validation to environment variable names 

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -948,11 +948,15 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	return a.SetEnvs(bind.SetEnvArgs{
+	err = a.SetEnvs(bind.SetEnvArgs{
 		Envs:          variables,
 		ShouldRestart: !e.NoRestart,
 		Writer:        writer,
 	})
+	if v, ok := err.(*errors.ValidationError); ok {
+		return &errors.HTTP{Code: http.StatusBadRequest, Message: v.Message}
+	}
+	return err
 }
 
 // title: unset envs


### PR DESCRIPTION
Kubernetes validates env var names, which may result in errors when an app is migrated from Docker cluster to Kubernetes.

The Kubernetes regexp to validate env vars is `[-._a-zA-Z][-._a-zA-Z0-9]*`, which allows var names like `----` and `.`. I decided to make a more restrictive validation, ensuring the first character is a letter and avoiding dots.

This fixes #2144