### PR TITLE
Ignore duplicated app router entries The previous router field is ignored when the same router was already added to routers field.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2248,6 +2248,11 @@ func (app *App) updateRoutersDB(routers []appTypes.AppRouter) error {
 func (app *App) GetRouters() []appTypes.AppRouter {
 	routers := append([]appTypes.AppRouter{}, app.Routers...)
 	if app.Router != "" {
+		for _, r := range routers {
+			if r.Name == app.Router {
+				return routers
+			}
+		}
 		routers = append([]appTypes.AppRouter{{
 			Name: app.Router,
 			Opts: app.RouterOpts,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5428,6 +5428,22 @@ func (s *S) TestGetRoutersWithAddrWithStatus(c *check.C) {
 	})
 }
 
+func (s *S) TestGetRoutersIgnoresDuplicatedEntry(c *check.C) {
+	app := App{Name: "myapp", Platform: "go", TeamOwner: s.team.Name}
+	err := CreateApp(&app, s.user)
+	c.Assert(err, check.IsNil)
+	err = app.AddRouter(appTypes.AppRouter{
+		Name: "fake-tls",
+	})
+	c.Assert(err, check.IsNil)
+	app.Router = "fake-tls"
+	routers := app.GetRouters()
+	c.Assert(routers, check.DeepEquals, []appTypes.AppRouter{
+		{Name: "fake"},
+		{Name: "fake-tls"},
+	})
+}
+
 func (s *S) TestUpdateAppUpdatableProvisioner(c *check.C) {
 	p1 := provisiontest.NewFakeProvisioner()
 	p1.Name = "fake1"


### PR DESCRIPTION
Fixes #2199