### PR TITLE
api: Allow (de)serialization of cluster client key as json

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -161,6 +161,9 @@ func listClusters(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 		}
 		return err
 	}
+	for i := range clusters {
+		clusters[i].ClientKey = nil
+	}
 	return json.NewEncoder(w).Encode(clusters)
 }
 

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -21,10 +22,15 @@ func (s *S) TestCreateCluster(c *check.C) {
 		Addresses:   []string{"addr1"},
 		Provisioner: "fake",
 		Default:     true,
+		ClientKey:   []byte("xyz"),
 	}
 	s.mockService.Cluster.OnFindByName = func(name string) (*provision.Cluster, error) {
 		c.Assert(name, check.Equals, kubeCluster.Name)
 		return nil, provision.ErrNoCluster
+	}
+	s.mockService.Cluster.OnCreate = func(cluster provision.Cluster) error {
+		c.Assert(cluster, check.DeepEquals, kubeCluster)
+		return nil
 	}
 	encoded, err := form.EncodeToString(kubeCluster)
 	c.Assert(err, check.IsNil)
@@ -78,6 +84,34 @@ func (s *S) TestCreateClusterWithNonExistentPool(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound, check.Commentf("body: %q", recorder.Body.String()))
+}
+
+func (s *S) TestCreateClusterJSON(c *check.C) {
+	kubeCluster := provision.Cluster{
+		Name:        "c1",
+		Addresses:   []string{"addr1"},
+		Provisioner: "fake",
+		Default:     true,
+		ClientKey:   []byte("xyz"),
+	}
+	s.mockService.Cluster.OnFindByName = func(name string) (*provision.Cluster, error) {
+		c.Assert(name, check.Equals, kubeCluster.Name)
+		return nil, provision.ErrNoCluster
+	}
+	s.mockService.Cluster.OnCreate = func(cluster provision.Cluster) error {
+		c.Assert(cluster, check.DeepEquals, kubeCluster)
+		return nil
+	}
+	encoded, err := json.Marshal(kubeCluster)
+	c.Assert(err, check.IsNil)
+	body := bytes.NewReader(encoded)
+	request, err := http.NewRequest(http.MethodPost, "/1.3/provisioner/clusters", body)
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK, check.Commentf("body: %q", recorder.Body.String()))
 }
 
 func (s *S) TestUpdateCluster(c *check.C) {

--- a/types/provision/cluster.go
+++ b/types/provision/cluster.go
@@ -13,7 +13,7 @@ type Cluster struct {
 	Provisioner string            `json:"provisioner"`
 	CaCert      []byte            `json:"cacert"`
 	ClientCert  []byte            `json:"clientcert"`
-	ClientKey   []byte            `json:"-"`
+	ClientKey   []byte            `json:"clientkey"`
 	Pools       []string          `json:"pools"`
 	CustomData  map[string]string `json:"custom_data"`
 	CreateData  map[string]string `json:"create_data"`


### PR DESCRIPTION
This ensures that we can set the cluster's clientkey while removing it in the list response.