### PR TITLE
provision/kubernetes: only wait for containers managed by tsuru

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -93,7 +93,7 @@ func doAttach(ctx context.Context, client *ClusterClient, stdin io.Reader, stdou
 			log.Errorf("error while waiting for container to finish during attach, attach not canceled: %v", err)
 		}
 	}()
-	// WARNING(cezarsa): If a context cancelation or a container finished
+	// WARNING(cezarsa): If a context cancellation or a container finished
 	// situation is triggered there's no reliable way to close the pending
 	// doUnsafeAttach call. We may only hope it will be gone eventually (as it
 	// should if the remote host isn't accessible anymore due to tcp keepalive
@@ -332,7 +332,7 @@ func createPod(ctx context.Context, params createPodParams) error {
 		}
 	}()
 	tctx, cancel := context.WithTimeout(ctx, kubeConf.PodRunningTimeout)
-	err = waitForPodContainersRunning(tctx, params.client, params.pod.Name, ns)
+	err = waitForPodContainersRunning(tctx, params.client, params.pod, ns)
 	cancel()
 	if err != nil {
 		return err
@@ -346,7 +346,7 @@ func createPod(ctx context.Context, params createPodParams) error {
 	}
 	tctx, cancel = context.WithTimeout(ctx, kubeConf.PodReadyTimeout)
 	defer cancel()
-	return waitForPod(tctx, params.client, params.pod.Name, ns, false)
+	return waitForPod(tctx, params.client, params.pod, ns, false)
 }
 
 func registryAuth(img string) (username, password, imgDomain string) {
@@ -1085,7 +1085,7 @@ func runInspectSidecar(params inspectParams) error {
 	defer cleanupPod(params.client, pod.Name, ns)
 	multiErr := tsuruErrors.NewMultiError()
 	ctx, cancel := context.WithTimeout(context.Background(), kubeConf.PodRunningTimeout)
-	err = waitForPodContainersRunning(ctx, params.client, pod.Name, ns)
+	err = waitForPodContainersRunning(ctx, params.client, &pod, ns)
 	cancel()
 	if err != nil {
 		multiErr.Add(errors.WithStack(err))
@@ -1099,7 +1099,7 @@ func runInspectSidecar(params inspectParams) error {
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), kubeConf.PodRunningTimeout)
 	defer cancel()
-	return waitForPod(ctx, params.client, pod.Name, ns, false)
+	return waitForPod(ctx, params.client, &pod, ns, false)
 }
 
 type deployAgentConfig struct {

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	tsuruv1 "github.com/tsuru/tsuru/provision/kubernetes/pkg/apis/tsuru/v1"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
+	"github.com/tsuru/tsuru/set"
 	"k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -272,13 +273,13 @@ podsLoop:
 	return messages, nil
 }
 
-func waitForPodContainersRunning(ctx context.Context, client *ClusterClient, podName, namespace string) error {
+func waitForPodContainersRunning(ctx context.Context, client *ClusterClient, origPod *apiv1.Pod, namespace string) error {
 	return waitFor(ctx, func() (bool, error) {
-		err := waitForPod(ctx, client, podName, namespace, true)
+		err := waitForPod(ctx, client, origPod, namespace, true)
 		if err != nil {
 			return true, errors.WithStack(err)
 		}
-		pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		pod, err := client.CoreV1().Pods(namespace).Get(origPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, errors.WithStack(err)
 		}
@@ -297,7 +298,7 @@ func waitForPodContainersRunning(ctx context.Context, client *ClusterClient, pod
 		}
 		return false, nil
 	}, func() error {
-		pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		pod, err := client.CoreV1().Pods(namespace).Get(origPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -322,9 +323,18 @@ func newInvalidPodPhaseError(client *ClusterClient, pod *apiv1.Pod, namespace st
 	return retErr
 }
 
-func waitForPod(ctx context.Context, client *ClusterClient, podName, namespace string, returnOnRunning bool) error {
+func podContainerNames(pod *apiv1.Pod) []string {
+	var names []string
+	for _, cont := range pod.Spec.Containers {
+		names = append(names, cont.Name)
+	}
+	return names
+}
+
+func waitForPod(ctx context.Context, client *ClusterClient, origPod *apiv1.Pod, namespace string, returnOnRunning bool) error {
+	validContSet := set.FromSlice(podContainerNames(origPod))
 	return waitFor(ctx, func() (bool, error) {
-		pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		pod, err := client.CoreV1().Pods(namespace).Get(origPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, errors.WithStack(err)
 		}
@@ -333,9 +343,25 @@ func waitForPod(ctx context.Context, client *ClusterClient, podName, namespace s
 		}
 		switch pod.Status.Phase {
 		case apiv1.PodRunning:
-			if !returnOnRunning {
-				return false, nil
+			if returnOnRunning {
+				return true, nil
 			}
+			allDone := len(validContSet) > 0
+			for _, contStatus := range pod.Status.ContainerStatuses {
+				if !validContSet.Includes(contStatus.Name) {
+					continue
+				}
+				termData := contStatus.State.Terminated
+				if termData == nil {
+					allDone = false
+					break
+				}
+				if termData.ExitCode != 0 {
+					invalidErr := newInvalidPodPhaseError(client, pod, namespace)
+					return true, errors.Wrapf(invalidErr, "unexpected container %q termination: Exit %d - Reason: %q - Message: %q", contStatus.Name, termData.ExitCode, termData.Reason, termData.Message)
+				}
+			}
+			return allDone, nil
 		case apiv1.PodUnknown:
 			fallthrough
 		case apiv1.PodFailed:
@@ -343,7 +369,7 @@ func waitForPod(ctx context.Context, client *ClusterClient, podName, namespace s
 		}
 		return true, nil
 	}, func() error {
-		pod, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		pod, err := client.CoreV1().Pods(namespace).Get(origPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -658,7 +684,7 @@ func runPod(args runSinglePodArgs) error {
 	kubeConf := getKubeConfig()
 	multiErr := tsuruErrors.NewMultiError()
 	ctx, cancel := context.WithTimeout(context.Background(), kubeConf.PodRunningTimeout)
-	err = waitForPod(ctx, args.client, pod.Name, ns, true)
+	err = waitForPod(ctx, args.client, pod, ns, true)
 	cancel()
 	if err != nil {
 		multiErr.Add(err)
@@ -675,7 +701,7 @@ func runPod(args runSinglePodArgs) error {
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), kubeConf.PodReadyTimeout)
 	defer cancel()
-	return waitForPod(ctx, args.client, pod.Name, ns, false)
+	return waitForPod(ctx, args.client, pod, ns, false)
 }
 
 func getNodeByAddr(client *ClusterClient, address string) (*apiv1.Node, error) {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
 	tsuruv1 "github.com/tsuru/tsuru/provision/kubernetes/pkg/apis/tsuru/v1"
+	"github.com/tsuru/tsuru/provision/kubernetes/testing"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/provision/provisiontest"
@@ -1146,6 +1147,7 @@ func (s *S) TestDeployBuilderImageCancel(c *check.C) {
 		pod, ok := action.(ktesting.CreateAction).GetObject().(*apiv1.Pod)
 		c.Assert(ok, check.Equals, true)
 		pod.Status.Phase = apiv1.PodRunning
+		testing.UpdatePodContainerStatus(pod, true)
 		return false, nil, nil
 	})
 	evt, err := event.New(&event.Opts{


### PR DESCRIPTION
This change allows tsuru to ignore containers added by admission controllers that may never reach the desired state.