### PR TITLE
app/image: always return a existing process on GetImageWebProcessName

### DIFF
--- a/app/image/image.go
+++ b/app/image/image.go
@@ -7,6 +7,7 @@ package image
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/globalsign/mgo"
@@ -168,7 +169,7 @@ func GetImageMetaData(imageName string) (ImageMetadata, error) {
 }
 
 func GetImageWebProcessName(imageName string) (string, error) {
-	processName := "web"
+	const processName = "web"
 	data, err := GetImageMetaData(imageName)
 	if err != nil {
 		return processName, err
@@ -176,12 +177,15 @@ func GetImageWebProcessName(imageName string) (string, error) {
 	if len(data.Processes) == 0 {
 		return "", nil
 	}
-	if len(data.Processes) == 1 {
-		for name := range data.Processes {
-			processName = name
+	var processes []string
+	for name := range data.Processes {
+		if name == processName || len(data.Processes) == 1 {
+			return name, nil
 		}
+		processes = append(processes, name)
 	}
-	return processName, nil
+	sort.Strings(processes)
+	return processes[0], nil
 }
 
 func AllAppProcesses(appName string) ([]string, error) {

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -169,17 +169,16 @@ func GetImageMetaData(imageName string) (ImageMetadata, error) {
 }
 
 func GetImageWebProcessName(imageName string) (string, error) {
-	const processName = "web"
 	data, err := GetImageMetaData(imageName)
 	if err != nil {
-		return processName, err
+		return "", err
 	}
 	if len(data.Processes) == 0 {
 		return "", nil
 	}
 	var processes []string
 	for name := range data.Processes {
-		if name == processName || len(data.Processes) == 1 {
+		if name == "web" || len(data.Processes) == 1 {
 			return name, nil
 		}
 		processes = append(processes, name)

--- a/app/image/image_test.go
+++ b/app/image/image_test.go
@@ -258,7 +258,7 @@ func (s *S) TestGetImageWebProcessName(c *check.C) {
 	c.Check(web1, check.Equals, "web")
 	web2, err := GetImageWebProcessName(img2)
 	c.Check(err, check.IsNil)
-	c.Check(web2, check.Equals, "web")
+	c.Check(web2, check.Equals, "worker1")
 	web3, err := GetImageWebProcessName(img3)
 	c.Check(err, check.IsNil)
 	c.Check(web3, check.Equals, "api")


### PR DESCRIPTION
Prior to this change, `GetImageWebProcessName` would return "web" if the
application had more than a single process, even if none of them was
actually called "web". This causes a issue on the Kubernetes provisioner
because it relies on the returned name to find some cluster resources,
causing the `RoutableAddresses()` method to fail.

This change makes sure that `GetImageWebProcessName` always return a
existing process name. If the application has more than a single process
it will either return "web", if one of them is called "web", or the
first process in alphabetical order.

Fixes #2165 