### PR TITLE
docs: fix typos in docs

### DIFF
--- a/docs/advanced_topics/metrics.rst
+++ b/docs/advanced_topics/metrics.rst
@@ -5,7 +5,7 @@
 Metrics
 =======
 
-Every docker node created on tsuru has a tsuru agent(a.k.a node-container),
+Every docker node created on tsuru has a tsuru agent (a.k.a node-container),
 called big-sibling, running as a container. One of it's responsibilities is
 collecting and reporting metrics, such as cpu and memory usage, from both it's
 host and other applications and containers running on the same host.

--- a/docs/services/api.rst
+++ b/docs/services/api.rst
@@ -58,7 +58,7 @@ Listing available plans
 =======================
 
 tsuru will list the available plans whenever the user issues the command
-``service-info``
+``service-info`` :
 
 .. highlight:: bash
 

--- a/docs/services/open-service-broker.rst
+++ b/docs/services/open-service-broker.rst
@@ -22,7 +22,7 @@ tsuru services, except for the support for instance creation and binding paramet
 Managing Service Brokers
 ========================
 
-To expose services from a broker, a tsuru admin needs to add the service broker endpoint to the tsuru api. This can be done on the cli.
+To expose services from a broker, a tsuru admin needs to add the service broker endpoint to the tsuru api. This can be done on the cli :
 
 .. highlight:: bash
 


### PR DESCRIPTION
**Description of the change**: Corrects typos in metrics.rst, api.rst and open-service-broker.rst.
**Reason for the change**: Typos in the doc files.
**Link to original source**: 
https://github.com/tsuru/tsuru/blob/master/docs/advanced_topics/metrics.rst
https://github.com/tsuru/tsuru/blob/master/docs/services/api.rst
https://github.com/tsuru/tsuru/blob/master/docs/services/open-service-broker.rst
