### PR TITLE
Support TLS certificate hot-reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TSR_BIN = $(BUILD_DIR)/tsurud
 TSR_SRC = ./cmd/tsurud
 TSR_PKGS = $$(go list ./... | grep -v /vendor/)
 
-.PHONY: all check-path test race docs install
+.PHONY: all check-path test race docs install tsurud $(TSR_BIN)
 
 all: check-path test
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -5,9 +5,15 @@
 package api
 
 import (
+	cryptoRand "crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"math/rand"
 	"net"
 	"net/http"
@@ -217,4 +223,168 @@ func (s *S) TestCreateServersHTTPAndHTTPS(c *check.C) {
 	err = waitForServer("localhost:" + httpPort)
 	c.Assert(err, check.IsNil)
 	s.testRequest(fmt.Sprintf("http://localhost:%s/foo", httpPort), c)
+}
+
+func (s *S) TestCreateServerHTTPSWhenGetCertificateIsCalledReturnsTheNewerLoadedCertificate(c *check.C) {
+	config.Set("use-tls", true)
+	config.Set("tls:listen", "127.0.0.1:8443")
+	config.Set("tls:cert-file", "./testdata/cert.pem")
+	config.Set("tls:key-file", "./testdata/key.pem")
+	config.Set("tls:auto-reload:interval", "500ms")
+
+	defer config.Unset("use-tls")
+
+	expectedTLSCertificate, err := tls.LoadX509KeyPair("./testdata/cert.pem", "./testdata/key.pem")
+	c.Assert(err, check.IsNil)
+
+	expectedCertificate, err := x509.ParseCertificate(expectedTLSCertificate.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	srvConf, err := createServers(nil)
+	c.Assert(err, check.IsNil)
+
+	tlsCertificate, err := generateTLSCertificate()
+	c.Assert(err, check.IsNil)
+
+	srvConf.Lock()
+	srvConf.certificate = tlsCertificate
+	srvConf.Unlock()
+
+	time.Sleep(time.Second)
+
+	gotCertificate, err := srvConf.httpsSrv.TLSConfig.GetCertificate(nil)
+	c.Assert(err, check.IsNil)
+
+	gotX509Certificate, err := x509.ParseCertificate(gotCertificate.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	c.Assert(gotX509Certificate.Equal(expectedCertificate), check.Equals, true)
+}
+
+func (s *S) TestCreateServerHTTPSWhenGetCertificateIsCalledAndCertificateIsNullShouldReturnError(c *check.C) {
+	config.Set("use-tls", true)
+	config.Set("tls:listen", "127.0.0.1:8443")
+	config.Set("tls:cert-file", "./testdata/cert.pem")
+	config.Set("tls:key-file", "./testdata/key.pem")
+
+	defer config.Unset("use-tls")
+
+	srvConf, err := createServers(nil)
+	c.Assert(err, check.IsNil)
+
+	srvConf.Lock()
+	srvConf.certificate = nil
+	srvConf.Unlock()
+
+	_, err = srvConf.httpsSrv.TLSConfig.GetCertificate(nil)
+	c.Assert(err, check.Not(check.IsNil))
+}
+
+func (s *S) TestSrvConfig_LoadCertificate_WhenFieldCertificateIsNullShouldLoadExpectedCertificate(c *check.C) {
+	srvConf := &srvConfig{
+		certificate: nil,
+		certFile:    "./testdata/cert.pem",
+		keyFile:     "./testdata/key.pem",
+	}
+
+	tlsCert, err := tls.LoadX509KeyPair("./testdata/cert.pem", "./testdata/key.pem")
+	c.Assert(err, check.IsNil)
+
+	expectedCertificate, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	changed, err := srvConf.loadCertificate()
+	c.Assert(err, check.IsNil)
+	c.Assert(changed, check.Equals, true)
+
+	gotCertificate, err := x509.ParseCertificate(srvConf.certificate.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	c.Assert(expectedCertificate.Equal(gotCertificate), check.Equals, true)
+}
+
+func (s *S) TestSrvConfig_LoadCertificate_WhenNewCertificateIsEqualsToOlderCertificateShouldNotChangeCertificate(c *check.C) {
+	tlsCert, err := tls.LoadX509KeyPair("./testdata/cert.pem", "./testdata/key.pem")
+	c.Assert(err, check.IsNil)
+
+	srvConf := &srvConfig{
+		certificate: &tlsCert,
+		certFile:    "./testdata/cert.pem",
+		keyFile:     "./testdata/key.pem",
+	}
+
+	changed, err := srvConf.loadCertificate()
+	c.Assert(err, check.IsNil)
+	c.Assert(changed, check.Equals, false)
+
+	expectedCertificate, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	gotCertificate, err := x509.ParseCertificate(srvConf.certificate.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	c.Assert(expectedCertificate.Equal(gotCertificate), check.Equals, true)
+}
+
+func (s *S) TestSrvConfig_LoadCertificate_WhenCertificatesAreNotEqualShouldLoadTheNewOne(c *check.C) {
+	tlsCert, err := generateTLSCertificate()
+	c.Assert(err, check.IsNil)
+
+	srvConf := &srvConfig{
+		certificate: tlsCert,
+		certFile:    "./testdata/cert.pem",
+		keyFile:     "./testdata/key.pem",
+	}
+
+	changed, err := srvConf.loadCertificate()
+	c.Assert(err, check.IsNil)
+	c.Assert(changed, check.Equals, true)
+
+	expectedCertificate, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	gotCertificate, err := x509.ParseCertificate(srvConf.certificate.Certificate[0])
+	c.Assert(err, check.IsNil)
+
+	c.Assert(expectedCertificate.Equal(gotCertificate), check.Equals, false)
+}
+
+func generateTLSCertificate() (*tls.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := cryptoRand.Int(cryptoRand.Reader, serialNumberLimit)
+
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Issuer: pkix.Name{
+			Organization: []string{"tsuru.io"},
+		},
+		Subject: pkix.Name{
+			Organization: []string{"tsuru.io"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute),
+	}
+
+	privateKey, err := rsa.GenerateKey(cryptoRand.Reader, 1024)
+
+	if err != nil {
+		return nil, err
+	}
+
+	derBytes, err := x509.CreateCertificate(cryptoRand.Reader, &template, &template, privateKey.Public(), privateKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	certPEMBlock := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEMBlock := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+
+	certificate, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+
+	return &certificate, err
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
             - ./data/mongo:/data/db
         networks:
             - tsuru_net
+        ports:
+            - 27017:27017
     redis:
         image: redis
         volumes:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -77,6 +77,18 @@ tls:key-file
 ``tls:key-file`` is the path to private key file configured to serve the
 domain. This setting is optional, unless ``use-tls`` is true.
 
+tls:auto-reload:interval
+++++++++++++++++++++++++
+
+``tls:auto-reload:interval`` defines the time frequency which the TLS 
+certificates are reloaded by the webserver. A new certificate only is loaded
+when there is difference between newer and older.
+
+This setting is optional. The default value is 0, which means automatic reload
+is not enabled. To enable it, you could use any `time.Duration <https://golang.org/pkg/time/#Duration>`_
+value greater than zero, as well as `parseable values <https://golang.org/pkg/time/#ParseDuration>`_
+as: "1h", "60m", "3600s", etc.
+
 server:read-timeout
 +++++++++++++++++++
 

--- a/etc/tsuru-custom.conf
+++ b/etc/tsuru-custom.conf
@@ -4,6 +4,8 @@ use-tls: false
 tls:
     cert-file: /certs/cert.pem
     key-file: /certs/key.pem
+    auto-reload:
+      interval: 0s
 repo-manager: none
 database:
   url: $MONGODB_ADDR:$MONGODB_PORT

--- a/etc/tsuru.conf
+++ b/etc/tsuru.conf
@@ -4,6 +4,8 @@ use-tls: false
 tls:
   cert-file: /data/tls/cert.pem
   key-file: /data/tls/key.pem
+  auto-reaload:
+    interval: 0s
 database:
   url: 127.0.0.1:27017
   name: tsuru


### PR DESCRIPTION
Prior to this change, it was needed to restart the web server to provide the newer TLS certificates on disk. That's bad practice because involves downtime of service.
    
This change allows that TLS certificates will be reloaded on runtime by the web server. That reload process occurs ever than the certificates on disk are different of the currently in-memory. The frequency of this process is defined by "tls:auto-reload:interval" setting on the configuration file.