### PR TITLE
api: remove middleware converting json to urlencoded

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -3508,8 +3508,8 @@ func (s *S) TestSetEnvMissingFormBody(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
-	msg := "missing form body\n"
-	c.Assert(recorder.Body.String(), check.Equals, msg)
+	msg := ".*missing form body\n"
+	c.Assert(recorder.Body.String(), check.Matches, msg)
 }
 
 func (s *S) TestSetEnvHandlerReturnsBadRequestIfVariablesAreMissing(c *check.C) {

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -382,7 +382,7 @@ func (s *AuthSuite) TestCreateTeam(c *check.C) {
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
-	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
+	c.Assert(recorder.Code, check.Equals, http.StatusCreated, check.Commentf("body: %v", recorder.Body.String()))
 	c.Assert(eventtest.EventDesc{
 		Target: teamTarget(teamName),
 		Owner:  s.token.GetUserName(),

--- a/api/build.go
+++ b/api/build.go
@@ -32,7 +32,7 @@ import (
 //   403: Forbidden
 //   404: Not found
 func build(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	tag := r.FormValue("tag")
+	tag := InputValue(r, "tag")
 	if tag == "" {
 		return &tsuruErrors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -53,7 +53,7 @@ func build(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		if t.GetAppName() != appName && t.GetAppName() != app.InternalAppName {
 			return &tsuruErrors.HTTP{Code: http.StatusUnauthorized, Message: "invalid app token"}
 		}
-		userName = r.FormValue("user")
+		userName = InputValue(r, "user")
 	} else {
 		userName = t.GetUserName()
 	}
@@ -114,8 +114,8 @@ func prepareToBuild(r *http.Request) (opts app.DeployOptions, err error) {
 		}
 		file.Seek(0, io.SeekStart)
 	}
-	archiveURL := r.FormValue("archive-url")
-	image := r.FormValue("image")
+	archiveURL := InputValue(r, "archive-url")
+	image := InputValue(r, "image")
 	if image == "" && archiveURL == "" && file == nil {
 		return opts, &tsuruErrors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -123,7 +123,7 @@ func prepareToBuild(r *http.Request) (opts app.DeployOptions, err error) {
 		}
 	}
 	var build bool
-	buildString := r.FormValue("build")
+	buildString := InputValue(r, "build")
 	if buildString != "" {
 		build, err = strconv.ParseBool(buildString)
 		if err != nil {

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -6,6 +6,7 @@ package context
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/tsuru/tsuru/app"
@@ -23,6 +24,7 @@ const (
 	delayedHandlerKey
 	preventUnlockKey
 	appContextKey
+	reqBodyKey
 )
 
 func Clear(r *http.Request) {
@@ -31,6 +33,22 @@ func Clear(r *http.Request) {
 	}
 	newReq := r.WithContext(context.Background())
 	*r = *newReq
+}
+
+func GetBody(r *http.Request) ([]byte, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+	if v, ok := r.Context().Value(reqBodyKey).([]byte); ok {
+		return v, nil
+	}
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq := r.WithContext(context.WithValue(r.Context(), reqBodyKey, data))
+	*r = *newReq
+	return data, nil
 }
 
 func GetApp(r *http.Request) *app.App {

--- a/api/iaas_test.go
+++ b/api/iaas_test.go
@@ -239,6 +239,7 @@ func (s *S) TestTemplateCreateBadRequest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*template name cannot be empty.*`)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 
@@ -357,7 +358,9 @@ func (s *S) TestTemplateUpdateBadRequest(c *check.C) {
 	request, err := http.NewRequest("PUT", "/iaas/templates/my-tpl", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*unable to parse form.*`)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 

--- a/api/install.go
+++ b/api/install.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ajg/form"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
@@ -30,15 +29,8 @@ func installHostAdd(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	err = r.ParseForm()
-	if err != nil {
-		return err
-	}
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	dec.IgnoreCase(true)
 	var host *install.Host
-	err = dec.DecodeValues(&host, r.Form)
+	err = ParseInput(r, &host)
 	if err != nil {
 		return err
 	}
@@ -46,7 +38,7 @@ func installHostAdd(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypeInstallHost, Value: host.Name},
 		Kind:       permission.PermInstallManage,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermInstallManage),
 	})
 	if err != nil {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -7,9 +7,9 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	stdLog "log"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -29,6 +29,7 @@ import (
 	"github.com/tsuru/tsuru/io"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
+	"github.com/tsuru/tsuru/set"
 	appTypes "github.com/tsuru/tsuru/types/app"
 )
 
@@ -36,6 +37,8 @@ const (
 	tsuruMin      = "1.0.1"
 	craneMin      = "1.0.0"
 	tsuruAdminMin = "1.0.0"
+
+	defaultMaxMemory = 32 << 20 // 32 MB
 )
 
 func validate(token string, r *http.Request) (auth.Token, error) {
@@ -278,47 +281,135 @@ func (l *loggerMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, ne
 	l.logger.Printf("%s %s %s %s %d %q in %0.6fms%s", nowFormatted, scheme, r.Method, r.URL.Path, statusCode, r.UserAgent(), float64(duration)/float64(time.Millisecond), requestID)
 }
 
-type contentHijackMiddleware struct {
-	excludedHandlers []http.Handler
+func InputValues(r *http.Request, field string) ([]string, bool) {
+	parseForm(r)
+	switch r.Header.Get("Content-Type") {
+	case "application/json":
+		data, err := context.GetBody(r)
+		if err != nil {
+			break
+		}
+		if len(data) == 0 {
+			break
+		}
+		var dst map[string]interface{}
+		err = json.Unmarshal(data, &dst)
+		if err != nil {
+			break
+		}
+		val, isSet := dst[field]
+		if !isSet {
+			break
+		}
+		if _, isSet := r.Form[field]; !isSet {
+			r.Form[field] = nil
+		}
+		if asSlice, ok := val.([]interface{}); ok {
+			for _, v := range asSlice {
+				r.Form[field] = append(r.Form[field], fmt.Sprint(v))
+			}
+		} else {
+			r.Form[field] = append(r.Form[field], fmt.Sprint(val))
+		}
+	}
+	val, isSet := r.Form[field]
+	return val, isSet
 }
 
-func (m *contentHijackMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	defer next(w, r)
-	if r.Body == nil {
-		return
+func InputValue(r *http.Request, field string) string {
+	if values, _ := InputValues(r, field); len(values) > 0 {
+		return values[0]
 	}
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
-		return
-	}
-	currentHandler := context.GetDelayedHandler(r)
-	if currentHandler != nil {
-		currentHandlerPtr := reflect.ValueOf(currentHandler).Pointer()
-		for _, h := range m.excludedHandlers {
-			if reflect.ValueOf(h).Pointer() == currentHandlerPtr {
-				return
+	return ""
+}
+
+func InputFields(r *http.Request, exclude ...string) url.Values {
+	parseForm(r)
+	baseValues := r.Form
+	excludeSet := set.FromSlice(exclude)
+	switch r.Header.Get("Content-Type") {
+	case "application/json":
+		data, err := context.GetBody(r)
+		if err != nil {
+			return nil
+		}
+		if len(data) == 0 {
+			return nil
+		}
+		var dst map[string]interface{}
+		err = json.Unmarshal(data, &dst)
+		if err != nil {
+			return nil
+		}
+		bodyValues, err := form.EncodeToValues(dst)
+		if err != nil {
+			return nil
+		}
+		for key, values := range bodyValues {
+			for _, v := range values {
+				baseValues.Add(key, v)
 			}
 		}
 	}
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Errorf("[content hijacker] error reading body: %v", err)
-		return
+	ret := url.Values{}
+	for key, value := range baseValues {
+		if excludeSet.Includes(key) {
+			ret[key] = []string{"*****"}
+			continue
+		}
+		ret[key] = value
 	}
-	if len(data) == 0 {
-		return
+	return ret
+}
+
+func ParseInput(r *http.Request, dst interface{}) error {
+	contentType := r.Header.Get("Content-Type")
+	switch contentType {
+	case "application/json":
+		data, err := context.GetBody(r)
+		if err != nil {
+			return err
+		}
+		if len(data) == 0 {
+			return nil
+		}
+		err = json.Unmarshal(data, dst)
+		if err != nil {
+			return &tsuruErrors.HTTP{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("unable to parse as json: %q - %v", string(data), err),
+			}
+		}
+	default:
+		dec := form.NewDecoder(nil)
+		dec.IgnoreCase(true)
+		dec.IgnoreUnknownKeys(true)
+		err := parseForm(r)
+		if err != nil && contentType == "application/x-www-form-urlencoded" {
+			return &tsuruErrors.HTTP{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("unable to parse form: %v", err),
+			}
+		}
+		err = dec.DecodeValues(dst, r.Form)
+		if err != nil {
+			return &tsuruErrors.HTTP{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("unable to decode form: %#v - %v", r.Form, err),
+			}
+		}
 	}
-	var bodyData map[string]interface{}
-	err = json.Unmarshal(data, &bodyData)
-	if err != nil {
-		log.Errorf("[content hijacker] unable to parse as json: %q - %v", string(data), err)
-		return
+	return nil
+}
+
+func parseForm(r *http.Request) error {
+	if r.Form == nil {
+		contentType := r.Header.Get("Content-Type")
+		if strings.HasPrefix(contentType, "multipart") {
+			return r.ParseMultipartForm(defaultMaxMemory)
+		} else {
+			return r.ParseForm()
+		}
 	}
-	formData, err := form.EncodeToString(bodyData)
-	if err != nil {
-		log.Errorf("[content hijacker] unable to format as form: %v", err)
-		return
-	}
-	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	r.Body = ioutil.NopCloser(strings.NewReader(formData))
+	return nil
 }

--- a/api/node_test.go
+++ b/api/node_test.go
@@ -995,12 +995,11 @@ func (s *S) TestNodeRebalanceEmptyBodyHandler(c *check.C) {
 	request, err := http.NewRequest("POST", "/node/rebalance", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	server := RunServer(true)
 	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Body.String(), check.Matches, "(?s).*rebalancing - dry: false, force: true.*Units successfully rebalanced.*")
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/x-json-stream")
-	c.Assert(recorder.Body.String(), check.Matches, "(?s).*rebalancing - dry: false, force: true.*Units successfully rebalanced.*")
 	units, err := s.provisioner.Units(&a)
 	c.Assert(err, check.IsNil)
 	var nodes []string

--- a/api/nodecontainer.go
+++ b/api/nodecontainer.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ajg/form"
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/auth"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
@@ -70,19 +69,12 @@ func nodeContainerList(w http.ResponseWriter, r *http.Request, t auth.Token) err
 //   400: Invald data
 //   401: Unauthorized
 func nodeContainerCreate(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return err
-	}
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	dec.IgnoreCase(true)
 	var config nodecontainer.NodeContainerConfig
-	err = dec.DecodeValues(&config, r.Form)
+	err = ParseInput(r, &config)
 	if err != nil {
 		return err
 	}
-	poolName := r.FormValue("pool")
+	poolName := InputValue(r, "pool")
 	var ctxs []permTypes.PermissionContext
 	if poolName != "" {
 		ctxs = append(ctxs, permission.Context(permTypes.CtxPool, poolName))
@@ -94,7 +86,7 @@ func nodeContainerCreate(w http.ResponseWriter, r *http.Request, t auth.Token) (
 		Target:     event.Target{Type: event.TargetTypeNodeContainer, Value: config.Name},
 		Kind:       permission.PermNodecontainerCreate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPoolReadEvents, ctxs...),
 	})
 	if err != nil {
@@ -166,19 +158,12 @@ func nodeContainerInfo(w http.ResponseWriter, r *http.Request, t auth.Token) err
 //   401: Unauthorized
 //   404: Not found
 func nodeContainerUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return err
-	}
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	dec.IgnoreCase(true)
 	var config nodecontainer.NodeContainerConfig
-	err = dec.DecodeValues(&config, r.Form)
+	err = ParseInput(r, &config)
 	if err != nil {
 		return err
 	}
-	poolName := r.FormValue("pool")
+	poolName := InputValue(r, "pool")
 	var ctxs []permTypes.PermissionContext
 	if poolName != "" {
 		ctxs = append(ctxs, permission.Context(permTypes.CtxPool, poolName))
@@ -190,7 +175,7 @@ func nodeContainerUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (
 		Target:     event.Target{Type: event.TargetTypeNodeContainer, Value: config.Name},
 		Kind:       permission.PermNodecontainerUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPoolReadEvents, ctxs...),
 	})
 	if err != nil {
@@ -225,7 +210,6 @@ func nodeContainerUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (
 //   401: Unauthorized
 //   404: Not found
 func nodeContainerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	name := r.URL.Query().Get(":name")
 	poolName := r.URL.Query().Get("pool")
 	kill, _ := strconv.ParseBool(r.URL.Query().Get("kill"))
@@ -240,7 +224,7 @@ func nodeContainerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (
 		Target:     event.Target{Type: event.TargetTypeNodeContainer, Value: name},
 		Kind:       permission.PermNodecontainerDelete,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPoolReadEvents, ctxs...),
 	})
 	if err != nil {
@@ -294,9 +278,8 @@ func nodeContainerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (
 //   401: Unauthorized
 //   404: Not found
 func nodeContainerUpgrade(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	name := r.URL.Query().Get(":name")
-	poolName := r.FormValue("pool")
+	poolName := InputValue(r, "pool")
 	var ctxs []permTypes.PermissionContext
 	if poolName != "" {
 		ctxs = append(ctxs, permission.Context(permTypes.CtxPool, poolName))
@@ -308,7 +291,7 @@ func nodeContainerUpgrade(w http.ResponseWriter, r *http.Request, t auth.Token) 
 		Target:     event.Target{Type: event.TargetTypeNodeContainer, Value: name},
 		Kind:       permission.PermNodecontainerUpdateUpgrade,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPoolReadEvents, ctxs...),
 	})
 	if err != nil {

--- a/api/permission.go
+++ b/api/permission.go
@@ -35,7 +35,7 @@ func addRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	if !permission.Check(t, permission.PermRoleCreate) {
 		return permission.ErrUnauthorized
 	}
-	roleName := r.FormValue("name")
+	roleName := InputValue(r, "name")
 	if roleName == "" {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -46,14 +46,14 @@ func addRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleCreate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	_, err = permission.NewRole(roleName, r.FormValue("context"), r.FormValue("description"))
+	_, err = permission.NewRole(roleName, InputValue(r, "context"), InputValue(r, "description"))
 	if err == permTypes.ErrInvalidRoleName {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -80,7 +80,6 @@ func addRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 //   401: Unauthorized
 //   404: Role not found
 func removeRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	if !permission.Check(t, permission.PermRoleDelete) {
 		return permission.ErrUnauthorized
 	}
@@ -89,7 +88,7 @@ func removeRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleDelete,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
@@ -269,7 +268,6 @@ func runWithPermSync(users []auth.User, callback func() error) error {
 //   401: Unauthorized
 //   409: Permission not allowed
 func addPermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	if !permission.Check(t, permission.PermRoleUpdatePermissionAdd) {
 		return permission.ErrUnauthorized
 	}
@@ -278,7 +276,7 @@ func addPermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdatePermissionAdd,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
@@ -289,16 +287,13 @@ func addPermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 	if err != nil {
 		return err
 	}
-	err = r.ParseForm()
-	if err != nil {
-		return err
-	}
 	users, err := auth.ListUsersWithRole(roleName)
 	if err != nil {
 		return err
 	}
 	err = runWithPermSync(users, func() error {
-		return role.AddPermissions(r.Form["permission"]...)
+		permissions, _ := InputValues(r, "permission")
+		return role.AddPermissions(permissions...)
 	})
 	if err == permTypes.ErrInvalidPermissionName {
 		return &errors.HTTP{
@@ -329,7 +324,6 @@ func addPermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 //   401: Unauthorized
 //   404: Not found
 func removePermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	if !permission.Check(t, permission.PermRoleUpdatePermissionRemove) {
 		return permission.ErrUnauthorized
 	}
@@ -338,7 +332,7 @@ func removePermissions(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdatePermissionRemove,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
@@ -403,7 +397,6 @@ func canUseRole(t auth.Token, roleName, contextValue string) error {
 //   401: Unauthorized
 //   404: Role not found
 func assignRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	if !permission.Check(t, permission.PermRoleUpdateAssign) {
 		return permission.ErrUnauthorized
 	}
@@ -412,15 +405,15 @@ func assignRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdateAssign,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	email := r.FormValue("email")
-	contextValue := r.FormValue("context")
+	email := InputValue(r, "email")
+	contextValue := InputValue(r, "context")
 	user, err := auth.GetUserByEmail(email)
 	if err != nil {
 		return err
@@ -444,7 +437,6 @@ func assignRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 //   401: Unauthorized
 //   404: Role not found
 func dissociateRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	if !permission.Check(t, permission.PermRoleUpdateDissociate) {
 		return permission.ErrUnauthorized
 	}
@@ -453,7 +445,7 @@ func dissociateRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdateDissociate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
@@ -522,13 +514,9 @@ func addDefaultRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 	if !permission.Check(t, permission.PermRoleDefaultCreate) {
 		return permission.ErrUnauthorized
 	}
-	err = r.ParseForm()
-	if err != nil {
-		return err
-	}
 	rolesMap := map[string][]string{}
 	for evtName := range permTypes.RoleEventMap {
-		roles := r.Form[evtName]
+		roles, _ := InputValues(r, evtName)
 		for _, roleName := range roles {
 			rolesMap[roleName] = append(rolesMap[roleName], evtName)
 		}
@@ -538,7 +526,7 @@ func addDefaultRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 			Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 			Kind:       permission.PermRoleDefaultCreate,
 			Owner:      t,
-			CustomData: event.FormToCustomData(r.Form),
+			CustomData: event.FormToCustomData(InputFields(r)),
 			Allowed:    event.Allowed(permission.PermRoleReadEvents),
 		})
 		if err != nil {
@@ -582,10 +570,10 @@ func removeDefaultRole(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 	if !permission.Check(t, permission.PermRoleDefaultDelete) {
 		return permission.ErrUnauthorized
 	}
-	r.ParseForm()
+
 	rolesMap := map[string][]string{}
 	for evtName := range permTypes.RoleEventMap {
-		roles := r.Form[evtName]
+		roles, _ := InputValues(r, evtName)
 		for _, roleName := range roles {
 			rolesMap[roleName] = append(rolesMap[roleName], evtName)
 		}
@@ -595,7 +583,7 @@ func removeDefaultRole(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 			Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 			Kind:       permission.PermRoleDefaultDelete,
 			Owner:      t,
-			CustomData: event.FormToCustomData(r.Form),
+			CustomData: event.FormToCustomData(InputFields(r)),
 			Allowed:    event.Allowed(permission.PermRoleReadEvents),
 		})
 		if err != nil {
@@ -650,11 +638,10 @@ func listDefaultRoles(w http.ResponseWriter, r *http.Request, t auth.Token) erro
 //   400: Invalid data
 //   401: Unauthorized
 func roleUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
-	r.ParseForm()
-	roleName := r.FormValue("name")
-	newName := r.FormValue("newName")
-	contextType := r.FormValue("contextType")
-	description := r.FormValue("description")
+	roleName := InputValue(r, "name")
+	newName := InputValue(r, "newName")
+	contextType := InputValue(r, "contextType")
+	description := InputValue(r, "description")
 	var wantedPerms []*permission.PermissionScheme
 	if newName != "" {
 		wantedPerms = append(wantedPerms, permission.PermRoleUpdateName)
@@ -678,7 +665,7 @@ func roleUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleUpdate),
 	})
 	if err != nil {
@@ -705,21 +692,17 @@ func roleUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   401: Unauthorized
 //   404: Role or team token not found
 func assignRoleToToken(w http.ResponseWriter, r *http.Request, t auth.Token) error {
-	err := r.ParseForm()
-	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	if !permission.Check(t, permission.PermRoleUpdateAssign) {
 		return permission.ErrUnauthorized
 	}
-	tokenID := r.FormValue("token_id")
-	contextValue := r.FormValue("context")
+	tokenID := InputValue(r, "token_id")
+	contextValue := InputValue(r, "context")
 	roleName := r.URL.Query().Get(":name")
 	evt, err := event.New(&event.Opts{
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdateAssign,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {
@@ -747,21 +730,17 @@ func assignRoleToToken(w http.ResponseWriter, r *http.Request, t auth.Token) err
 //   401: Unauthorized
 //   404: Role or team token not found
 func dissociateRoleFromToken(w http.ResponseWriter, r *http.Request, t auth.Token) error {
-	err := r.ParseForm()
-	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	if !permission.Check(t, permission.PermRoleUpdateDissociate) {
 		return permission.ErrUnauthorized
 	}
 	tokenID := r.URL.Query().Get(":token_id")
-	contextValue := r.FormValue("context")
+	contextValue := InputValue(r, "context")
 	roleName := r.URL.Query().Get(":name")
 	evt, err := event.New(&event.Opts{
 		Target:     event.Target{Type: event.TargetTypeRole, Value: roleName},
 		Kind:       permission.PermRoleUpdateDissociate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermRoleReadEvents),
 	})
 	if err != nil {

--- a/api/plan.go
+++ b/api/plan.go
@@ -27,12 +27,12 @@ import (
 //   401: Unauthorized
 //   409: Plan already exists
 func addPlan(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	cpuShare, _ := strconv.Atoi(r.FormValue("cpushare"))
-	isDefault, _ := strconv.ParseBool(r.FormValue("default"))
-	memory := getSize(r.FormValue("memory"))
-	swap := getSize(r.FormValue("swap"))
+	cpuShare, _ := strconv.Atoi(InputValue(r, "cpushare"))
+	isDefault, _ := strconv.ParseBool(InputValue(r, "default"))
+	memory := getSize(InputValue(r, "memory"))
+	swap := getSize(InputValue(r, "swap"))
 	plan := appTypes.Plan{
-		Name:     r.FormValue("name"),
+		Name:     InputValue(r, "name"),
 		Memory:   memory,
 		Swap:     swap,
 		CpuShare: cpuShare,
@@ -46,7 +46,7 @@ func addPlan(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		Target:     event.Target{Type: event.TargetTypePlan, Value: plan.Name},
 		Kind:       permission.PermPlanCreate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlanReadEvents),
 	})
 	if err != nil {
@@ -100,7 +100,6 @@ func listPlans(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   401: Unauthorized
 //   404: Plan not found
 func removePlan(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	allowed := permission.Check(t, permission.PermPlanDelete)
 	if !allowed {
 		return permission.ErrUnauthorized
@@ -110,7 +109,7 @@ func removePlan(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		Target:     event.Target{Type: event.TargetTypePlan, Value: planName},
 		Kind:       permission.PermPlanDelete,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlanReadEvents),
 	})
 	if err != nil {

--- a/api/platform.go
+++ b/api/platform.go
@@ -30,7 +30,7 @@ import (
 //   400: Invalid data
 //   401: Unauthorized
 func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	name := r.FormValue("name")
+	name := InputValue(r, "name")
 	file, _, err := r.FormFile("dockerfile_content")
 	if err != nil {
 		return &tErrors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
@@ -59,7 +59,7 @@ func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) (err erro
 		Target:     event.Target{Type: event.TargetTypePlatform, Value: name},
 		Kind:       permission.PermPlatformCreate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlatformReadEvents),
 	})
 	if err != nil {
@@ -92,9 +92,6 @@ func platformAdd(w http.ResponseWriter, r *http.Request, t auth.Token) (err erro
 //   401: Unauthorized
 //   404: Not found
 func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	if err = r.ParseForm(); err != nil {
-		return err
-	}
 	name := r.URL.Query().Get(":name")
 	file, _, _ := r.FormFile("dockerfile_content")
 	if file != nil {
@@ -116,7 +113,7 @@ func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypePlatform, Value: name},
 		Kind:       permission.PermPlatformUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlatformReadEvents),
 	})
 	if err != nil {
@@ -151,9 +148,6 @@ func platformUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 //   401: Unauthorized
 //   404: Not found
 func platformRemove(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	if err = r.ParseForm(); err != nil {
-		return err
-	}
 	canDeletePlatform := permission.Check(t, permission.PermPlatformDelete)
 	if !canDeletePlatform {
 		return permission.ErrUnauthorized
@@ -163,7 +157,7 @@ func platformRemove(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypePlatform, Value: name},
 		Kind:       permission.PermPlatformDelete,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlatformReadEvents),
 	})
 	if err != nil {
@@ -209,9 +203,6 @@ func platformList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   401: Unauthorized
 //   404: NotFound
 func platformInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
-	if err := r.ParseForm(); err != nil {
-		return err
-	}
 	name := r.URL.Query().Get(":name")
 	canUsePlat := permission.Check(t, permission.PermPlatformUpdate) ||
 		permission.Check(t, permission.PermPlatformCreate)
@@ -247,11 +238,8 @@ func platformInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   401: Unauthorized
 //   404: Not found
 func platformRollback(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	if err = r.ParseForm(); err != nil {
-		return err
-	}
 	name := r.URL.Query().Get(":name")
-	image := r.FormValue("image")
+	image := InputValue(r, "image")
 	if image == "" {
 		return &tErrors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -270,7 +258,7 @@ func platformRollback(w http.ResponseWriter, r *http.Request, t auth.Token) (err
 		Target:     event.Target{Type: event.TargetTypePlatform, Value: name},
 		Kind:       permission.PermPlatformUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermPlatformReadEvents),
 	})
 	if err != nil {

--- a/api/platform_test.go
+++ b/api/platform_test.go
@@ -574,5 +574,6 @@ func (s *PlatformSuite) TestPlatformRollbackError(c *check.C) {
 	request.Header.Set("Authorization", "b "+token.GetValue())
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
-	c.Assert(recorder.Code, check.Equals, http.StatusInternalServerError)
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*cannot rollback without an image name.*`)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }

--- a/api/quota.go
+++ b/api/quota.go
@@ -58,7 +58,6 @@ func getUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   403: Limit lower than allocated value
 //   404: User not found
 func changeUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	email := r.URL.Query().Get(":email")
 	allowed := permission.Check(t, permission.PermUserUpdateQuota, permission.Context(permTypes.CtxUser, email))
 	if !allowed {
@@ -77,14 +76,14 @@ func changeUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err 
 		Target:     event.Target{Type: event.TargetTypeUser, Value: email},
 		Kind:       permission.PermUserUpdateQuota,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermUserReadEvents, permission.Context(permTypes.CtxUser, email)),
 	})
 	if err != nil {
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	limit, err := strconv.Atoi(r.FormValue("limit"))
+	limit, err := strconv.Atoi(InputValue(r, "limit"))
 	if err != nil {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -133,7 +132,6 @@ func getAppQuota(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   403: Limit lower than allocated
 //   404: Application not found
 func changeAppQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	appName := r.URL.Query().Get(":appname")
 	a, err := getAppFromContext(appName, r)
 	if err != nil {
@@ -147,14 +145,14 @@ func changeAppQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		Target:     event.Target{Type: event.TargetTypeApp, Value: appName},
 		Kind:       permission.PermAppAdminQuota,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermAppReadEvents, contextsForApp(&a)...),
 	})
 	if err != nil {
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	limit, err := strconv.Atoi(r.FormValue("limit"))
+	limit, err := strconv.Atoi(InputValue(r, "limit"))
 	if err != nil {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,

--- a/api/router.go
+++ b/api/router.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/ajg/form"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
@@ -84,17 +83,10 @@ contexts:
 //   404: App or router not found
 //   400: Invalid request
 func addAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	var appRouter appTypes.AppRouter
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	dec.IgnoreCase(true)
-	err = dec.DecodeValues(&appRouter, r.Form)
+	err = ParseInput(r, &appRouter)
 	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
+		return err
 	}
 	appName := r.URL.Query().Get(":app")
 	a, err := getAppFromContext(appName, r)
@@ -131,7 +123,7 @@ func addAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 		Target:     appTarget(appName),
 		Kind:       permission.PermAppUpdateRouterAdd,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermAppReadEvents, contextsForApp(&a)...),
 	})
 	if err != nil {
@@ -150,17 +142,10 @@ func addAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 //   404: App or router not found
 //   400: Invalid request
 func updateAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	var appRouter appTypes.AppRouter
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	dec.IgnoreCase(true)
-	err = dec.DecodeValues(&appRouter, r.Form)
+	err = ParseInput(r, &appRouter)
 	if err != nil {
-		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
+		return err
 	}
 	routerName := r.URL.Query().Get(":router")
 	appRouter.Name = routerName
@@ -199,7 +184,7 @@ func updateAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err 
 		Target:     appTarget(appName),
 		Kind:       permission.PermAppUpdateRouterUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermAppReadEvents, contextsForApp(&a)...),
 	})
 	if err != nil {
@@ -217,7 +202,6 @@ func updateAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err 
 //   200: OK
 //   404: App or router not found
 func removeAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	r.ParseForm()
 	appName := r.URL.Query().Get(":app")
 	routerName := r.URL.Query().Get(":router")
 	a, err := getAppFromContext(appName, r)
@@ -234,7 +218,7 @@ func removeAppRouter(w http.ResponseWriter, r *http.Request, t auth.Token) (err 
 		Target:     appTarget(appName),
 		Kind:       permission.PermAppUpdateRouterRemove,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermAppReadEvents, contextsForApp(&a)...),
 	})
 	if err != nil {

--- a/api/server.go
+++ b/api/server.go
@@ -472,10 +472,6 @@ func RunServer(dry bool) http.Handler {
 	n.Use(negroni.HandlerFunc(errorHandlingMiddleware))
 	n.Use(negroni.HandlerFunc(setVersionHeadersMiddleware))
 	n.Use(negroni.HandlerFunc(authTokenMiddleware))
-	n.Use(&contentHijackMiddleware{excludedHandlers: []http.Handler{
-		proxyInstanceHandler,
-		proxyServiceHandler,
-	}})
 	n.Use(&appLockMiddleware{excludedHandlers: []http.Handler{
 		logPostHandler,
 		runHandler,

--- a/api/service_broker.go
+++ b/api/service_broker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ajg/form"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
@@ -58,7 +57,7 @@ func serviceBrokerAdd(w http.ResponseWriter, r *http.Request, t auth.Token) erro
 		Target:     event.Target{Type: event.TargetTypeServiceBroker, Value: broker.Name},
 		Kind:       permission.PermServiceBrokerCreate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermServiceBrokerReadEvents),
 	})
 	if err != nil {
@@ -98,7 +97,7 @@ func serviceBrokerUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) e
 		Target:     event.Target{Type: event.TargetTypeServiceBroker, Value: broker.Name},
 		Kind:       permission.PermServiceBrokerUpdate,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermServiceBrokerReadEvents),
 	})
 	if err != nil {
@@ -130,7 +129,7 @@ func serviceBrokerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) e
 		Target:     event.Target{Type: event.TargetTypeServiceBroker, Value: brokerName},
 		Kind:       permission.PermServiceBrokerDelete,
 		Owner:      t,
-		CustomData: event.FormToCustomData(r.Form),
+		CustomData: event.FormToCustomData(InputFields(r)),
 		Allowed:    event.Allowed(permission.PermServiceBrokerReadEvents),
 	})
 	if err != nil {
@@ -145,13 +144,7 @@ func serviceBrokerDelete(w http.ResponseWriter, r *http.Request, t auth.Token) e
 
 func decodeServiceBroker(request *http.Request) (*service.Broker, error) {
 	var broker service.Broker
-	dec := form.NewDecoder(nil)
-	dec.IgnoreCase(true)
-	dec.IgnoreUnknownKeys(true)
-	if err := request.ParseForm(); err != nil {
-		return nil, fmt.Errorf("unable to parse form: %v", err)
-	}
-	if err := dec.DecodeValues(&broker, request.Form); err != nil {
+	if err := ParseInput(request, &broker); err != nil {
 		return nil, fmt.Errorf("unable to parse broker: %v", err)
 	}
 	return &broker, nil

--- a/api/shell.go
+++ b/api/shell.go
@@ -161,7 +161,7 @@ func remoteShellHandler(w http.ResponseWriter, r *http.Request) {
 		Target:      appTarget(appName),
 		Kind:        permission.PermAppRunShell,
 		Owner:       token,
-		CustomData:  event.FormToCustomData(r.Form),
+		CustomData:  event.FormToCustomData(InputFields(r)),
 		Allowed:     event.Allowed(permission.PermAppReadEvents, contextsForApp(&a)...),
 		DisableLock: true,
 	})

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -866,15 +866,7 @@ paths:
           in: body
           required: true
           schema:
-            type: object
-            properties:
-              name:
-                type: string
-              tags:
-                type: array
-                items:
-                  type: string
-          description: Team name.
+            $ref: "#/definitions/TeamCreateArgs"
       responses:
         "201":
           description: Team created.
@@ -966,16 +958,8 @@ paths:
         - name: updateData
           in: body
           required: true
-          description: Team update data.
           schema:
-            type: object
-            properties:
-              newname:
-                type: string
-              tags:
-                type: array
-                items:
-                  type: string
+            $ref: "#/definitions/TeamUpdateArgs"
       consumes:
         - application/json
       responses:
@@ -1746,9 +1730,9 @@ paths:
         - cluster
       security:
         - Bearer: []
-  /1.3/provisioner/clusters/{cluster}:
+  /1.3/provisioner/clusters/{cluster_name}:
     parameters:
-      - name: cluster
+      - name: cluster_name
         in: path
         required: true
         type: string
@@ -1772,9 +1756,9 @@ paths:
         - cluster
       security:
         - Bearer: []
-  /1.4/provisioner/clusters/{cluster}:
+  /1.4/provisioner/clusters/{cluster_name}:
     parameters:
-      - name: cluster
+      - name: cluster_name
         in: path
         required: true
         type: string
@@ -1871,7 +1855,6 @@ paths:
       - name: BindData
         in: body
         schema:
-          type: object
           $ref: "#/definitions/VolumeBindData"
     post:
       operationId: VolumeBind
@@ -2931,6 +2914,24 @@ definitions:
         type: array
         items:
           type: string
+  TeamCreateArgs:
+    type: object
+    properties:
+      name:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+  TeamUpdateArgs:
+    type: object
+    properties:
+      newname:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
   TeamInfo:
     type: object
     properties:
@@ -3150,10 +3151,16 @@ definitions:
         type: string
       cacert:
         type: string
+        format: byte
+        x-go-custom-type: "[]byte"
       clientcert:
         type: string
+        format: byte
+        x-go-custom-type: "[]byte"
       clientkey:
         type: string
+        format: byte
+        x-go-custom-type: "[]byte"
       pools:
         type: array
         items:

--- a/iaas/template.go
+++ b/iaas/template.go
@@ -5,10 +5,10 @@
 package iaas
 
 import (
-	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/storage"
+	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/log"
 )
 
@@ -89,7 +89,7 @@ func (t *Template) Update(toMerge *Template) error {
 
 func (t *Template) Save() error {
 	if t.Name == "" {
-		return errors.New("template name cannot be empty")
+		return &errors.ValidationError{Message: "template name cannot be empty"}
 	}
 	_, err := getIaasProvider(t.IaaSName)
 	if err != nil {

--- a/provision/docker/handlers.go
+++ b/provision/docker/handlers.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ajg/form"
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/api"
 	"github.com/tsuru/tsuru/app"
@@ -55,21 +54,15 @@ func init() {
 //   401: Unauthorized
 //   404: Not found
 func moveContainerHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return &tsuruErrors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	params := map[string]string{}
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	err = dec.DecodeValues(&params, r.Form)
+	err = api.ParseInput(r, &params)
 	if err != nil {
-		return &tsuruErrors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
+		return err
 	}
 	contId := r.URL.Query().Get(":id")
 	to := params["to"]
 	if to == "" {
-		return errors.Errorf("Invalid params: id: %s - to: %s", contId, to)
+		return &tsuruErrors.ValidationError{Message: fmt.Sprintf("Invalid params: id: %q - to: %q", contId, to)}
 	}
 	cont, err := mainDockerProvisioner.GetContainer(contId)
 	if err != nil {
@@ -117,21 +110,15 @@ func moveContainerHandler(w http.ResponseWriter, r *http.Request, t auth.Token) 
 //   401: Unauthorized
 //   404: Not found
 func moveContainersHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return &tsuruErrors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 	params := map[string]string{}
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	err = dec.DecodeValues(&params, r.Form)
+	err = api.ParseInput(r, &params)
 	if err != nil {
-		return &tsuruErrors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
+		return err
 	}
 	from := params["from"]
 	to := params["to"]
 	if from == "" || to == "" {
-		return errors.Errorf("Invalid params: from: %s - to: %s", from, to)
+		return &tsuruErrors.ValidationError{Message: fmt.Sprintf("Invalid params: from: %q - to: %q", from, to)}
 	}
 	permContexts, err := moveContainersPermissionContexts(from, to)
 	if err != nil {
@@ -235,24 +222,12 @@ func logsConfigGetHandler(w http.ResponseWriter, r *http.Request, t auth.Token) 
 //   400: Invalid data
 //   401: Unauthorized
 func logsConfigSetHandler(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	err = r.ParseForm()
-	if err != nil {
-		return &tsuruErrors.HTTP{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("unable to parse form values: %s", err),
-		}
-	}
-	pool := r.FormValue("pool")
-	restart, _ := strconv.ParseBool(r.FormValue("restart"))
+	pool := api.InputValue(r, "pool")
+	restart, _ := strconv.ParseBool(api.InputValue(r, "restart"))
 	var conf container.DockerLogConfig
-	dec := form.NewDecoder(nil)
-	dec.IgnoreUnknownKeys(true)
-	err = dec.DecodeValues(&conf, r.Form)
+	err = api.ParseInput(r, &conf)
 	if err != nil {
-		return &tsuruErrors.HTTP{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("unable to parse fields in docker log config: %s", err),
-		}
+		return err
 	}
 	var ctxs []permTypes.PermissionContext
 	if pool != "" {

--- a/provision/docker/handlers_test.go
+++ b/provision/docker/handlers_test.go
@@ -145,6 +145,7 @@ func (s *HandlersSuite) TestMoveContainersEmptyBodyHandler(c *check.C) {
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	server := api.RunServer(true)
 	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*Invalid params.*`)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 }
 
@@ -160,8 +161,8 @@ func (s *HandlersSuite) TestMoveContainersEmptyToHandler(c *check.C) {
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	server := api.RunServer(true)
 	server.ServeHTTP(recorder, request)
-	c.Assert(recorder.Code, check.Equals, http.StatusInternalServerError)
-	c.Assert(recorder.Body.String(), check.Equals, "Invalid params: from: fromhost - to: \n")
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+	c.Assert(recorder.Body.String(), check.Equals, "Invalid params: from: \"fromhost\" - to: \"\"\n")
 }
 
 func (s *HandlersSuite) TestMoveContainersHandler(c *check.C) {


### PR DESCRIPTION
This middleware was a source of trouble since it was possible for
different encoding/decoding depending on the presence of `json` or
`form` struct tags. Now each handler parses body data directly to the
destination struct using helper functions which have different behaviors
depending on the content type.