### PR TITLE
api,provision/docker: store logs for multiple types of events

### DIFF
--- a/api/nodecontainer.go
+++ b/api/nodecontainer.go
@@ -265,13 +265,14 @@ func nodeContainerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 15*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
+	evt.SetLogWriter(writer)
 	var allErrors []string
 	for _, prov := range provs {
 		ncProv, ok := prov.(provision.NodeContainerProvisioner)
 		if !ok {
 			continue
 		}
-		err = ncProv.RemoveNodeContainer(name, poolName, writer)
+		err = ncProv.RemoveNodeContainer(name, poolName, evt)
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}
@@ -332,13 +333,14 @@ func nodeContainerUpgrade(w http.ResponseWriter, r *http.Request, t auth.Token) 
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 15*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
+	evt.SetLogWriter(writer)
 	var allErrors []string
 	for _, prov := range provs {
 		ncProv, ok := prov.(provision.NodeContainerProvisioner)
 		if !ok {
 			continue
 		}
-		err = ncProv.UpgradeNodeContainer(name, poolName, writer)
+		err = ncProv.UpgradeNodeContainer(name, poolName, evt)
 		if err != nil {
 			allErrors = append(allErrors, err.Error())
 		}

--- a/api/volume.go
+++ b/api/volume.go
@@ -316,7 +316,8 @@ func volumeBind(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	return a.Restart("", writer)
+	evt.SetLogWriter(writer)
+	return a.Restart("", evt)
 }
 
 // title: volume unbind
@@ -382,5 +383,6 @@ func volumeUnbind(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	return a.Restart("", writer)
+	evt.SetLogWriter(writer)
+	return a.Restart("", evt)
 }

--- a/provision/docker/handlers.go
+++ b/provision/docker/handlers.go
@@ -97,7 +97,8 @@ func moveContainerHandler(w http.ResponseWriter, r *http.Request, t auth.Token) 
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 15*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	_, err = mainDockerProvisioner.moveContainer(contId, to, writer)
+	evt.SetLogWriter(writer)
+	_, err = mainDockerProvisioner.moveContainer(contId, to, evt)
 	if err != nil {
 		return errors.Wrap(err, "Error trying to move container")
 	}
@@ -154,11 +155,12 @@ func moveContainersHandler(w http.ResponseWriter, r *http.Request, t auth.Token)
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 15*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	err = mainDockerProvisioner.MoveContainers(from, to, writer)
+	evt.SetLogWriter(writer)
+	err = mainDockerProvisioner.MoveContainers(from, to, evt)
 	if err != nil {
 		return errors.Wrap(err, "Error trying to move containers")
 	}
-	fmt.Fprintf(writer, "Containers moved successfully!\n")
+	fmt.Fprintf(evt, "Containers moved successfully!\n")
 	return nil
 }
 
@@ -280,13 +282,14 @@ func logsConfigSetHandler(w http.ResponseWriter, r *http.Request, t auth.Token) 
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 15*time.Second, "")
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
-	fmt.Fprintln(writer, "Log config successfully updated.")
+	evt.SetLogWriter(writer)
+	fmt.Fprintln(evt, "Log config successfully updated.")
 	if restart {
 		filter := &app.Filter{}
 		if pool != "" {
 			filter.Pools = []string{pool}
 		}
-		return tryRestartAppsByFilter(filter, writer)
+		return tryRestartAppsByFilter(filter, evt)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR redirects the log of multiple different events to the event object itself. This guarantees that the log is going to be persisted into the storage.