### PR TITLE
Add documentation about Docker image deploy

### DIFF
--- a/docs/using/docker-image.rst
+++ b/docs/using/docker-image.rst
@@ -102,7 +102,7 @@ A simple web application in Go `main.go`:
     }
     
 .. note::
-    Make sure that the app listens on the port provided by the $PORT environment variable
+    The app should listen to $PORT or to the exposed port.
 
 
 Building the image
@@ -145,7 +145,6 @@ After pushing your image to your Docker image registry, you can do the deploy us
 
     This image should be in a registry and be accessible by the nodes.
     Image should also have a Entrypoint or a Procfile at given paths, / or /app/user/ or /home/application/current
-    The Image should not expose a Port! This is done automatically using the $PORT environment variable.
 
 
 Running the application

--- a/docs/using/docker-image.rst
+++ b/docs/using/docker-image.rst
@@ -61,6 +61,10 @@ A simple `Dockerfile`:
     ADD . /app/
     RUN go build .
     ENTRYPOINT ./app
+    
+.. note::
+    Notice that the Dockerfile does not make use of an EXPOSE clause.
+    This won't work, because the Tsuru API then configures a port mapping to the exposed port, but the port mapping should go to $PORT environment variable.
 
 A simple web application in Go `main.go`:
 
@@ -94,6 +98,9 @@ A simple web application in Go `main.go`:
     func hello(res http.ResponseWriter, req *http.Request) {
         fmt.Fprintln(res, "hello, world!")
     }
+    
+.. note::
+    Make sure that the app listens on the port provided by the $PORT environment variable
 
 
 Building the image
@@ -136,6 +143,7 @@ After pushing your image to your Docker image registry, you can do the deploy us
 
     This image should be in a registry and be accessible by the nodes.
     Image should also have a Entrypoint or a Procfile at given paths, / or /app/user/ or /home/application/current
+    The Image should not expose a Port! This is done automatically using the $PORT environment variable.
 
 
 Running the application

--- a/docs/using/docker-image.rst
+++ b/docs/using/docker-image.rst
@@ -63,8 +63,9 @@ A simple `Dockerfile`:
     ENTRYPOINT ./app
     
 .. note::
-    Notice that the Dockerfile does not make use of an EXPOSE clause.
-    This won't work, because the Tsuru API then configures a port mapping to the exposed port, but the port mapping should go to $PORT environment variable.
+    Notice that you do not have to EXPOSE a port in your Dockerfile.
+    When a EXPOSE clause is used, the port mapping goes to the exposed port.
+    If you do not expose a port, the port is mapped to the $PORT environment variable.
 
 A simple web application in Go `main.go`:
 

--- a/docs/using/docker-image.rst
+++ b/docs/using/docker-image.rst
@@ -65,6 +65,7 @@ A simple `Dockerfile`:
 .. note::
     Notice that you do not have to EXPOSE a port in your Dockerfile.
     When a EXPOSE clause is used, the port mapping goes to the exposed port.
+    Make sure to not expose more than one port. This will make the deployment fail.
     If you do not expose a port, the port is mapped to the $PORT environment variable.
 
 A simple web application in Go `main.go`:


### PR DESCRIPTION
This pull will add documentation details about the deploy process with plain Docker images.

Outline:
- do not expose a port in Docker image
- listen to $PORT env var