### PR TITLE
Improve name validation for Kubernetes

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1393,7 +1393,7 @@ func (s *S) TestCreateAppInvalidName(c *check.C) {
 	request.Header.Set("Authorization", "b "+token.GetValue())
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
-	msg := "Invalid app name, your app should have at most 63 " +
+	msg := "Invalid app name, your app should have at most 40 " +
 		"characters, containing only lower case letters, numbers " +
 		"or dashes, starting with a letter."
 	c.Assert(recorder.Body.String(), check.Equals, msg+"\n")

--- a/api/volume.go
+++ b/api/volume.go
@@ -137,7 +137,7 @@ func volumeCreate(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 	if err == nil {
 		return &errors.HTTP{Code: http.StatusConflict, Message: "volume already exists"}
 	}
-	err = inputVolume.Save()
+	err = inputVolume.Create()
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func volumeUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	return inputVolume.Save()
+	return inputVolume.Update()
 }
 
 // title: volume plan list

--- a/api/volume_test.go
+++ b/api/volume_test.go
@@ -27,7 +27,7 @@ func (s *S) TestVolumeList(c *check.C) {
 	config.Set("volume-plans:nfs:fake:access-modes", "ReadWriteMany")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	url := "/1.4/volumes"
 	request, err := http.NewRequest("GET", url, nil)
@@ -60,10 +60,10 @@ func (s *S) TestVolumeListPermissions(c *check.C) {
 	err := pool.AddPool(pool.AddPoolOptions{Name: "otherpool", Public: true})
 	c.Assert(err, check.IsNil)
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: "otherteam", Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	v2 := volume.Volume{Name: "v2", Pool: "otherpool", TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v2.Save()
+	err = v2.Create()
 	c.Assert(err, check.IsNil)
 	token1 := userWithPermission(c, permission.Permission{
 		Scheme:  permission.PermVolumeRead,
@@ -109,7 +109,7 @@ func (s *S) TestVolumeListBinded(c *check.C) {
 	err := app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	err = v1.BindApp(a.Name, "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -162,7 +162,7 @@ func (s *S) TestVolumeInfo(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	url := "/1.4/volumes/v1"
 	request, err := http.NewRequest("GET", url, nil)
@@ -229,7 +229,7 @@ func (s *S) TestVolumeCreateConflict(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	body := strings.NewReader(`name=v1&pool=test1&teamowner=tsuruteam&plan.name=nfs&status=ignored&plan.opts.something=ignored`)
 	url := "/1.4/volumes"
@@ -246,7 +246,7 @@ func (s *S) TestVolumeUpdate(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}, Opts: map[string]string{"a": "b"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	body := strings.NewReader(`name=v1&pool=test1&teamowner=tsuruteam&plan.name=nfs&status=ignored&plan.opts.something=ignored&opts.a=c`)
 	url := "/1.4/volumes/v1"
@@ -320,7 +320,7 @@ func (s *S) TestVolumeDelete(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	url := "/1.4/volumes/v1"
 	request, err := http.NewRequest("DELETE", url, nil)
@@ -342,7 +342,7 @@ func (s *S) TestVolumeBind(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err = app.CreateApp(&a, s.user)
@@ -407,7 +407,7 @@ func (s *S) TestVolumeBindConflict(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err = app.CreateApp(&a, s.user)
@@ -439,7 +439,7 @@ func (s *S) TestVolumeBindNoRestart(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err := v1.Save()
+	err := v1.Create()
 	c.Assert(err, check.IsNil)
 	a := app.App{Name: "myapp", TeamOwner: s.team.Name}
 	err = app.CreateApp(&a, s.user)
@@ -467,7 +467,7 @@ func (s *S) TestVolumeUnbind(c *check.C) {
 	err := app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	err = v1.BindApp(a.Name, "/mnt1", false)
 	c.Assert(err, check.IsNil)
@@ -518,7 +518,7 @@ func (s *S) TestVolumeUnbindNotFound(c *check.C) {
 	err := app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	url := "/1.4/volumes/v1/bind?app=myapp&mountpoint=/mnt1"
 	request, err := http.NewRequest("DELETE", url, nil)
@@ -540,7 +540,7 @@ func (s *S) TestVolumeUnbindNoRestart(c *check.C) {
 	err := app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	err = v1.BindApp(a.Name, "/mnt1", false)
 	c.Assert(err, check.IsNil)

--- a/app/app.go
+++ b/app/app.go
@@ -1151,7 +1151,7 @@ func (app *App) getEnv(name string) (bind.EnvVar, error) {
 // validate checks app name format
 func (app *App) validate() error {
 	if app.Name == InternalAppName || !validation.ValidateName(app.Name) {
-		msg := "Invalid app name, your app should have at most 63 " +
+		msg := "Invalid app name, your app should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."
 		return &tsuruErrors.ValidationError{Message: msg}

--- a/app/app.go
+++ b/app/app.go
@@ -433,7 +433,7 @@ func CreateApp(app *App, user *auth.User) error {
 	app.Teams = []string{app.TeamOwner}
 	app.Owner = user.Email
 	app.Tags = processTags(app.Tags)
-	err = app.validate()
+	err = app.validateNew()
 	if err != nil {
 		return err
 	}
@@ -1148,14 +1148,19 @@ func (app *App) getEnv(name string) (bind.EnvVar, error) {
 	return bind.EnvVar{}, errors.New("Environment variable not declared for this app.")
 }
 
-// validate checks app name format
-func (app *App) validate() error {
+// validateNew checks app name format and pool
+func (app *App) validateNew() error {
 	if app.Name == InternalAppName || !validation.ValidateName(app.Name) {
 		msg := "Invalid app name, your app should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."
 		return &tsuruErrors.ValidationError{Message: msg}
 	}
+	return app.validate()
+}
+
+// validate checks app pool
+func (app *App) validate() error {
 	return app.validatePool()
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -241,7 +241,7 @@ func (s *S) TestDeleteWithBoundVolumes(c *check.C) {
 	config.Set("volume-plans:nfs:fake:plugin", "nfs")
 	defer config.Unset("volume-plans")
 	v1 := volume.Volume{Name: "v1", Pool: s.Pool, TeamOwner: s.team.Name, Plan: volume.VolumePlan{Name: "nfs"}}
-	err = v1.Save()
+	err = v1.Create()
 	c.Assert(err, check.IsNil)
 	err = v1.BindApp(a.Name, "/mnt", false)
 	c.Assert(err, check.IsNil)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -441,7 +441,7 @@ func (s *S) TestCantCreateAppWithInvalidName(c *check.C) {
 	c.Assert(err, check.NotNil)
 	e, ok := err.(*errors.ValidationError)
 	c.Assert(ok, check.Equals, true)
-	msg := "Invalid app name, your app should have at most 63 " +
+	msg := "Invalid app name, your app should have at most 40 " +
 		"characters, containing only lower case letters, numbers or dashes, " +
 		"starting with a letter."
 	c.Assert(e.Message, check.Equals, msg)
@@ -2331,7 +2331,7 @@ func (s *S) TestIsValid(c *check.C) {
 		Blacklist: true,
 	})
 	c.Assert(err, check.IsNil)
-	errMsg := "Invalid app name, your app should have at most 63 characters, containing only lower case letters, numbers or dashes, starting with a letter."
+	errMsg := "Invalid app name, your app should have at most 40 characters, containing only lower case letters, numbers or dashes, starting with a letter."
 	var data = []struct {
 		name      string
 		teamOwner string
@@ -2339,9 +2339,9 @@ func (s *S) TestIsValid(c *check.C) {
 		router    string
 		expected  string
 	}{
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyapp", s.team.Name, "pool1", "fake", errMsg},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyap", s.team.Name, "pool1", "fake", errMsg},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmya", s.team.Name, "pool1", "fake", ""},
+		{"myappmyappmyappmyappmyappmyappmyappmyappmy", s.team.Name, "pool1", "fake", errMsg},
+		{"myappmyappmyappmyappmyappmyappmyappmyappm", s.team.Name, "pool1", "fake", errMsg},
+		{"myappmyappmyappmyappmyappmyappmyappmyapp", s.team.Name, "pool1", "fake", ""},
 		{"myApp", s.team.Name, "pool1", "fake", errMsg},
 		{"my app", s.team.Name, "pool1", "fake", errMsg},
 		{"123myapp", s.team.Name, "pool1", "fake", errMsg},

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2358,7 +2358,7 @@ func (s *S) TestIsValid(c *check.C) {
 	}
 	for _, d := range data {
 		a := App{Name: d.name, TeamOwner: d.teamOwner, Pool: d.pool, Routers: []appTypes.AppRouter{{Name: d.router}}}
-		if valid := a.validate(); valid != nil && valid.Error() != d.expected {
+		if valid := a.validateNew(); valid != nil && valid.Error() != d.expected {
 			c.Errorf("Is %q a valid app? Expected: %v. Got: %v.", d.name, d.expected, valid)
 		}
 	}
@@ -4564,6 +4564,19 @@ func (s *S) TestAppMetricEnvs(c *check.C) {
 		"METRICS_BACKEND":      "LOGSTASH",
 	}
 	c.Assert(envs, check.DeepEquals, expected)
+}
+
+func (s *S) TestUpdateAppWithInvalidName(c *check.C) {
+	app := App{Name: "app with invalid name", Platform: "python", TeamOwner: s.team.Name, Pool: s.Pool}
+	err := s.conn.Apps().Insert(app)
+	c.Assert(err, check.IsNil)
+
+	updateData := App{Name: app.Name, Description: "bleble"}
+	err = app.Update(updateData, new(bytes.Buffer))
+	c.Assert(err, check.IsNil)
+	dbApp, err := GetByName(app.Name)
+	c.Assert(err, check.IsNil)
+	c.Assert(dbApp.Description, check.Equals, "bleble")
 }
 
 func (s *S) TestUpdateDescription(c *check.C) {

--- a/app/platform_test.go
+++ b/app/platform_test.go
@@ -88,13 +88,12 @@ func (s *PlatformSuite) TestPlatformCreateValidatesPlatformName(c *check.C) {
 		{"plat_form", appTypes.ErrInvalidPlatformName},
 		{"123platform", appTypes.ErrInvalidPlatformName},
 		{"plat-form", nil},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyapp", appTypes.ErrInvalidPlatformName},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyap", appTypes.ErrInvalidPlatformName},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmya", nil},
+		{"myapp-41-characters-ppmyappmyappmyappmyap", appTypes.ErrInvalidPlatformName},
+		{"myapp-40-characters-ppmyappmyappmyappmya", nil},
 	}
 	for _, t := range tt {
 		err := ps.Create(appTypes.PlatformOptions{Name: t.name})
-		c.Assert(err, check.DeepEquals, t.expectedErr)
+		c.Check(err, check.DeepEquals, t.expectedErr)
 	}
 }
 

--- a/event/webhook/webhook.go
+++ b/event/webhook/webhook.go
@@ -267,11 +267,12 @@ func (s *webhookService) Create(w eventTypes.Webhook) error {
 	if w.Name == "" {
 		return &tsuruErrors.ValidationError{Message: "webhook name must not be empty"}
 	}
-	err := validation.EnsureValidateName(w.Name)
-	if err != nil {
-		return err
+	if !validation.ValidateName(w.Name) {
+		return &tsuruErrors.ValidationError{Message: "Invalid webhook name, webhook name should have at most 40 " +
+			"characters, containing only lower case letters, numbers or dashes, " +
+			"starting with a letter."}
 	}
-	err = validateURLs(w)
+	err := validateURLs(w)
 	if err != nil {
 		return err
 	}

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -289,9 +289,11 @@ func (s *S) TestWebhookServiceCreateInvalid(c *check.C) {
 			expectedErr: &errors.ValidationError{Message: "webhook name must not be empty"},
 		},
 		{
-			name:        "_-*x",
-			url:         "http://a",
-			expectedErr: &errors.ValidationError{Message: "name does not match regex \"^[a-z][a-z0-9-]{0,39}$\""},
+			name: "_-*x",
+			url:  "http://a",
+			expectedErr: &errors.ValidationError{Message: "Invalid webhook name, webhook name should have at most 40 " +
+				"characters, containing only lower case letters, numbers or dashes, " +
+				"starting with a letter."},
 		},
 		{
 			name: "c",

--- a/provision/cluster/cluster.go
+++ b/provision/cluster/cluster.go
@@ -112,7 +112,7 @@ func (s *clusterService) validate(c provTypes.Cluster) error {
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: "cluster name is mandatory"})
 	}
 	if !validation.ValidateName(c.Name) {
-		msg := "Invalid cluster name, cluster name should have at most 63 " +
+		msg := "Invalid cluster name, cluster name should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: msg})

--- a/provision/cluster/cluster.go
+++ b/provision/cluster/cluster.go
@@ -38,22 +38,27 @@ func ClusterService() (provTypes.ClusterService, error) {
 }
 
 func (s *clusterService) Create(c provTypes.Cluster) error {
-	if err := s.createClusterMachine(&c); err != nil {
+	err := s.createClusterMachine(&c)
+	if err != nil {
+		return err
+	}
+	err = s.validate(c, true)
+	if err != nil {
 		return err
 	}
 	return s.save(c)
 }
 
 func (s *clusterService) Update(c provTypes.Cluster) error {
+	err := s.validate(c, false)
+	if err != nil {
+		return err
+	}
 	return s.save(c)
 }
 
 func (s *clusterService) save(c provTypes.Cluster) error {
-	err := s.validate(c)
-	if err != nil {
-		return err
-	}
-	err = s.initCluster(c)
+	err := s.initCluster(c)
 	if err != nil {
 		return err
 	}
@@ -106,12 +111,12 @@ func (s *clusterService) Delete(c provTypes.Cluster) error {
 	return s.storage.Delete(c)
 }
 
-func (s *clusterService) validate(c provTypes.Cluster) error {
+func (s *clusterService) validate(c provTypes.Cluster, isNewCluster bool) error {
 	c.Name = strings.TrimSpace(c.Name)
 	if c.Name == "" {
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: "cluster name is mandatory"})
 	}
-	if !validation.ValidateName(c.Name) {
+	if isNewCluster && !validation.ValidateName(c.Name) {
 		msg := "Invalid cluster name, cluster name should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."

--- a/provision/cluster/cluster_test.go
+++ b/provision/cluster/cluster_test.go
@@ -166,7 +166,7 @@ func (s *S) TestClusterServiceUpdateValidationError(c *check.C) {
 				Default:     true,
 				Provisioner: "fake",
 			},
-			err: "Invalid cluster name, cluster name should have at most 63 " +
+			err: "Invalid cluster name, cluster name should have at most 40 " +
 				"characters, containing only lower case letters, numbers or dashes, " +
 				"starting with a letter.",
 		},
@@ -177,7 +177,7 @@ func (s *S) TestClusterServiceUpdateValidationError(c *check.C) {
 				Default:     true,
 				Provisioner: "fake",
 			},
-			err: "Invalid cluster name, cluster name should have at most 63 " +
+			err: "Invalid cluster name, cluster name should have at most 40 " +
 				"characters, containing only lower case letters, numbers or dashes, " +
 				"starting with a letter.",
 		},
@@ -188,18 +188,18 @@ func (s *S) TestClusterServiceUpdateValidationError(c *check.C) {
 				Default:     true,
 				Provisioner: "fake",
 			},
-			err: "Invalid cluster name, cluster name should have at most 63 " +
+			err: "Invalid cluster name, cluster name should have at most 40 " +
 				"characters, containing only lower case letters, numbers or dashes, " +
 				"starting with a letter.",
 		},
 		{
 			c: provTypes.Cluster{
-				Name:        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				Name:        "41-characters-ccccccccccccccccccccccccccc",
 				Addresses:   []string{"addr1", "addr2"},
 				Default:     true,
 				Provisioner: "fake",
 			},
-			err: "Invalid cluster name, cluster name should have at most 63 " +
+			err: "Invalid cluster name, cluster name should have at most 40 " +
 				"characters, containing only lower case letters, numbers or dashes, " +
 				"starting with a letter.",
 		},

--- a/provision/kubernetes/builder.go
+++ b/provision/kubernetes/builder.go
@@ -33,7 +33,7 @@ func (c *KubeClient) BuildPod(a provision.App, evt *event.Event, archiveFile io.
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	buildPodName, err := buildPodNameForApp(a, "")
+	buildPodName, err := buildPodNameForApp(a)
 	if err != nil {
 		return "", err
 	}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -174,7 +174,7 @@ func createBuildPod(ctx context.Context, params createPodParams) error {
 	cmds := dockercommon.ArchiveBuildCmds(params.app, "file:///home/application/archive.tar.gz")
 	if params.podName == "" {
 		var err error
-		if params.podName, err = buildPodNameForApp(params.app, ""); err != nil {
+		if params.podName, err = buildPodNameForApp(params.app); err != nil {
 			return err
 		}
 	}

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1727,7 +1727,7 @@ func (s *S) TestServiceManagerDeployServiceWithVolumes(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -97,7 +97,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		"tsuru.io/app-pool":             "test-default",
 		"tsuru.io/provisioner":          "kubernetes",
 		"tsuru.io/builder":              "",
-		"app":                           "tsuru-app-myapp-p1",
+		"app":                           "myapp-p1",
 	}
 	podLabels := make(map[string]string)
 	for k, v := range depLabels {

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -76,15 +76,12 @@ func deployPodNameForApp(a provision.App) (string, error) {
 	return fmt.Sprintf("%s-%s-deploy", name, version), nil
 }
 
-func buildPodNameForApp(a provision.App, suffix string) (string, error) {
+func buildPodNameForApp(a provision.App) (string, error) {
 	version, err := image.AppCurrentImageVersion(a.GetName())
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to retrieve app current image version")
 	}
 	name := validKubeName(a.GetName())
-	if suffix != "" {
-		return fmt.Sprintf("%s-%s-build-%s", name, version, suffix), nil
-	}
 	return fmt.Sprintf("%s-%s-build", name, version), nil
 }
 

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -60,15 +60,11 @@ func serviceAccountNameForNodeContainer(nodeContainer nodecontainer.NodeContaine
 }
 
 func deploymentNameForApp(a provision.App, process string) string {
-	name := validKubeName(a.GetName())
-	process = validKubeName(process)
-	return fmt.Sprintf("%s-%s", name, process)
+	return appProcessName(a, process)
 }
 
 func headlessServiceNameForApp(a provision.App, process string) string {
-	name := validKubeName(a.GetName())
-	process = validKubeName(process)
-	return fmt.Sprintf("%s-%s-units", name, process)
+	return fmt.Sprintf("%s-units", appProcessName(a, process))
 }
 
 func deployPodNameForApp(a provision.App) (string, error) {
@@ -93,6 +89,10 @@ func buildPodNameForApp(a provision.App, suffix string) (string, error) {
 }
 
 func appLabelForApp(a provision.App, process string) string {
+	return appProcessName(a, process)
+}
+
+func appProcessName(a provision.App, process string) string {
 	name := validKubeName(a.GetName())
 	process = validKubeName(process)
 	label := fmt.Sprintf("%s-%s", name, process)

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -93,7 +93,7 @@ func buildPodNameForApp(a provision.App, suffix string) (string, error) {
 func appLabelForApp(a provision.App, process string) string {
 	name := validKubeName(a.GetName())
 	process = validKubeName(process)
-	return fmt.Sprintf("tsuru-app-%s-%s", name, process)
+	return fmt.Sprintf("%s-%s", name, process)
 }
 
 func execCommandPodNameForApp(a provision.App) string {

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -33,7 +33,7 @@ func (s *S) TestServiceAccountNameForApp(c *check.C) {
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		c.Assert(serviceAccountNameForApp(a), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(serviceAccountNameForApp(a), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 
@@ -46,7 +46,7 @@ func (s *S) TestServiceAccountNameForNodeContainer(c *check.C) {
 		{"my-nc_nc", "node-container-my-nc-nc"},
 	}
 	for i, tt := range tests {
-		c.Assert(serviceAccountNameForNodeContainer(nodecontainer.NodeContainerConfig{
+		c.Check(serviceAccountNameForNodeContainer(nodecontainer.NodeContainerConfig{
 			Name: tt.name,
 		}), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
@@ -99,8 +99,8 @@ func (s *S) TestDeployPodNameForApp(c *check.C) {
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
 		name, err := deployPodNameForApp(a)
-		c.Assert(err, check.IsNil)
-		c.Assert(name, check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(err, check.IsNil)
+		c.Check(name, check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 
@@ -114,7 +114,7 @@ func (s *S) TestExecCommandPodNameForApp(c *check.C) {
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		c.Assert(execCommandPodNameForApp(a), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(execCommandPodNameForApp(a), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 
@@ -131,7 +131,7 @@ func (s *S) TestDaemonSetName(c *check.C) {
 		{"d1", "P-x_1", "node-container-d1-pool-p-x-1"},
 	}
 	for i, tt := range tests {
-		c.Assert(daemonSetName(tt.name, tt.pool), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(daemonSetName(tt.name, tt.pool), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 
@@ -143,7 +143,7 @@ func (s *S) TestRegistrySecretName(c *check.C) {
 		{"my-registry", "registry-my-registry"},
 	}
 	for i, tt := range tests {
-		c.Assert(registrySecretName(tt.name), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(registrySecretName(tt.name), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -146,6 +146,10 @@ func (s *S) TestAppLabelForApp(c *check.C) {
 		{"myapp", "p1", "myapp-p1"},
 		{"MYAPP", "p-1", "myapp-p-1"},
 		{"my-app_app", "P_1-1", "my-app-app-p-1-1"},
+		{"app-with-a-very-very-long-name", "p1", "app-with-a-very-very-long-name-p1"},
+		{"my-app", "process-with-a-very-very-long-name-1234567890123", "my-app-process-with-a-very-very-long-name-1234567890123"},
+		{"my-app", "process-with-a-very-very-long-name-12345678901234", "my-app-0718ca0d56b1219fb50636a73252a47b977839e983558e08"},
+		{"app-with-a-very-very-long-name", "process-with-a-very-very-long-name", "app-with-a-very-very-long-name-a9101bf0964e84e3f4c4b2b0"},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -59,10 +59,14 @@ func (s *S) TestDeploymentNameForApp(c *check.C) {
 		{"myapp", "p1", "myapp-p1"},
 		{"MYAPP", "p-1", "myapp-p-1"},
 		{"my-app_app", "P_1-1", "my-app-app-p-1-1"},
+		{"app-with-a-very-very-long-name", "p1", "app-with-a-very-very-long-name-p1"},
+		{"my-app", "process-with-a-very-very-long-name-1234567890123", "my-app-process-with-a-very-very-long-name-1234567890123"},
+		{"my-app", "process-with-a-very-very-long-name-12345678901234", "my-app-0718ca0d56b1219fb50636a73252a47b977839e983558e08"},
+		{"app-with-a-very-very-long-name", "process-with-a-very-very-long-name", "app-with-a-very-very-long-name-a9101bf0964e84e3f4c4b2b0"},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		c.Assert(deploymentNameForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(deploymentNameForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 
@@ -73,10 +77,14 @@ func (s *S) TestHeadlessServiceNameForApp(c *check.C) {
 		{"myapp", "p1", "myapp-p1-units"},
 		{"MYAPP", "p-1", "myapp-p-1-units"},
 		{"my-app_app", "P_1-1", "my-app-app-p-1-1-units"},
+		{"app-with-a-very-very-long-name", "p1", "app-with-a-very-very-long-name-p1-units"},
+		{"my-app", "process-with-a-very-very-long-name-1234567890123", "my-app-process-with-a-very-very-long-name-1234567890123-units"},
+		{"my-app", "process-with-a-very-very-long-name-12345678901234", "my-app-0718ca0d56b1219fb50636a73252a47b977839e983558e08-units"},
+		{"app-with-a-very-very-long-name", "process-with-a-very-very-long-name", "app-with-a-very-very-long-name-a9101bf0964e84e3f4c4b2b0-units"},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		c.Assert(headlessServiceNameForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(headlessServiceNameForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -143,13 +143,13 @@ func (s *S) TestAppLabelForApp(c *check.C) {
 	var tests = []struct {
 		name, process, expected string
 	}{
-		{"myapp", "p1", "tsuru-app-myapp-p1"},
-		{"MYAPP", "p-1", "tsuru-app-myapp-p-1"},
-		{"my-app_app", "P_1-1", "tsuru-app-my-app-app-p-1-1"},
+		{"myapp", "p1", "myapp-p1"},
+		{"MYAPP", "p-1", "myapp-p-1"},
+		{"my-app_app", "P_1-1", "my-app-app-p-1-1"},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		c.Assert(appLabelForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
+		c.Check(appLabelForApp(a, tt.process), check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }
 

--- a/provision/kubernetes/volume_test.go
+++ b/provision/kubernetes/volume_test.go
@@ -34,7 +34,7 @@ func (s *S) TestCreateVolumesForAppPlugin(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -149,7 +149,7 @@ func (s *S) TestCreateVolumesForAppPluginNonPersistent(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -207,7 +207,7 @@ func (s *S) TestCreateVolumesForAppStorageClass(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -294,7 +294,7 @@ func (s *S) TestCreateVolumeAppNamespace(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -335,7 +335,7 @@ func (s *S) TestCreateVolumeMultipleNamespacesFail(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -365,7 +365,7 @@ func (s *S) TestDeleteVolume(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
@@ -402,7 +402,7 @@ func (s *S) TestVolumeExists(c *check.C) {
 		Pool:      "test-default",
 		TeamOwner: "admin",
 	}
-	err = v.Save()
+	err = v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -248,7 +248,7 @@ func (p *Pool) validate() error {
 		return ErrPoolNameIsRequired
 	}
 	if !validation.ValidateName(p.Name) {
-		msg := "Invalid pool name, pool name should have at most 63 " +
+		msg := "Invalid pool name, pool name should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."
 		return &tsuruErrors.ValidationError{Message: msg}

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -90,7 +90,7 @@ func (s *S) TestValidateRouters(c *check.C) {
 }
 
 func (s *S) TestAddPool(c *check.C) {
-	msg := "Invalid pool name, pool name should have at most 63 " +
+	msg := "Invalid pool name, pool name should have at most 40 " +
 		"characters, containing only lower case letters, numbers or dashes, " +
 		"starting with a letter."
 	vErr := &tsuruErrors.ValidationError{Message: msg}
@@ -102,6 +102,7 @@ func (s *S) TestAddPool(c *check.C) {
 		{"myPool", vErr},
 		{"my pool", vErr},
 		{"123mypool", vErr},
+		{"my-pool-with-very-long-name-41-characters", vErr},
 		{"", ErrPoolNameIsRequired},
 		{"p", nil},
 	}

--- a/provision/swarm/volume_test.go
+++ b/provision/swarm/volume_test.go
@@ -28,7 +28,7 @@ func (s *S) TestMountsForApp(c *check.C) {
 		Pool:      "bonehunters",
 		TeamOwner: "admin",
 	}
-	err := v.Save()
+	err := v.Create()
 	c.Assert(err, check.IsNil)
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)

--- a/service/service.go
+++ b/service/service.go
@@ -253,7 +253,7 @@ func (s *Service) validate(skipName bool) (err error) {
 		return fmt.Errorf("Brokered services are not managed.")
 	}
 	if !skipName && !validation.ValidateName(s.Name) {
-		return fmt.Errorf("Invalid service id, should have at most 63 " +
+		return fmt.Errorf("Invalid service id, should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter.")
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -155,7 +155,7 @@ func (s *S) TestCreateService(c *check.C) {
 	c.Assert(se.Username, check.Equals, "test")
 }
 
-func (s *S) TestCreateServiceMissingFields(c *check.C) {
+func (s *S) TestCreateServiceValidation(c *check.C) {
 	endpt := map[string]string{
 		"production": "somehost.com",
 	}
@@ -169,7 +169,10 @@ func (s *S) TestCreateServiceMissingFields(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "Service id is required")
 	service.Name = "INVALID NAME"
 	err = Create(*service)
-	c.Assert(err, check.ErrorMatches, "Invalid service id, should have at most 63 characters, containing only lower case letters, numbers or dashes, starting with a letter.")
+	c.Assert(err, check.ErrorMatches, "Invalid service id, should have at most 40 characters, containing only lower case letters, numbers or dashes, starting with a letter.")
+	service.Name = "a-very-loooooooooooong-name-41-characters"
+	err = Create(*service)
+	c.Assert(err, check.ErrorMatches, "Invalid service id, should have at most 40 characters, containing only lower case letters, numbers or dashes, starting with a letter.")
 	service.Name = "servicename"
 	service.Password = ""
 	err = Create(*service)

--- a/types/app/platform.go
+++ b/types/app/platform.go
@@ -54,7 +54,7 @@ var (
 	ErrMissingFileContent     = errors.New("Missing file content.")
 	ErrDeletePlatformWithApps = errors.New("Platform has apps. You must remove them before remove the platform.")
 	ErrInvalidPlatformName    = &tsuruErrors.ValidationError{
-		Message: "Invalid platform name, should have at most 63 " +
+		Message: "Invalid platform name, should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter.",
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	emailRegexp = regexp.MustCompile(`^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$`)
-	nameRegexp  = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+	nameRegexp  = regexp.MustCompile(`^[a-z][a-z0-9-]{0,39}$`)
 )
 
 func ValidateEmail(email string) bool {
@@ -40,7 +40,7 @@ func ValidateLength(value string, min, max int) bool {
 	return true
 }
 
-// ValidateName checks wether the given data contains at most 63 characters
+// ValidateName checks wether the given data contains at most 40 characters
 // containing only lower case letters, numbers or dashes and starts with a letter
 func ValidateName(name string) bool {
 	return nameRegexp.MatchString(name)

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -6,10 +6,7 @@
 package validation
 
 import (
-	"fmt"
 	"regexp"
-
-	"github.com/tsuru/tsuru/errors"
 )
 
 var (
@@ -44,11 +41,4 @@ func ValidateLength(value string, min, max int) bool {
 // containing only lower case letters, numbers or dashes and starts with a letter
 func ValidateName(name string) bool {
 	return nameRegexp.MatchString(name)
-}
-
-func EnsureValidateName(name string) error {
-	if !ValidateName(name) {
-		return &errors.ValidationError{Message: fmt.Sprintf("name does not match regex %q", nameRegexp.String())}
-	}
-	return nil
 }

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -36,7 +36,7 @@ func (s *S) TestValidateEmail(c *check.C) {
 		{"invalid@validate", false},
 	}
 	for _, d := range data {
-		c.Assert(ValidateEmail(d.input), check.Equals, d.expected)
+		c.Check(ValidateEmail(d.input), check.Equals, d.expected)
 	}
 }
 
@@ -52,7 +52,7 @@ func (s *S) TestValidateLength(c *check.C) {
 		{"gopher", -1, 3, false},
 	}
 	for _, d := range data {
-		c.Assert(ValidateLength(d.input, d.min, d.max), check.Equals, d.expected)
+		c.Check(ValidateLength(d.input, d.min, d.max), check.Equals, d.expected)
 	}
 }
 
@@ -61,9 +61,9 @@ func (s *S) TestValidateName(c *check.C) {
 		input    string
 		expected bool
 	}{
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyapp", false},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyap", false},
-		{"myappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmyappmya", true},
+		{"myappmyappmyappmpmyappmyappmyappmyappmyapp", false},
+		{"myappmyappmyappmpmyappmyappmyappmyappmyap", false},
+		{"myappmyappmyappmpmyappmyappmyappmyappmya", true},
 		{"myApp", false},
 		{"my app", false},
 		{"123myapp", false},
@@ -75,6 +75,6 @@ func (s *S) TestValidateName(c *check.C) {
 		{"b", true},
 	}
 	for _, d := range data {
-		c.Assert(ValidateName(d.input), check.Equals, d.expected)
+		c.Check(ValidateName(d.input), check.Equals, d.expected)
 	}
 }

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -62,7 +62,7 @@ func (v *Volume) UnmarshalPlan(result interface{}) error {
 	return errors.WithStack(json.Unmarshal(jsonData, result))
 }
 
-func (v *Volume) Validate() error {
+func (v *Volume) validateNew() error {
 	if v.Name == "" {
 		return errors.New("volume name cannot be empty")
 	}
@@ -72,6 +72,10 @@ func (v *Volume) Validate() error {
 			"starting with a letter."
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: msg})
 	}
+	return v.validate()
+}
+
+func (v *Volume) validate() error {
 	p, err := pool.GetPoolByName(v.Pool)
 	if err != nil {
 		return errors.WithStack(err)
@@ -96,11 +100,23 @@ func (v *Volume) Validate() error {
 	return nil
 }
 
-func (v *Volume) Save() error {
-	err := v.Validate()
+func (v *Volume) Create() error {
+	err := v.validateNew()
 	if err != nil {
 		return err
 	}
+	return v.save()
+}
+
+func (v *Volume) Update() error {
+	err := v.validate()
+	if err != nil {
+		return err
+	}
+	return v.save()
+}
+
+func (v *Volume) save() error {
 	isProv, err := v.isProvisioned()
 	if err != nil {
 		return err

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -67,7 +67,7 @@ func (v *Volume) Validate() error {
 		return errors.New("volume name cannot be empty")
 	}
 	if !validation.ValidateName(v.Name) {
-		msg := "Invalid volume name, volume name should have at most 63 " +
+		msg := "Invalid volume name, volume name should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."
 		return errors.WithStack(&tsuruErrors.ValidationError{Message: msg})

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -578,7 +578,7 @@ volume-plans:
     other:
       storage-class: my-ebs-storage-class
 `)
-	msg := "Invalid volume name, volume name should have at most 63 " +
+	msg := "Invalid volume name, volume name should have at most 40 " +
 		"characters, containing only lower case letters, numbers or dashes, " +
 		"starting with a letter."
 	nameErr := &tsuruErrors.ValidationError{Message: msg}
@@ -587,14 +587,18 @@ volume-plans:
 		expectedErr error
 	}{
 		{Volume{Name: "volume1", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nil},
+		{Volume{Name: "MYVOLUME", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nameErr},
 		{Volume{Name: "volume_1", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nameErr},
 		{Volume{Name: "123volume", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nameErr},
+		{Volume{Name: "an *invalid* name", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nameErr},
+		{Volume{Name: "volume-with-a-name-longer-than-40-characters", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nameErr},
+		{Volume{Name: "volume-with-exactly-40-characters-123456", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, nil},
 		{Volume{Name: "volume1", Pool: "invalidpool", TeamOwner: "myteam", Plan: VolumePlan{Name: "nfs"}}, pool.ErrPoolNotFound},
 		{Volume{Name: "volume1", Pool: "mypool", TeamOwner: "invalidteam", Plan: VolumePlan{Name: "nfs"}}, authTypes.ErrTeamNotFound},
 		{Volume{Name: "volume1", Pool: "mypool", TeamOwner: "myteam", Plan: VolumePlan{Name: "invalidplan"}}, config.ErrKeyNotFound{Key: "volume-plans:invalidplan:fake"}},
 	}
 	for _, t := range tt {
-		c.Assert(errors.Cause(t.volume.Validate()), check.DeepEquals, t.expectedErr, check.Commentf(t.volume.Name))
+		c.Check(errors.Cause(t.volume.Validate()), check.DeepEquals, t.expectedErr, check.Commentf(t.volume.Name))
 	}
 }
 


### PR DESCRIPTION
Change name validation rules to avoid incompatibilities with Kubernetes:

- reduce max length to 40 characters for app, platform, team token id, event webhook, pool, cluster, volume and service
- remove `tsuru-app-` prefix from `app` label in deployments and pods, to save some characters (label values can't have more than 63 characters)
- limit service and deployment names to 55 characters (max length allowed by Kubernetes is 63 characters). If `<app name>-<process name>`has more than 55 characters, replace the process name with a sha256 hash

This fixes #2145.