### PR TITLE
app: enable filtering apps with specific platform versions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1842,7 +1842,21 @@ func (f *Filter) Query() bson.M {
 		query["teamowner"] = f.TeamOwner
 	}
 	if f.Platform != "" {
-		query["framework"] = f.Platform
+		parts := strings.SplitN(f.Platform, ":", 2)
+		query["framework"] = parts[0]
+		if len(parts) == 2 {
+			v := parts[1]
+			if v == "latest" {
+				query["$and"] = []bson.M{
+					{"$or": []bson.M{
+						{"platformversion": bson.M{"$in": []string{"latest", ""}}},
+						{"platformversion": bson.M{"$exists": false}},
+					}},
+				}
+			} else {
+				query["platformversion"] = v
+			}
+		}
 	}
 	if f.UserOwner != "" {
 		query["owner"] = f.UserOwner

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -3134,6 +3134,39 @@ func (s *S) TestListReturnsAppsForAGivenUserFilteringByPlatform(c *check.C) {
 	c.Assert(apps, check.HasLen, 1)
 }
 
+func (s *S) TestListReturnsAppsForAGivenUserFilteringByPlatformVersion(c *check.C) {
+	apps := []App{
+		App{Name: "testapp", Platform: "ruby", TeamOwner: s.team.Name},
+		App{Name: "testapplatest", Platform: "ruby", TeamOwner: s.team.Name, PlatformVersion: "latest"},
+		App{Name: "othertestapp", Platform: "ruby", PlatformVersion: "v1", TeamOwner: s.team.Name},
+		App{Name: "testappwithoutversion", Platform: "ruby", TeamOwner: s.team.Name},
+		App{Name: "testappwithoutversionfield", Platform: "ruby", TeamOwner: s.team.Name},
+	}
+	for _, a := range apps {
+		err := s.conn.Apps().Insert(a)
+		c.Assert(err, check.IsNil)
+	}
+	err := s.conn.Apps().Update(bson.M{"name": "testappwithoutversionfield"}, bson.M{"$unset": bson.M{"platformversion": ""}})
+	c.Assert(err, check.IsNil)
+	tt := []struct {
+		platform string
+		apps     []string
+	}{
+		{platform: "ruby", apps: []string{"testapp", "testapplatest", "othertestapp", "testappwithoutversion", "testappwithoutversionfield"}},
+		{platform: "ruby:latest", apps: []string{"testapp", "testapplatest", "testappwithoutversion", "testappwithoutversionfield"}},
+		{platform: "ruby:v1", apps: []string{"othertestapp"}},
+	}
+	for _, t := range tt {
+		apps, err := List(&Filter{Platform: t.platform})
+		c.Assert(err, check.IsNil)
+		var appNames []string
+		for _, a := range apps {
+			appNames = append(appNames, a.Name)
+		}
+		c.Assert(appNames, check.DeepEquals, t.apps, check.Commentf("Invalid apps for platform %v", t.platform))
+	}
+}
+
 func (s *S) TestListReturnsAppsForAGivenUserFilteringByTeamOwner(c *check.C) {
 	a := App{
 		Name:      "testapp",


### PR DESCRIPTION
Prior to this change, users could not filter apps that were using a
specific plataform version (locked).

This change makes it possible to filter apps that are locked to a
specific platform version or are not locked to a specific version. Usage
is as follows:

`app list -p go` -> returns all apps using go (locked or not)
`app list -p go:v1` -> returns all apps that are using go locked to the
v1 version
`app list -p go:latest` -> return all apps that are not locked to a
specific go platform version.