### PR TITLE
provision/kubernetes: allow custom headless service port

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -975,6 +975,7 @@ func (m *serviceManager) DeployService(ctx context.Context, a provision.App, pro
 		return errors.WithStack(err)
 	}
 	labels.SetIsHeadlessService()
+	kubeConf := getKubeConfig()
 	_, err = m.client.CoreV1().Services(ns).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        headlessServiceNameForApp(a, process),
@@ -987,7 +988,7 @@ func (m *serviceManager) DeployService(ctx context.Context, a provision.App, pro
 			Ports: []apiv1.ServicePort{
 				{
 					Protocol:   "TCP",
-					Port:       int32(port),
+					Port:       int32(kubeConf.HeadlessServicePort),
 					TargetPort: intstr.FromInt(targetPort),
 				},
 			},

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -120,6 +120,9 @@ type kubernetesConfig struct {
 	// AttachTimeoutAfterContainerFinished is the time tsuru will wait for an
 	// attach call to finish after the attached container has finished.
 	AttachTimeoutAfterContainerFinished time.Duration
+	// HeadlessServicePort is the port used in headless service, by default the
+	// same port number used for container is used.
+	HeadlessServicePort int
 }
 
 func getKubeConfig() kubernetesConfig {
@@ -168,6 +171,10 @@ func getKubeConfig() kubernetesConfig {
 		conf.AttachTimeoutAfterContainerFinished = time.Duration(attachTimeout * float64(time.Second))
 	} else {
 		conf.AttachTimeoutAfterContainerFinished = defaultAttachTimeoutAfterContainerFinished
+	}
+	conf.HeadlessServicePort, _ = config.GetInt("kubernetes:headless-service-port")
+	if conf.HeadlessServicePort == 0 {
+		conf.HeadlessServicePort, _ = strconv.Atoi(provision.WebProcessDefaultPort())
 	}
 	return conf
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1703,6 +1703,7 @@ func (s *S) TestGetKubeConfig(c *check.C) {
 	config.Set("kubernetes:pod-running-timeout", 2*60)
 	config.Set("kubernetes:deployment-progress-timeout", 3*60)
 	config.Set("kubernetes:attach-after-finish-timeout", 5)
+	config.Set("kubernetes:headless-service-port", 8889)
 	defer config.Unset("kubernetes")
 	kubeConf := getKubeConfig()
 	c.Assert(kubeConf, check.DeepEquals, kubernetesConfig{
@@ -1714,6 +1715,7 @@ func (s *S) TestGetKubeConfig(c *check.C) {
 		PodRunningTimeout:                   2 * time.Minute,
 		DeploymentProgressTimeout:           3 * time.Minute,
 		AttachTimeoutAfterContainerFinished: 5 * time.Second,
+		HeadlessServicePort:                 8889,
 	})
 }
 
@@ -1729,6 +1731,7 @@ func (s *S) TestGetKubeConfigDefaults(c *check.C) {
 		PodRunningTimeout:                   10 * time.Minute,
 		DeploymentProgressTimeout:           10 * time.Minute,
 		AttachTimeoutAfterContainerFinished: time.Minute,
+		HeadlessServicePort:                 8888,
 	})
 }
 


### PR DESCRIPTION
This is useful to avoid port conflicts with other services when using
Isitio, due to a limitation on how istio handles headless services.