### PR TITLE
provision/kubernetes: adds a way to append labels/annotations as is

### DIFF
--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -35,12 +35,14 @@ import (
 )
 
 const (
-	tsuruLabelPrefix       = "tsuru.io/"
-	tsuruInProgressTaint   = tsuruLabelPrefix + "inprogress"
-	tsuruNodeDisabledTaint = tsuruLabelPrefix + "disabled"
-	replicaDepRevision     = "deployment.kubernetes.io/revision"
-	kubeKindReplicaSet     = "ReplicaSet"
-	kubeLabelNameMaxLen    = 55
+	tsuruLabelPrefix          = "tsuru.io/"
+	tsuruInProgressTaint      = tsuruLabelPrefix + "inprogress"
+	tsuruNodeDisabledTaint    = tsuruLabelPrefix + "disabled"
+	tsuruExtraLabelsMeta      = tsuruLabelPrefix + "extra-labels"
+	tsuruExtraAnnotationsMeta = tsuruLabelPrefix + "extra-annotations"
+	replicaDepRevision        = "deployment.kubernetes.io/revision"
+	kubeKindReplicaSet        = "ReplicaSet"
+	kubeLabelNameMaxLen       = 55
 )
 
 var kubeNameRegex = regexp.MustCompile(`(?i)[^a-z0-9.-]`)

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -645,14 +645,12 @@ func setNodeMetadata(node *apiv1.Node, pool, iaasID string, meta map[string]stri
 			appendKV(v, ",", "=", node.Annotations)
 		case tsuruExtraLabelsMeta:
 			appendKV(v, ",", "=", node.Labels)
-		default:
-			if v == "" {
-				delete(node.Annotations, k)
-				continue
-			}
-			node.Annotations[k] = v
 		}
-
+		if v == "" {
+			delete(node.Annotations, k)
+			continue
+		}
+		node.Annotations[k] = v
 	}
 	baseNodeLabels := provision.NodeLabels(provision.NodeLabelsOpts{
 		IaaSID: iaasID,

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -640,11 +640,19 @@ func setNodeMetadata(node *apiv1.Node, pool, iaasID string, meta map[string]stri
 	}
 	for k, v := range meta {
 		k = tsuruLabelPrefix + strings.TrimPrefix(k, tsuruLabelPrefix)
-		if v == "" {
-			delete(node.Annotations, k)
-		} else {
+		switch k {
+		case tsuruExtraAnnotationsMeta:
+			appendKV(v, ",", "=", node.Annotations)
+		case tsuruExtraLabelsMeta:
+			appendKV(v, ",", "=", node.Labels)
+		default:
+			if v == "" {
+				delete(node.Annotations, k)
+				continue
+			}
 			node.Annotations[k] = v
 		}
+
 	}
 	baseNodeLabels := provision.NodeLabels(provision.NodeLabelsOpts{
 		IaaSID: iaasID,
@@ -657,6 +665,21 @@ func setNodeMetadata(node *apiv1.Node, pool, iaasID string, meta map[string]stri
 		}
 		delete(node.Annotations, k)
 		node.Labels[k] = v
+	}
+}
+
+func appendKV(s, outSep, innSep string, m map[string]string) {
+	kvs := strings.Split(s, outSep)
+	for _, kv := range kvs {
+		parts := strings.SplitN(kv, innSep, 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == "" {
+			delete(m, parts[1])
+			continue
+		}
+		m[parts[0]] = parts[1]
 	}
 }
 

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -173,10 +173,12 @@ func (s *S) TestAddNodePrefixed(c *check.C) {
 		Address: "my-node-addr",
 		Pool:    "p1",
 		Metadata: map[string]string{
-			"tsuru.io/m1":   "v1",
-			"m2":            "v2",
-			"pool":          "p2", // ignored
-			"tsuru.io/pool": "p3", // ignored
+			"tsuru.io/m1":                "v1",
+			"m2":                         "v2",
+			"pool":                       "p2", // ignored
+			"tsuru.io/pool":              "p3", // ignored
+			"tsuru.io/extra-labels":      "k1=v1,k2=v2",
+			"tsuru.io/extra-annotations": "k3=v3,k4=v4",
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -192,10 +194,14 @@ func (s *S) TestAddNodePrefixed(c *check.C) {
 	})
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Labels, check.DeepEquals, map[string]string{
 		"tsuru.io/pool": "p1",
+		"k1":            "v1",
+		"k2":            "v2",
 	})
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Annotations, check.DeepEquals, map[string]string{
 		"tsuru.io/m1": "v1",
 		"tsuru.io/m2": "v2",
+		"k3":          "v3",
+		"k4":          "v4",
 	})
 }
 

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -188,9 +188,11 @@ func (s *S) TestAddNodePrefixed(c *check.C) {
 	c.Assert(nodes[0].Address(), check.Equals, "my-node-addr")
 	c.Assert(nodes[0].Pool(), check.Equals, "p1")
 	c.Assert(nodes[0].Metadata(), check.DeepEquals, map[string]string{
-		"tsuru.io/pool": "p1",
-		"tsuru.io/m1":   "v1",
-		"tsuru.io/m2":   "v2",
+		"tsuru.io/pool":              "p1",
+		"tsuru.io/m1":                "v1",
+		"tsuru.io/m2":                "v2",
+		"tsuru.io/extra-labels":      "k1=v1,k2=v2",
+		"tsuru.io/extra-annotations": "k3=v3,k4=v4",
 	})
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Labels, check.DeepEquals, map[string]string{
 		"tsuru.io/pool": "p1",
@@ -198,10 +200,12 @@ func (s *S) TestAddNodePrefixed(c *check.C) {
 		"k2":            "v2",
 	})
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Annotations, check.DeepEquals, map[string]string{
-		"tsuru.io/m1": "v1",
-		"tsuru.io/m2": "v2",
-		"k3":          "v3",
-		"k4":          "v4",
+		"tsuru.io/m1":                "v1",
+		"tsuru.io/m2":                "v2",
+		"k3":                         "v3",
+		"k4":                         "v4",
+		"tsuru.io/extra-labels":      "k1=v1,k2=v2",
+		"tsuru.io/extra-annotations": "k3=v3,k4=v4",
 	})
 }
 


### PR DESCRIPTION
Prior to this change, every label/annotation added to a node thru the
metadata fields would contain the "tsuru.io/" prefix. This makes it hard
to use the metadata field as a way to add annotations and labels
required by some Kubernetes components.

This change introduces two special metadata fields:
"tsuru.io/extra-labels" and "tsuru.io/extra-annotations". Each of these
fields may contain multiple key and values that are applied as is as
labels ou annotations on a Kubernetes node.