### PR TITLE
Dev: Add docker ip alias to compose file

### DIFF
--- a/etc/tsuru-compose.conf
+++ b/etc/tsuru-compose.conf
@@ -34,6 +34,10 @@ routers:
     type: hipache
     domain: 127.0.0.1.nip.io:8989
     redis-server: redis:6379
+  docker:
+    type: hipache
+    domain: 10.200.10.1.nip.io:8989
+    redis-server: redis:6379
 queue:
   mongo-url: mongo:27017
   mongo-database: queuedb


### PR DESCRIPTION
build-compose.sh file creates an IP alias to docker interface (10.200.10.1), 
this alias is used by registry container.

in order to  Tsuru API can reach and use Tsuru apps, a router to this alias is needed.

This PR adds the router 10.200.10.1.nip.io:8989 to etc/tsuru-compose.conf

an example of this is setting tsuru/healthcheck-as-a-service app as a Tsuru service.

example of haas service.yml:

```
id: healthcheck
password: abc123
team: admin
endpoint:
  production: hcaas.10.200.10.1.nip.io:8989
```
