### PR TITLE
Reduces downtime during updates between diff provisioners

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -508,7 +508,6 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 	if updateData.UpdatePlatform {
 		app.UpdatePlatform = true
 	}
-
 	err = app.validate()
 	if err != nil {
 		return err
@@ -520,11 +519,13 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 		actions = append(actions, &updateAppProvisioner)
 	}
 	if newProv.GetName() != oldProv.GetName() {
+		defer func() {
+			rebuild.RoutesRebuildOrEnqueue(app.Name)
+		}()
 		err = validateVolumes(app)
 		if err != nil {
 			return err
 		}
-
 		actions = append(actions,
 			&provisionAppNewProvisioner,
 			&provisionAppAddUnits,


### PR DESCRIPTION
This PR aims to reduce the downtime during an app update that involves different provisioners. Routers are set to nil during the add unit process to make sure that we only rebuild the app routes after the entire process is finished.

A final routes rebuild is always called to make sure that we don't miss anything.