### PR TITLE
api,app,db: create log collection on app creation

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -4292,7 +4292,8 @@ func (s *S) TestAppLogSelectByLinesShouldReturnTheLastestEntries(c *check.C) {
 	err := app.CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	now := time.Now()
-	coll := s.logConn.Logs(a.Name)
+	coll, err := s.logConn.CreateAppLogCollection(a.Name)
+	c.Assert(err, check.IsNil)
 	for i := 0; i < 15; i++ {
 		l := app.Applog{
 			Date:    now.Add(time.Duration(i) * time.Hour),

--- a/api/build_test.go
+++ b/api/build_test.go
@@ -94,7 +94,7 @@ func (s *BuildSuite) TearDownSuite(c *check.C) {
 	config.Unset("docker:router")
 	pool.RemovePool("pool1")
 	s.conn.Apps().Database.DropDatabase()
-	s.logConn.Logs("myapp").Database.DropDatabase()
+	s.logConn.AppLogCollection("myapp").Database.DropDatabase()
 	s.conn.Close()
 	s.logConn.Close()
 	s.reset()

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -100,7 +100,7 @@ func (s *DeploySuite) TearDownSuite(c *check.C) {
 	config.Unset("docker:router")
 	pool.RemovePool("pool1")
 	s.conn.Apps().Database.DropDatabase()
-	s.logConn.Logs("myapp").Database.DropDatabase()
+	s.logConn.AppLogCollection("myapp").Database.DropDatabase()
 	s.conn.Close()
 	s.logConn.Close()
 	s.reset()

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -70,7 +70,7 @@ func (s *EventSuite) SetUpSuite(c *check.C) {
 
 func (s *EventSuite) TearDownSuite(c *check.C) {
 	s.conn.Apps().Database.DropDatabase()
-	s.logConn.Logs("myapp").Database.DropDatabase()
+	s.logConn.AppLogCollection("myapp").Database.DropDatabase()
 	s.conn.Close()
 	s.logConn.Close()
 }

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -117,7 +117,9 @@ func (s *S) SetUpTest(c *check.C) {
 	dbtest.ClearAllCollections(s.conn.Apps().Database)
 	s.logConn, err = db.LogConn()
 	c.Assert(err, check.IsNil)
-	dbtest.ClearAllCollections(s.logConn.Logs("myapp").Database)
+	appLogColl := s.logConn.AppLogCollection("myapp")
+	appLogColl.DropCollection()
+	dbtest.ClearAllCollections(appLogColl.Database)
 	s.createUserAndTeam(c)
 	s.provisioner = provisiontest.ProvisionerInstance
 	s.provisioner.Reset()
@@ -187,7 +189,7 @@ func (s *S) TearDownSuite(c *check.C) {
 	logConn, err := db.LogConn()
 	c.Assert(err, check.IsNil)
 	defer logConn.Close()
-	logConn.Logs("myapp").Database.DropDatabase()
+	logConn.AppLogCollection("myapp").Database.DropDatabase()
 }
 
 func userWithPermission(c *check.C, perm ...permission.Permission) auth.Token {

--- a/app/app.go
+++ b/app/app.go
@@ -736,7 +736,7 @@ func Delete(app *App, evt *event.Event, requestID string) error {
 	logConn, err := db.LogConn()
 	if err == nil {
 		defer logConn.Close()
-		err = logConn.Logs(appName).DropCollection()
+		err = logConn.AppLogCollection(appName).DropCollection()
 	}
 	if err != nil {
 		logErr("Unable to remove logs collection", err)
@@ -1750,7 +1750,7 @@ func (app *App) Log(message, source, unit string) error {
 			return err
 		}
 		defer conn.Close()
-		return conn.Logs(app.Name).Insert(logs...)
+		return conn.AppLogCollection(app.Name).Insert(logs...)
 	}
 	return nil
 }
@@ -1796,7 +1796,7 @@ func (app *App) lastLogs(lines int, filterLog Applog, invertFilter bool) ([]Appl
 			q[k] = bson.M{"$ne": v}
 		}
 	}
-	err = conn.Logs(app.Name).Find(q).Sort("-$natural").Limit(lines).All(&logs)
+	err = conn.AppLogCollection(app.Name).Find(q).Sort("-$natural").Limit(lines).All(&logs)
 	if err != nil {
 		return nil, err
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -101,7 +101,7 @@ func (s *S) TestDelete(c *check.C) {
 	c.Assert(s.provisioner.Provisioned(&a), check.Equals, false)
 	err = servicemanager.UserQuota.Inc(s.user.Email, 1)
 	c.Assert(err, check.IsNil)
-	count, err := s.logConn.Logs(app.Name).Count()
+	count, err := s.logConn.AppLogCollection(app.Name).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(count, check.Equals, 0)
 	_, err = repository.Manager().GetRepository(a.Name)
@@ -2504,12 +2504,12 @@ func (s *S) TestLog(c *check.C) {
 	err := CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	defer func() {
-		s.logConn.Logs(a.Name).DropCollection()
+		s.logConn.AppLogCollection(a.Name).DropCollection()
 	}()
 	err = a.Log("last log msg", "tsuru", "outermachine")
 	c.Assert(err, check.IsNil)
 	var logs []Applog
-	err = s.logConn.Logs(a.Name).Find(nil).All(&logs)
+	err = s.logConn.AppLogCollection(a.Name).Find(nil).All(&logs)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 1)
 	c.Assert(logs[0].Message, check.Equals, "last log msg")
@@ -2523,12 +2523,12 @@ func (s *S) TestLogShouldAddOneRecordByLine(c *check.C) {
 	err := CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	defer func() {
-		s.logConn.Logs(a.Name).DropCollection()
+		s.logConn.AppLogCollection(a.Name).DropCollection()
 	}()
 	err = a.Log("last log msg\nfirst log", "source", "machine")
 	c.Assert(err, check.IsNil)
 	var logs []Applog
-	err = s.logConn.Logs(a.Name).Find(nil).Sort("$natural").All(&logs)
+	err = s.logConn.AppLogCollection(a.Name).Find(nil).Sort("$natural").All(&logs)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 2)
 	c.Assert(logs[0].Message, check.Equals, "last log msg")
@@ -2543,7 +2543,7 @@ func (s *S) TestLogShouldNotLogBlankLines(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = a.Log("", "", "")
 	c.Assert(err, check.IsNil)
-	count, err := s.logConn.Logs(a.Name).Find(nil).Count()
+	count, err := s.logConn.AppLogCollection(a.Name).Find(nil).Count()
 	c.Assert(err, check.IsNil)
 	c.Assert(count, check.Equals, 1)
 }
@@ -2571,7 +2571,7 @@ func (s *S) TestLogWithListeners(c *check.C) {
 	}()
 	err = a.Log("last log msg", "tsuru", "machine")
 	c.Assert(err, check.IsNil)
-	defer s.logConn.Logs(a.Name).DropCollection()
+	defer s.logConn.AppLogCollection(a.Name).DropCollection()
 	done := make(chan bool, 1)
 	q := make(chan bool)
 	go func(quit chan bool) {

--- a/app/log.go
+++ b/app/log.go
@@ -112,7 +112,7 @@ func NewLogListener(a *App, filterLog Applog) (*LogListener, error) {
 	}
 	c := make(chan Applog, 10)
 	quit := make(chan struct{})
-	coll := conn.Logs(a.Name)
+	coll := conn.AppLogCollection(a.Name)
 	var lastLog Applog
 	err = coll.Find(nil).Sort("-_id").Limit(1).One(&lastLog)
 	if err == mgo.ErrNotFound {
@@ -306,7 +306,7 @@ func (d *appLogDispatcher) flush(msgs []interface{}, lastMessage *msgWithTS) boo
 		log.Errorf("[log flusher] unable to connect to mongodb: %s", err)
 		return false
 	}
-	coll := conn.Logs(d.appName)
+	coll := conn.AppLogCollection(d.appName)
 	err = coll.Insert(msgs...)
 	coll.Close()
 	if err != nil {

--- a/app/suite_test.go
+++ b/app/suite_test.go
@@ -87,6 +87,19 @@ func (s *S) createUserAndTeam(c *check.C) {
 	s.team = authTypes.Team{Name: "tsuruteam"}
 }
 
+func (s *S) dropAppLogCollections() {
+	logdb := s.logConn.AppLogCollection("myapp").Database
+	colls, err := logdb.CollectionNames()
+	if err != nil {
+		return
+	}
+	for _, coll := range colls {
+		if len(coll) > 5 && coll[0:5] == "logs_" {
+			logdb.C(coll).DropCollection()
+		}
+	}
+}
+
 var nativeScheme = auth.Scheme(native.NativeScheme{})
 
 func (s *S) SetUpSuite(c *check.C) {
@@ -116,7 +129,7 @@ func (s *S) TearDownSuite(c *check.C) {
 	defer s.conn.Close()
 	defer s.logConn.Close()
 	s.conn.Apps().Database.DropDatabase()
-	s.logConn.Logs("myapp").Database.DropDatabase()
+	s.logConn.AppLogCollection("myapp").Database.DropDatabase()
 }
 
 func (s *S) SetUpTest(c *check.C) {
@@ -145,6 +158,7 @@ func (s *S) SetUpTest(c *check.C) {
 	s.provisioner.Reset()
 	repositorytest.Reset()
 	dbtest.ClearAllCollections(s.conn.Apps().Database)
+	s.dropAppLogCollections()
 	s.createUserAndTeam(c)
 	s.defaultPlan = appTypes.Plan{
 		Name:     "default-plan",

--- a/db/storage.go
+++ b/db/storage.go
@@ -155,14 +155,19 @@ var logCappedInfo = mgo.CollectionInfo{
 	MaxDocs:  5000,
 }
 
-// Logs returns the logs collection for one app from MongoDB.
-func (s *LogStorage) Logs(appName string) *storage.Collection {
+// AppLogCollection returns the logs collection for one app from MongoDB.
+func (s *LogStorage) AppLogCollection(appName string) *storage.Collection {
 	if appName == "" {
 		return nil
 	}
-	c := s.Collection("logs_" + appName)
-	c.Create(&logCappedInfo)
-	return c
+	return s.Collection("logs_" + appName)
+}
+
+// CreateAppLogCollection creates a new capped collection to store logs for an app.
+func (s *LogStorage) CreateAppLogCollection(appName string) (*storage.Collection, error) {
+	c := s.AppLogCollection(appName)
+	err := c.Create(&logCappedInfo)
+	return c, err
 }
 
 // LogsCollections returns logs collections for all apps from MongoDB.

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -146,7 +146,7 @@ func (s *S) TestLogs(c *check.C) {
 	strg, err := LogConn()
 	c.Assert(err, check.IsNil)
 	defer strg.Close()
-	logs := strg.Logs("myapp")
+	logs := strg.AppLogCollection("myapp")
 	logsc := strg.Collection("logs_myapp")
 	c.Assert(logs, check.DeepEquals, logsc)
 }


### PR DESCRIPTION
MongoDB collections for app logs are created as [capped collections](https://docs.mongodb.com/manual/core/capped-collections/). But if the collection creation fails for any reason, the error is ignored, and the first insert ends up creating the collection, but uncapped.

With this PR, the app log collection is created on the app creation.