### PR TITLE
docs: fix instructions for minikube setup

### DIFF
--- a/docs/contributing/compose.rst
+++ b/docs/contributing/compose.rst
@@ -75,7 +75,7 @@ One can register a minikube instance as a cluster in tsuru to be able to orchest
 Start minikube:
 
 ::
-    
+
     $ minikube start --insecure-registry=10.0.0.0/8
 
 Create a pool in tsuru to be managed by the cluster:
@@ -89,13 +89,19 @@ Register your minikube as a tsuru cluster:
 
 ::
 
-    tsuru cluster add minikube kubernetes --addr https://`minikube ip`:8443 --cacert $HOME/.minikube/ca.crt --clientcert $HOME/.minikube/apiserver.crt --clientkey $HOME/.minikube/apiserver.key --pool kubepool
+    $ tsuru cluster add minikube kubernetes --addr https://`minikube ip`:8443 --cacert $HOME/.minikube/ca.crt --clientcert $HOME/.minikube/apiserver.crt --clientkey $HOME/.minikube/apiserver.key --pool kubepool
 
-Add your kubernetes master as a member of kubepool:
+Check your node IP:
 
 ::
 
-    tsuru node update `minikube ip` pool=kubepool
+    $ tsuru node list -f tsuru.io/cluster=minikube
+
+Add this IP address as a member of kubepool:
+
+::
+
+    $ tsuru node update <node ip> pool=kubepool
 
 You are ready to create and deploy apps kubernetes.
 


### PR DESCRIPTION
The node IP that is registered should be the internal IP, not the minikube VM IP.