### PR TITLE
provision/kubernetes: handle deployment rollback on first deploys

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -926,6 +926,10 @@ func (m *serviceManager) DeployService(ctx context.Context, a provision.App, pro
 			oldDep.ResourceVersion = ""
 			fmt.Fprintf(m.writer, "\n**** UPDATING BACK AFTER FAILURE ****\n ---> %s <---\n", err)
 			_, rollbackErr = m.client.AppsV1beta2().Deployments(ns).Update(oldDep)
+		} else if oldDep == nil && newDep != nil {
+			// We have just created the deployment, so we need to remove it
+			fmt.Fprintf(m.writer, "\n**** DELETING CREATED DEPLOYMENT AFTER FAILURE ****\n ---> %s <---\n", err)
+			rollbackErr = m.client.AppsV1beta2().Deployments(ns).Delete(newDep.Name, &metav1.DeleteOptions{})
 		} else {
 			fmt.Fprintf(m.writer, "\n**** ROLLING BACK AFTER FAILURE ****\n ---> %s <---\n", err)
 			rollbackErr = m.client.ExtensionsV1beta1().Deployments(ns).Rollback(&extensions.DeploymentRollback{

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1837,6 +1837,7 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
+	waitDep()
 	c.Assert(err, check.IsNil)
 	var rollbackObj *extensions.DeploymentRollback
 	ns, err := s.client.AppNamespace(a)
@@ -1887,6 +1888,7 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
+	waitDep()
 	c.Assert(err, check.ErrorMatches, "^timeout waiting healthcheck after .+ waiting for units: Pod myapp-p1-pod-2-1: invalid pod phase \"Running\"$")
 	c.Assert(rollbackObj, check.DeepEquals, &extensions.DeploymentRollback{
 		Name: "myapp-p1",
@@ -1906,6 +1908,7 @@ func (s *S) TestServiceManagerDeployServiceRollbackHealthcheckTimeout(c *check.C
 	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
 		"p1": servicecommon.ProcessState{Start: true},
 	}, nil)
+	waitDep()
 	c.Assert(err, check.ErrorMatches, "^timeout waiting healthcheck after .+ waiting for units: Pod myapp-p1-pod-3-1: invalid pod phase \"Running\" - last event: my evt message$")
 }
 


### PR DESCRIPTION
Prior to this change, if the first deploy of an app fails, tsuru would not properly rollback the Deployment. In this case, the correct rollback procedure would be to delete Deployment.

This change checks if the current operation created a Deployment object
and deletes it after the operation fails.

Fixes #2132.