### PR TITLE
db: add log message when can't create app log collection

### DIFF
--- a/db/storage/storage.go
+++ b/db/storage/storage.go
@@ -95,3 +95,7 @@ func (s *Storage) DropDatabase(name string) error {
 func (s *Storage) Collection(name string) *Collection {
 	return &Collection{Collection: s.session.DB(s.dbname).C(name)}
 }
+
+func (s *Storage) CollectionNames() ([]string, error) {
+	return s.Database(s.dbname).CollectionNames()
+}


### PR DESCRIPTION
MongoDB collections for app logs are created as [capped collections](https://docs.mongodb.com/manual/core/capped-collections/). But if the collection creation fails for any reason, the error is ignored, and the first insert ends up creating the collection, but uncapped.

This PR adds a log message when that occurs.