### PR TITLE
docs: fix dot usage in docs

### DIFF
--- a/docs/advanced_topics/node_scaling.rst
+++ b/docs/advanced_topics/node_scaling.rst
@@ -101,7 +101,7 @@ Each time tsuru tries to run an auto scale action (add, remove, or rebalance). I
 will create an auto scale event. This event will record the result of the auto
 scale action and possible errors that occurred during its execution.
 
-You can list auto scale events with `tsuru docker-autoscale-list`
+You can list auto scale events with `tsuru docker-autoscale-list`.
 
 Running auto scale once
 -----------------------

--- a/docs/installing/gandalf.rst
+++ b/docs/installing/gandalf.rst
@@ -8,7 +8,7 @@ Gandalf
 To enable application deployment using git, tsuru uses Gandalf to manage Git repositories
 used to push applications to. It's also responsible for setting hooks in these repositories
 which will notify the tsuru API when a new deploy is made. For more details
-check `Gandalf Documentation <http://gandalf.readthedocs.org/>`_
+check `Gandalf Documentation <http://gandalf.readthedocs.org/>`_.
 
 .. note::
 

--- a/docs/managing/logs.rst
+++ b/docs/managing/logs.rst
@@ -61,7 +61,7 @@ configured external syslog servers. Similar to the diagram below:
 
 For informations about how to configure bs to forward logs and also some tunning
 options, please refer to the `bs documentation
-<https://github.com/tsuru/bs#environment-variables>`_
+<https://github.com/tsuru/bs#environment-variables>`_.
 
 The advantage of having the bs container as an intermediary is that it knows how
 to talk to the tsuru api server. Sending logs to the tsuru api server enables


### PR DESCRIPTION
Description of the change: Corrects the dots usage in the node_scaling.rst, gandalf.rst and logs.rst files.
Reason for the change: In the texts of the files are missing points.
Link to original source:
https://github.com/tsuru/tsuru/blob/master/docs/installing/gandalf.rst
https://github.com/tsuru/tsuru/blob/master/docs/advanced_topics/node_scaling.rst
https://github.com/tsuru/tsuru/blob/master/docs/managing/logs.rst