### PR TITLE
Kubernetes: apps with binded volumes can't change namespaces

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -496,7 +496,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 		wantedPerms = append(wantedPerms, permission.PermAppUpdateImageReset)
 	}
 	if len(wantedPerms) == 0 {
-		msg := "Neither the description, plan, pool, team owner or platform were set. You must define at least one."
+		msg := "Neither the description, tags, plan, pool, team owner or platform were set. You must define at least one."
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: msg}
 	}
 	for _, perm := range wantedPerms {

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1903,7 +1903,7 @@ func (s *S) TestUpdateAppWithoutFlag(c *check.C) {
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
-	errorMessage := "Neither the description, plan, pool, team owner or platform were set. You must define at least one.\n"
+	errorMessage := "Neither the description, tags, plan, pool, team owner or platform were set. You must define at least one.\n"
 	c.Check(recorder.Code, check.Equals, http.StatusBadRequest)
 	c.Check(recorder.Body.String(), check.Equals, errorMessage)
 }

--- a/provision/kubernetes/nodecontainer_test.go
+++ b/provision/kubernetes/nodecontainer_test.go
@@ -48,6 +48,7 @@ func (s *S) prepareMultiCluster(c *check.C) (*kTesting.ClientWrapper, *kTesting.
 		TsuruClientset:         faketsuru.NewSimpleClientset(),
 		ClusterInterface:       clusterClient1,
 	}
+	clusterClient1.Interface = client1
 	cluster2 := &provTypes.Cluster{
 		Name:        "c2",
 		Addresses:   []string{"https://clusteraddr2"},
@@ -63,6 +64,7 @@ func (s *S) prepareMultiCluster(c *check.C) (*kTesting.ClientWrapper, *kTesting.
 		TsuruClientset:         faketsuru.NewSimpleClientset(),
 		ClusterInterface:       clusterClient2,
 	}
+	clusterClient2.Interface = client2
 
 	s.mockService.Cluster.OnFindByProvisioner = func(provName string) ([]provTypes.Cluster, error) {
 		return []provTypes.Cluster{*cluster1, *cluster2}, nil

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1031,13 +1031,13 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 	if err != nil {
 		return err
 	}
-	if client.Cluster.Name != newclient.Cluster.Name || client.PoolNamespace(old.GetPool()) != client.PoolNamespace(new.GetPool()) {
+	if client.Cluster.Name == newclient.Cluster.Name && client.PoolNamespace(old.GetPool()) != client.PoolNamespace(new.GetPool()) {
 		volumes, err := volume.ListByApp(old.GetName())
 		if err != nil {
 			return err
 		}
 		if len(volumes) > 0 {
-			return fmt.Errorf("can't change the provisioner of an app with binded volumes")
+			return fmt.Errorf("can't change the pool of an app with binded volumes")
 		}
 	}
 	params := updatePipelineParams{

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1031,7 +1031,7 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 	if err != nil {
 		return err
 	}
-	if client.Cluster.Name != newclient.Cluster.Name {
+	if client.Cluster.Name != newclient.Cluster.Name || client.PoolNamespace(old.GetPool()) != client.PoolNamespace(new.GetPool()) {
 		volumes, err := volume.ListByApp(old.GetName())
 		if err != nil {
 			return err

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	"github.com/tsuru/tsuru/set"
 	provTypes "github.com/tsuru/tsuru/types/provision"
+	"github.com/tsuru/tsuru/volume"
 	apiv1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -1029,6 +1030,15 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 	newclient, err := clusterForPool(new.GetPool())
 	if err != nil {
 		return err
+	}
+	if client.Cluster.Name != newclient.Cluster.Name {
+		volumes, err := volume.ListByApp(old.GetName())
+		if err != nil {
+			return err
+		}
+		if len(volumes) > 0 {
+			return fmt.Errorf("can't change the provisioner of an app with binded volumes")
+		}
 	}
 	params := updatePipelineParams{
 		old: old,

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -236,7 +236,32 @@ func (p *kubernetesProvisioner) removeResources(client *ClusterClient, app *tsur
 			}
 		}
 	}
-	err := client.CoreV1().ServiceAccounts(app.Spec.NamespaceName).Delete(app.Spec.ServiceAccountName, &metav1.DeleteOptions{})
+	vols, err := volume.ListByApp(app.Name)
+	if err != nil {
+		multiErrors.Add(errors.WithStack(err))
+	} else {
+		for _, vol := range vols {
+			_, err = vol.LoadBinds()
+			if err != nil {
+				continue
+			}
+
+			bindedToOtherApps := false
+			for _, b := range vol.Binds {
+				if b.ID.App != app.Name {
+					bindedToOtherApps = true
+					break
+				}
+			}
+			if !bindedToOtherApps {
+				err = deleteVolume(client, vol.Name)
+				if err != nil {
+					multiErrors.Add(errors.WithStack(err))
+				}
+			}
+		}
+	}
+	err = client.CoreV1().ServiceAccounts(app.Spec.NamespaceName).Delete(app.Spec.ServiceAccountName, &metav1.DeleteOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		multiErrors.Add(errors.WithStack(err))
 	}
@@ -1031,7 +1056,9 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 	if err != nil {
 		return err
 	}
-	if client.Cluster.Name == newclient.Cluster.Name && client.PoolNamespace(old.GetPool()) != client.PoolNamespace(new.GetPool()) {
+	sameCluster := client.GetCluster().Name == newclient.GetCluster().Name
+	sameNamespace := client.PoolNamespace(old.GetPool()) == client.PoolNamespace(new.GetPool())
+	if sameCluster && !sameNamespace {
 		volumes, err := volume.ListByApp(old.GetName())
 		if err != nil {
 			return err
@@ -1046,7 +1073,7 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 		w:   w,
 		p:   p,
 	}
-	if !(client.GetCluster().Name == newclient.GetCluster().Name) {
+	if !sameCluster {
 		actions := []*action.Action{
 			&provisionNewApp,
 			&restartApp,
@@ -1056,7 +1083,7 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 		return action.NewPipeline(actions...).Execute(params)
 	}
 	// same cluster and it is not configured with per-pool-namespace, nothing to do.
-	if client.PoolNamespace(old.GetPool()) == newclient.PoolNamespace(new.GetPool()) {
+	if sameNamespace {
 		return nil
 	}
 	actions := []*action.Action{

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1962,7 +1962,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeSameClusterOtherNamespace(c *check
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
 	err = s.p.UpdateApp(a, newApp, buf)
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "can't change the pool of an app with binded volumes")
 }
 
 func (s *S) TestProvisionerUpdateAppWithVolumeOtherCluster(c *check.C) {
@@ -2034,5 +2034,5 @@ func (s *S) TestProvisionerUpdateAppWithVolumeOtherCluster(c *check.C) {
 	err = v.BindApp(a.GetName(), "/mnt", false)
 	c.Assert(err, check.IsNil)
 	err = s.p.UpdateApp(a, newApp, buf)
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.IsNil)
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tsuru/tsuru/router/routertest"
 	"github.com/tsuru/tsuru/safe"
 	provTypes "github.com/tsuru/tsuru/types/provision"
+	"github.com/tsuru/tsuru/volume"
 	"gopkg.in/check.v1"
 	"k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
@@ -1833,4 +1834,81 @@ func (s *S) TestProvisionerUpdateApp(c *check.C) {
 			Host:   "192.168.100.1:30002",
 		},
 	})
+}
+
+func (s *S) TestProvisionerUpdateAppWithVolumeOtherCluster(c *check.C) {
+	config.Set("volume-plans:p1:kubernetes:plugin", "nfs")
+	defer config.Unset("volume-plans")
+	s.mockService.Cluster.OnFindByPool = func(provName, poolName string) (*provTypes.Cluster, error) {
+		if poolName == "test-pool-2" {
+			return &provTypes.Cluster{
+				Name:        "c2",
+				Addresses:   []string{"192.168.100.2"},
+				Provisioner: "kubernetes",
+				Pools:       []string{poolName},
+			}, nil
+		}
+		return s.client.GetCluster(), nil
+	}
+	err := pool.AddPool(pool.AddPoolOptions{
+		Name:        "test-pool-2",
+		Provisioner: "kubernetes",
+	})
+	c.Assert(err, check.IsNil)
+	config.Set("kubernetes:use-pool-namespaces", true)
+	defer config.Unset("kubernetes:use-pool-namespaces")
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	evt, err := event.New(&event.Opts{
+		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		Kind:    permission.PermAppDeploy,
+		Owner:   s.token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	c.Assert(err, check.IsNil)
+	customData := map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "run mycmd arg1",
+		},
+	}
+	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
+	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
+	wait()
+	sList, err := s.client.CoreV1().Services("tsuru-test-pool-2").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(len(sList.Items), check.Equals, 0)
+	sList, err = s.client.CoreV1().Services("tsuru-test-default").List(metav1.ListOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(len(sList.Items), check.Equals, 2)
+	newApp := provisiontest.NewFakeAppWithPool(a.GetName(), a.GetPlatform(), "test-pool-2", 0)
+	buf := new(bytes.Buffer)
+	s.client.PrependReactor("create", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pod := action.(ktesting.CreateAction).GetObject().(*apiv1.Pod)
+		c.Assert(pod.Spec.NodeSelector, check.DeepEquals, map[string]string{
+			"tsuru.io/pool": newApp.GetPool(),
+		})
+		c.Assert(pod.ObjectMeta.Labels["tsuru.io/app-pool"], check.Equals, newApp.GetPool())
+		return true, nil, nil
+	})
+	v := volume.Volume{
+		Name: "v1",
+		Opts: map[string]string{
+			"path":         "/exports",
+			"server":       "192.168.1.1",
+			"capacity":     "20Gi",
+			"access-modes": string(apiv1.ReadWriteMany),
+		},
+		Plan:      volume.VolumePlan{Name: "p1"},
+		Pool:      "test-default",
+		TeamOwner: "admin",
+	}
+	err = v.Create()
+	c.Assert(err, check.IsNil)
+	err = v.BindApp(a.GetName(), "/mnt", false)
+	c.Assert(err, check.IsNil)
+	err = s.p.UpdateApp(a, newApp, buf)
+	c.Assert(err, check.NotNil)
 }

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -59,13 +59,15 @@ type ClusterInterface interface {
 }
 
 type KubeMock struct {
-	client      *ClientWrapper
-	Stream      map[string]StreamResult
-	LogHook     func(w io.Writer, r *http.Request)
-	DefaultHook func(w http.ResponseWriter, r *http.Request)
-	p           provision.Provisioner
-	factory     informers.SharedInformerFactory
-	HandleSize  bool
+	client        *ClientWrapper
+	Stream        map[string]StreamResult
+	LogHook       func(w io.Writer, r *http.Request)
+	DefaultHook   func(w http.ResponseWriter, r *http.Request)
+	p             provision.Provisioner
+	factory       informers.SharedInformerFactory
+	HandleSize    bool
+	IgnorePool    bool
+	IgnoreAppName bool
 }
 
 func NewKubeMock(cluster *ClientWrapper, p provision.Provisioner, factory informers.SharedInformerFactory) *KubeMock {
@@ -351,10 +353,16 @@ func (s *KubeMock) MockfakeNodes(c *check.C, urls ...string) {
 	}
 }
 
+func (s *KubeMock) AppReaction(a provision.App, c *check.C) ktesting.ReactionFunc {
+	return s.appReaction(a, c)
+}
+
 func (s *KubeMock) appReaction(a provision.App, c *check.C) ktesting.ReactionFunc {
 	return func(action ktesting.Action) (bool, runtime.Object, error) {
-		app := action.(ktesting.CreateAction).GetObject().(*tsuruv1.App)
-		c.Assert(app.GetName(), check.Equals, a.GetName())
+		if !s.IgnoreAppName {
+			app := action.(ktesting.CreateAction).GetObject().(*tsuruv1.App)
+			c.Assert(app.GetName(), check.Equals, a.GetName())
+		}
 		return false, nil, nil
 	}
 }
@@ -394,14 +402,18 @@ func (s *KubeMock) deployPodReaction(a provision.App, c *check.C) (ktesting.Reac
 			err := s.factory.Core().V1().Pods().Informer().GetStore().Add(pod)
 			c.Assert(err, check.IsNil)
 		}()
-		c.Assert(pod.Spec.NodeSelector, check.DeepEquals, map[string]string{
-			"tsuru.io/pool": a.GetPool(),
-		})
+		if !s.IgnorePool {
+			c.Assert(pod.Spec.NodeSelector, check.DeepEquals, map[string]string{
+				"tsuru.io/pool": a.GetPool(),
+			})
+		}
 		c.Assert(pod.ObjectMeta.Labels, check.NotNil)
 		c.Assert(pod.ObjectMeta.Labels["tsuru.io/is-tsuru"], check.Equals, trueStr)
 		c.Assert(pod.ObjectMeta.Labels["tsuru.io/app-name"], check.Equals, a.GetName())
 		c.Assert(pod.ObjectMeta.Labels["tsuru.io/app-platform"], check.Equals, a.GetPlatform())
-		c.Assert(pod.ObjectMeta.Labels["tsuru.io/app-pool"], check.Equals, a.GetPool())
+		if !s.IgnorePool {
+			c.Assert(pod.ObjectMeta.Labels["tsuru.io/app-pool"], check.Equals, a.GetPool())
+		}
 		c.Assert(pod.ObjectMeta.Labels["tsuru.io/provisioner"], check.Equals, "kubernetes")
 		c.Assert(pod.ObjectMeta.Annotations, check.NotNil)
 		c.Assert(pod.ObjectMeta.Annotations["tsuru.io/router-type"], check.Equals, "fake")


### PR DESCRIPTION
Currently we don't support moving volumes between namespaces of a Kubernetes cluster. This PR adds a validation to prevent this.

Moving between different clusters works fine.