### PR TITLE
api: add nameOnly flag to apps endpoint

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -222,6 +222,9 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		for i, ap := range apps {
 			ur := app.AppUnitsResponse{Units: nil, Err: nil}
 			miniApps[i], err = minifyApp(ap, ur)
+			if err != nil {
+				return err
+			}
 		}
 		return json.NewEncoder(w).Encode(miniApps)
 	}

--- a/api/app.go
+++ b/api/app.go
@@ -219,18 +219,9 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	w.Header().Set("Content-Type", "application/json")
 	miniApps := make([]miniApp, len(apps))
 	if simple {
-		for i, app := range apps {
-			ma := miniApp{
-				Name:      app.Name,
-				Pool:      app.Pool,
-				Plan:      app.Plan,
-				TeamOwner: app.TeamOwner,
-				CName:     app.CName,
-				Routers:   app.Routers,
-				Lock:      &app.Lock,
-				Tags:      app.Tags,
-			}
-			miniApps[i] = ma
+		for i, ap := range apps {
+			ur := app.AppUnitsResponse{Units: nil, Err: nil}
+			miniApps[i], err = minifyApp(ap, ur)
 		}
 		return json.NewEncoder(w).Encode(miniApps)
 	}
@@ -238,8 +229,6 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
-
-	// miniApps := make([]miniApp, len(apps))
 	for i, app := range apps {
 		miniApps[i], err = minifyApp(app, appUnits[app.Name])
 		if err != nil {

--- a/api/app.go
+++ b/api/app.go
@@ -215,11 +215,24 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
+	w.Header().Set("Content-Type", "application/json")
+	simple, _ := strconv.ParseBool(r.URL.Query().Get("nameOnly"))
+	if simple {
+		appsNames := make([]interface{}, len(apps))
+		for i, appName := range apps {
+			res := map[string]interface{}{
+				"name": appName.Name,
+			}
+			appsNames[i] = res
+		}
+		return json.NewEncoder(w).Encode(appsNames)
+	}
+
 	appUnits, err := app.Units(apps)
 	if err != nil {
 		return err
 	}
-	w.Header().Set("Content-Type", "application/json")
+
 	miniApps := make([]miniApp, len(apps))
 	for i, app := range apps {
 		miniApps[i], err = minifyApp(app, appUnits[app.Name])

--- a/api/app.go
+++ b/api/app.go
@@ -215,25 +215,31 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
+	simple, _ := strconv.ParseBool(r.URL.Query().Get("simplified"))
 	w.Header().Set("Content-Type", "application/json")
-	simple, _ := strconv.ParseBool(r.URL.Query().Get("nameOnly"))
+	miniApps := make([]miniApp, len(apps))
 	if simple {
-		appsNames := make([]interface{}, len(apps))
-		for i, appName := range apps {
-			res := map[string]interface{}{
-				"name": appName.Name,
+		for i, app := range apps {
+			ma := miniApp{
+				Name:      app.Name,
+				Pool:      app.Pool,
+				Plan:      app.Plan,
+				TeamOwner: app.TeamOwner,
+				CName:     app.CName,
+				Routers:   app.Routers,
+				Lock:      &app.Lock,
+				Tags:      app.Tags,
 			}
-			appsNames[i] = res
+			miniApps[i] = ma
 		}
-		return json.NewEncoder(w).Encode(appsNames)
+		return json.NewEncoder(w).Encode(miniApps)
 	}
-
 	appUnits, err := app.Units(apps)
 	if err != nil {
 		return err
 	}
 
-	miniApps := make([]miniApp, len(apps))
+	// miniApps := make([]miniApp, len(apps))
 	for i, app := range apps {
 		miniApps[i], err = minifyApp(app, appUnits[app.Name])
 		if err != nil {

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -450,6 +450,7 @@ func (s *S) TestSimpleAppList(c *check.C) {
 		Tags:      []string{},
 	}
 	err = app.CreateApp(&app1, s.user)
+	c.Assert(err, check.IsNil)
 	acquireDate := time.Date(2015, time.February, 12, 12, 3, 0, 0, time.Local)
 	app2 := app.App{
 		Name:      "app2",

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -436,7 +436,7 @@ func (s *S) TestAppListFilteringByStatusIgnoresInvalidValues(c *check.C) {
 	}
 }
 
-func (s *S) TestSimpleAppList(c *check.C) {
+func (s *S) TestSimplifiedAppList(c *check.C) {
 	p := pool.Pool{Name: "pool1"}
 	opts := pool.AddPoolOptions{Name: p.Name, Public: true}
 	err := pool.AddPool(opts)
@@ -468,7 +468,7 @@ func (s *S) TestSimpleAppList(c *check.C) {
 	}
 	err = app.CreateApp(&app2, s.user)
 	c.Assert(err, check.IsNil)
-	request, err := http.NewRequest("GET", "/apps?nameOnly=true", nil)
+	request, err := http.NewRequest("GET", "/apps?simplified=true", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -481,7 +481,10 @@ func (s *S) TestSimpleAppList(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(apps, check.HasLen, 2)
 	c.Assert(apps[0].Name, check.Equals, app1.Name)
-
+	app1u, _ := apps[0].Units()
+	c.Assert(app1u, check.HasLen, 0)
+	c.Assert(apps[1].Name, check.Equals, app2.Name)
+	c.Assert(app1u, check.HasLen, 0)
 }
 
 func (s *S) TestAppList(c *check.C) {

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -303,6 +303,10 @@ paths:
           description: Filter applications by team owner.
           in: query
           type: string
+        - name: simplified
+          description: Returns applications without units list.
+          in: query
+          type: boolean 
       produces:
         - application/json
       responses:


### PR DESCRIPTION
This is my attempt to fix issue #2138 

I added a new flag: `nameOnly`. If the flag is present and true, then it returns a JSON with an array of app names in the form: 
```
 [
    {"name": "app-name1"},
    {"name": "app-name2"}
]
```
It also skips the query for the app unit status.

I also added one test case to check the flag does not break the current interface implementation.