### PR TITLE
Add support to multiple ports on Kubernetes

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -134,9 +134,7 @@ func (p *Pipeline) Result() Result {
 // After rolling back all completed actions, it returns the original error
 // returned by the action that failed.
 func (p *Pipeline) Execute(params ...interface{}) (err error) {
-	var (
-		r Result
-	)
+	var r Result
 	if len(p.actions) == 0 {
 		return ErrPipelineNoActions
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -2519,10 +2519,10 @@ func (app *App) GetHealthcheckData() (router.HealthcheckData, error) {
 		return router.HealthcheckData{}, err
 	}
 	yamlData, err := image.GetImageTsuruYamlData(imageName)
-	if err != nil {
+	if err != nil || yamlData.Healthcheck == nil {
 		return router.HealthcheckData{}, err
 	}
-	return yamlData.Healthcheck.ToRouterHC(), nil
+	return yamlData.ToRouterHC(), nil
 }
 
 func validateEnv(envName string) error {

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -319,7 +319,7 @@ func deployToProvisioner(opts *DeployOptions, evt *event.Event) (string, error) 
 	if opts.Kind == "" {
 		opts.GetKind()
 	}
-	if (opts.App.GetPlatform() == "") && ((opts.Kind != DeployImage) && (opts.Kind != DeployRollback)) {
+	if opts.App.GetPlatform() == "" && opts.Kind != DeployImage && opts.Kind != DeployRollback {
 		return "", errors.Errorf("can't deploy app without platform, if it's not an image or rollback")
 	}
 

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -64,7 +64,7 @@ func (i *ImageMetadata) Save() error {
 	if i.Name == "" {
 		return errors.New("image name is mandatory")
 	}
-	coll, err := imageCustomDataColl()
+	coll, err := ImageCustomDataColl()
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func SaveImageCustomData(imageName string, customData map[string]interface{}) er
 }
 
 func GetImageMetaData(imageName string) (ImageMetadata, error) {
-	coll, err := imageCustomDataColl()
+	coll, err := ImageCustomDataColl()
 	if err != nil {
 		return ImageMetadata{}, err
 	}
@@ -204,7 +204,7 @@ func GetImageTsuruYamlData(imageName string) (provision.TsuruYamlData, error) {
 	var customData struct {
 		Customdata provision.TsuruYamlData
 	}
-	coll, err := imageCustomDataColl()
+	coll, err := ImageCustomDataColl()
 	if err != nil {
 		return customData.Customdata, err
 	}
@@ -364,7 +364,7 @@ func ImageHistorySize() int {
 }
 
 func DeleteAllAppImageNames(appName string) error {
-	dataColl, err := imageCustomDataColl()
+	dataColl, err := ImageCustomDataColl()
 	if err != nil {
 		return err
 	}
@@ -397,7 +397,7 @@ func DeleteAllAppImageNames(appName string) error {
 }
 
 func UpdateAppImageRollback(img, reason string, disableRollback bool) error {
-	dataColl, err := imageCustomDataColl()
+	dataColl, err := ImageCustomDataColl()
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func UpdateAppImageRollback(img, reason string, disableRollback bool) error {
 }
 
 func PullAppImageNames(appName string, images []string) error {
-	dataColl, err := imageCustomDataColl()
+	dataColl, err := ImageCustomDataColl()
 	if err != nil {
 		return err
 	}
@@ -596,7 +596,8 @@ func appBuilderImagesColl() (*storage.Collection, error) {
 	}
 	return conn.Collection("builder_app_image"), nil
 }
-func imageCustomDataColl() (*storage.Collection, error) {
+
+func ImageCustomDataColl() (*storage.Collection, error) {
 	conn, err := db.Conn()
 	if err != nil {
 		return nil, err

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -50,6 +50,7 @@ type ImageMetadata struct {
 	LegacyProcesses map[string]string   `bson:"processes"`
 	Processes       map[string][]string `bson:"processes_list"`
 	ExposedPort     string
+	ExposedPorts    []string
 	DisableRollback bool
 	Reason          string
 }

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -49,7 +49,6 @@ type ImageMetadata struct {
 	CustomData      map[string]interface{}
 	LegacyProcesses map[string]string   `bson:"processes"`
 	Processes       map[string][]string `bson:"processes_list"`
-	ExposedPort     string
 	ExposedPorts    []string
 	DisableRollback bool
 	Reason          string

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -50,10 +50,10 @@ type tsuruYamlKubernetesGroup struct {
 
 type tsuruYamlKubernetesProcess struct {
 	Name  string
-	Ports []tsuruYamlKubernetesPodPortConfig `bson:",omitempty"`
+	Ports []tsuruYamlKubernetesProcessPortConfig `bson:",omitempty"`
 }
 
-type tsuruYamlKubernetesPodPortConfig struct {
+type tsuruYamlKubernetesProcessPortConfig struct {
 	Name       string `json:"name,omitempty" bson:"name,omitempty"`
 	Protocol   string `json:"protocol,omitempty" bson:"protocol,omitempty"`
 	Port       int    `json:"port,omitempty" bson:"port,omitempty"`
@@ -304,7 +304,7 @@ func marshalCustomData(data map[string]interface{}) (map[string]interface{}, err
 		for procName, procData := range groupData {
 			proc := tsuruYamlKubernetesProcess{Name: procName}
 			for _, port := range procData.Ports {
-				proc.Ports = append(proc.Ports, tsuruYamlKubernetesPodPortConfig(port))
+				proc.Ports = append(proc.Ports, tsuruYamlKubernetesProcessPortConfig(port))
 			}
 			group.Processes = append(group.Processes, proc)
 		}
@@ -371,11 +371,11 @@ func unmarshalYamlData(data map[string]interface{}) (provision.TsuruYamlData, er
 	for _, g := range customData.Kubernetes.Groups {
 		group := provision.TsuruYamlKubernetesGroup{}
 		for _, proc := range g.Processes {
-			group[proc.Name] = provision.TsuruYamlKubernetesPodConfig{
-				Ports: make([]provision.TsuruYamlKubernetesPodPortConfig, len(proc.Ports)),
+			group[proc.Name] = provision.TsuruYamlKubernetesProcessConfig{
+				Ports: make([]provision.TsuruYamlKubernetesProcessPortConfig, len(proc.Ports)),
 			}
 			for i, port := range proc.Ports {
-				group[proc.Name].Ports[i] = provision.TsuruYamlKubernetesPodPortConfig(port)
+				group[proc.Name].Ports[i] = provision.TsuruYamlKubernetesProcessPortConfig(port)
 			}
 		}
 		if result.Kubernetes.Groups == nil {

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -353,22 +353,22 @@ func unmarshalYamlData(data map[string]interface{}) (provision.TsuruYamlData, er
 	if err != nil {
 		return provision.TsuruYamlData{}, err
 	}
-	customData := customData{}
-	err = json.Unmarshal(b, &customData)
+	custom := customData{}
+	err = json.Unmarshal(b, &custom)
 	if err != nil {
 		return provision.TsuruYamlData{}, err
 	}
 
 	result := provision.TsuruYamlData{
-		Hooks:       customData.Hooks,
-		Healthcheck: customData.Healthcheck,
+		Hooks:       custom.Hooks,
+		Healthcheck: custom.Healthcheck,
 	}
-	if customData.Kubernetes == nil {
+	if custom.Kubernetes == nil {
 		return result, nil
 	}
 
 	result.Kubernetes = &provision.TsuruYamlKubernetesConfig{}
-	for _, g := range customData.Kubernetes.Groups {
+	for _, g := range custom.Kubernetes.Groups {
 		group := provision.TsuruYamlKubernetesGroup{}
 		for _, proc := range g.Processes {
 			group[proc.Name] = provision.TsuruYamlKubernetesProcessConfig{

--- a/app/image/image.go
+++ b/app/image/image.go
@@ -134,9 +134,6 @@ func customDataToImageMetadata(imageName string, customData map[string]interface
 		Processes:  processes,
 		CustomData: customData,
 	}
-	if exposedPort, ok := customData["exposedPort"]; ok {
-		data.ExposedPort = exposedPort.(string)
-	}
 	return &data, nil
 }
 

--- a/app/image/image_test.go
+++ b/app/image/image_test.go
@@ -562,14 +562,14 @@ func (s *S) TestTsuruYamlConversion(c *check.C) {
 		},
 		Kubernetes: &provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
-				"pod1": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"pod1": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc1": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Port: 8888},
 						},
 					},
 					"proc2": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Port: 8889},
 							{TargetPort: 5000},
 						},

--- a/app/image/image_test.go
+++ b/app/image/image_test.go
@@ -271,22 +271,9 @@ func (s *S) TestGetImageWebProcessName(c *check.C) {
 	c.Check(web5, check.Equals, "")
 }
 
-func (s *S) TestSavePortInImageCustomData(c *check.C) {
-	img1 := "tsuru/app-myapp:v1"
-	customData1 := map[string]interface{}{
-		"exposedPort": "3434",
-	}
-	err := SaveImageCustomData(img1, customData1)
-	c.Assert(err, check.IsNil)
-	imageMetaData, err := GetImageMetaData(img1)
-	c.Check(err, check.IsNil)
-	c.Check(imageMetaData.ExposedPort, check.Equals, "3434")
-}
-
 func (s *S) TestSaveImageCustomData(c *check.C) {
 	img1 := "tsuru/app-myapp:v1"
 	customData1 := map[string]interface{}{
-		"exposedPort": "3434",
 		"processes": map[string]interface{}{
 			"worker1": "python myapp.py",
 			"worker2": "someworker",
@@ -296,7 +283,6 @@ func (s *S) TestSaveImageCustomData(c *check.C) {
 	c.Assert(err, check.IsNil)
 	imageMetaData, err := GetImageMetaData(img1)
 	c.Check(err, check.IsNil)
-	c.Check(imageMetaData.ExposedPort, check.Equals, "3434")
 	c.Check(imageMetaData.Processes, check.DeepEquals, map[string][]string{
 		"worker1": {"python myapp.py"},
 		"worker2": {"someworker"},
@@ -306,14 +292,12 @@ func (s *S) TestSaveImageCustomData(c *check.C) {
 func (s *S) TestSaveImageCustomDataProcfile(c *check.C) {
 	img1 := "tsuru/app-myapp:v1"
 	customData1 := map[string]interface{}{
-		"exposedPort": "3434",
-		"procfile":    "worker1: python myapp.py\nworker2: someworker",
+		"procfile": "worker1: python myapp.py\nworker2: someworker",
 	}
 	err := SaveImageCustomData(img1, customData1)
 	c.Assert(err, check.IsNil)
 	imageMetaData, err := GetImageMetaData(img1)
 	c.Check(err, check.IsNil)
-	c.Check(imageMetaData.ExposedPort, check.Equals, "3434")
 	c.Check(imageMetaData.Processes, check.DeepEquals, map[string][]string{
 		"worker1": {"python myapp.py"},
 		"worker2": {"someworker"},
@@ -323,7 +307,6 @@ func (s *S) TestSaveImageCustomDataProcfile(c *check.C) {
 func (s *S) TestSaveImageCustomDataProcessList(c *check.C) {
 	img1 := "tsuru/app-myapp:v1"
 	customData1 := map[string]interface{}{
-		"exposedPort": "3434",
 		"processes": map[string]interface{}{
 			"worker1": "python myapp.py",
 			"worker2": []string{"worker", "arg", "arg2"},
@@ -333,7 +316,6 @@ func (s *S) TestSaveImageCustomDataProcessList(c *check.C) {
 	c.Assert(err, check.IsNil)
 	imageMetaData, err := GetImageMetaData(img1)
 	c.Check(err, check.IsNil)
-	c.Check(imageMetaData.ExposedPort, check.Equals, "3434")
 	c.Check(imageMetaData.Processes, check.DeepEquals, map[string][]string{
 		"worker1": {"python myapp.py"},
 		"worker2": {"worker", "arg", "arg2"},

--- a/app/image/migrate/migrate.go
+++ b/app/image/migrate/migrate.go
@@ -1,0 +1,34 @@
+// Copyright 2019 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package migrate
+
+import (
+	"github.com/globalsign/mgo/bson"
+	"github.com/tsuru/tsuru/app/image"
+)
+
+func MigrateExposedPorts() error {
+	coll, err := image.ImageCustomDataColl()
+	if err != nil {
+		return err
+	}
+	defer coll.Close()
+
+	var img struct {
+		Name         string `bson:"_id"`
+		ExposedPort  string
+		ExposedPorts []string
+	}
+	iter := coll.Find(nil).Iter()
+	for iter.Next(&img) {
+		if len(img.ExposedPorts) == 0 && len(img.ExposedPort) != 0 {
+			err = coll.UpdateId(img.Name, bson.M{"$set": bson.M{"exposedports": []string{img.ExposedPort}}})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/app/image/migrate/migrate_test.go
+++ b/app/image/migrate/migrate_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/app/image"
+	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/db/storage"
+	check "gopkg.in/check.v1"
+)
+
+type S struct {
+	coll *storage.Collection
+}
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (s *S) SetUpSuite(c *check.C) {
+	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
+	config.Set("database:name", "tsuru_app_image_migrate_test")
+	var err error
+	s.coll, err = image.ImageCustomDataColl()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TearDownSuite(c *check.C) {
+	s.coll.Database.DropDatabase()
+	s.coll.Close()
+}
+
+func (s *S) SetUpTest(c *check.C) {
+	dbtest.ClearAllCollections(s.coll.Database)
+}
+
+var _ = check.Suite(&S{})
+
+func (s *S) TestMigrateExposedPorts(c *check.C) {
+	err := s.coll.Insert(bson.M{"_id": "1-exposed-port", "exposedport": "8000/tcp"})
+	c.Assert(err, check.IsNil)
+	err = s.coll.Insert(bson.M{"_id": "2-exposed-port-and-ports", "exposedport": "8001/tcp", "exposedports": []string{"8002/tcp", "8003/tcp"}})
+	c.Assert(err, check.IsNil)
+	err = s.coll.Insert(bson.M{"_id": "3-exposed-ports", "exposedport": "", "exposedports": []string{"8004/tcp"}})
+	c.Assert(err, check.IsNil)
+	err = s.coll.Insert(bson.M{"_id": "4-no-port"})
+	c.Assert(err, check.IsNil)
+
+	err = MigrateExposedPorts()
+	c.Assert(err, check.IsNil)
+
+	var results []map[string]interface{}
+	err = s.coll.Find(nil).All(&results)
+	c.Assert(err, check.IsNil)
+	c.Assert(results, check.DeepEquals, []map[string]interface{}{
+		{"_id": "1-exposed-port", "exposedport": "8000/tcp", "exposedports": []interface{}{"8000/tcp"}},
+		{"_id": "2-exposed-port-and-ports", "exposedport": "8001/tcp", "exposedports": []interface{}{"8002/tcp", "8003/tcp"}},
+		{"_id": "3-exposed-ports", "exposedport": "", "exposedports": []interface{}{"8004/tcp"}},
+		{"_id": "4-no-port"},
+	})
+}

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -221,7 +221,7 @@ func tsuruYamlToCustomData(yaml *provision.TsuruYamlData) map[string]interface{}
 }
 
 func runBuildHooks(client provision.BuilderDockerClient, app provision.App, imageID string, evt *event.Event, tsuruYamlData *provision.TsuruYamlData) (string, error) {
-	if tsuruYamlData == nil || len(tsuruYamlData.Hooks.Build) == 0 {
+	if tsuruYamlData == nil || tsuruYamlData.Hooks == nil || len(tsuruYamlData.Hooks.Build) == 0 {
 		return "", nil
 	}
 	cmd := strings.Join(tsuruYamlData.Hooks.Build, " && ")

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -146,12 +146,15 @@ func imageBuild(client provision.BuilderDockerClient, app provision.App, opts *b
 		return "", err
 	}
 	imageData := image.ImageMetadata{
-		Name:       newImage,
-		Processes:  procfile,
-		CustomData: tsuruYamlToCustomData(yaml),
+		Name:         newImage,
+		Processes:    procfile,
+		CustomData:   tsuruYamlToCustomData(yaml),
+		ExposedPorts: make([]string, len(imageInspect.Config.ExposedPorts)),
 	}
+	i := 0
 	for k := range imageInspect.Config.ExposedPorts {
-		imageData.ExposedPort = string(k)
+		imageData.ExposedPorts[i] = string(k)
+		i++
 	}
 	err = imageData.Save()
 	if err != nil {

--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -280,7 +280,7 @@ func (s *S) TestBuilderImageIDWithExposedPort(c *check.C) {
 	c.Assert(imgID, check.Equals, u.Host+"/tsuru/app-myapp:v1")
 	imd, err := image.GetImageMetaData(imgID)
 	c.Assert(err, check.IsNil)
-	c.Assert(imd.ExposedPort, check.DeepEquals, "80/tcp")
+	c.Assert(imd.ExposedPorts, check.DeepEquals, []string{"80/tcp"})
 }
 
 func (s *S) TestBuilderImageIDWithProcfile(c *check.C) {

--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -475,7 +475,6 @@ hooks:
 				"after":  []interface{}{"./after.sh"},
 			},
 		},
-		"kubernetes": map[string]interface{}{},
 	})
 }
 

--- a/builder/docker/builder_test.go
+++ b/builder/docker/builder_test.go
@@ -465,7 +465,7 @@ hooks:
 		"healthcheck": map[string]interface{}{
 			"path":   "/status",
 			"method": "GET",
-			"status": 200,
+			"status": float64(200),
 			"scheme": "https",
 		},
 		"hooks": map[string]interface{}{
@@ -475,6 +475,7 @@ hooks:
 				"after":  []interface{}{"./after.sh"},
 			},
 		},
+		"kubernetes": map[string]interface{}{},
 	})
 }
 

--- a/builder/kubernetes/builder.go
+++ b/builder/kubernetes/builder.go
@@ -70,9 +70,6 @@ func imageBuild(client provision.BuilderKubeClient, a provision.App, imageID str
 	if err != nil {
 		return "", err
 	}
-	if len(imageInspect.Config.ExposedPorts) > 1 {
-		return "", errors.Errorf("too many ports exposed in Dockerfile, only one allowed: %+v", imageInspect.Config.ExposedPorts)
-	}
 	procfile := image.GetProcessesFromProcfile(procfileRaw)
 	if len(procfile) == 0 {
 		fmt.Fprintln(evt, " ---> Procfile not found, using entrypoint and cmd")
@@ -90,8 +87,11 @@ func imageBuild(client provision.BuilderKubeClient, a provision.App, imageID str
 		Processes:  procfile,
 		CustomData: tsuruYamlToCustomData(tsuruYaml),
 	}
+	imageData.ExposedPorts = make([]string, len(imageInspect.Config.ExposedPorts))
+	i := 0
 	for k := range imageInspect.Config.ExposedPorts {
-		imageData.ExposedPort = string(k)
+		imageData.ExposedPorts[i] = string(k)
+		i++
 	}
 	err = imageData.Save()
 	if err != nil {

--- a/builder/kubernetes/builder.go
+++ b/builder/kubernetes/builder.go
@@ -104,10 +104,17 @@ func tsuruYamlToCustomData(yaml *provision.TsuruYamlData) map[string]interface{}
 	if yaml == nil {
 		return nil
 	}
-	return map[string]interface{}{
-		"healthcheck": yaml.Healthcheck,
-		"hooks":       yaml.Hooks,
+	customData := map[string]interface{}{}
+	if yaml.Healthcheck.Path != "" {
+		customData["healthcheck"] = yaml.Healthcheck
 	}
+	if len(yaml.Hooks.Build) != 0 || len(yaml.Hooks.Restart.Before) != 0 || len(yaml.Hooks.Restart.After) != 0 {
+		customData["hooks"] = yaml.Hooks
+	}
+	if len(yaml.Kubernetes.Groups) != 0 {
+		customData["kubernetes"] = yaml.Kubernetes
+	}
+	return customData
 }
 
 func downloadFromContainer(client provision.BuilderKubeClient, app provision.App, evt *event.Event) (io.ReadCloser, error) {

--- a/builder/kubernetes/builder.go
+++ b/builder/kubernetes/builder.go
@@ -104,17 +104,11 @@ func tsuruYamlToCustomData(yaml *provision.TsuruYamlData) map[string]interface{}
 	if yaml == nil {
 		return nil
 	}
-	customData := map[string]interface{}{}
-	if yaml.Healthcheck.Path != "" {
-		customData["healthcheck"] = yaml.Healthcheck
+	return map[string]interface{}{
+		"healthcheck": yaml.Healthcheck,
+		"hooks":       yaml.Hooks,
+		"kubernetes":  yaml.Kubernetes,
 	}
-	if len(yaml.Hooks.Build) != 0 || len(yaml.Hooks.Restart.Before) != 0 || len(yaml.Hooks.Restart.After) != 0 {
-		customData["hooks"] = yaml.Hooks
-	}
-	if len(yaml.Kubernetes.Groups) != 0 {
-		customData["kubernetes"] = yaml.Kubernetes
-	}
-	return customData
 }
 
 func downloadFromContainer(client provision.BuilderKubeClient, app provision.App, evt *event.Event) (io.ReadCloser, error) {

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -298,6 +298,12 @@ func (s *S) TestImageIDWithTsuruYamlNoHealthcheck(c *check.C) {
 	imd, err := image.GetImageMetaData(img)
 	c.Assert(err, check.IsNil)
 	c.Assert(imd.CustomData, check.DeepEquals, map[string]interface{}{
+		"healthcheck": map[string]interface{}{
+			"method": "",
+			"status": 0,
+			"scheme": "",
+			"path":   "",
+		},
 		"hooks": map[string]interface{}{
 			"build": []interface{}{"./build1", "./build2"},
 			"restart": map[string]interface{}{
@@ -305,6 +311,7 @@ func (s *S) TestImageIDWithTsuruYamlNoHealthcheck(c *check.C) {
 				"after":  []interface{}{"./after.sh"},
 			},
 		},
+		"kubernetes": map[string]interface{}{},
 	})
 }
 

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -232,7 +232,7 @@ func (s *S) TestImageIDWithTsuruYaml(c *check.C) {
 		"healthcheck": map[string]interface{}{
 			"path":   "/status",
 			"method": "GET",
-			"status": 200,
+			"status": float64(200),
 			"scheme": "https",
 		},
 		"hooks": map[string]interface{}{
@@ -249,11 +249,11 @@ func (s *S) TestImageIDWithTsuruYaml(c *check.C) {
 						"ports": []interface{}{
 							map[string]interface{}{
 								"name":        "main-port",
-								"target_port": 8000,
+								"target_port": float64(8000),
 							},
 							map[string]interface{}{
-								"port":        8080,
-								"target_port": 8001,
+								"port":        float64(8080),
+								"target_port": float64(8001),
 							},
 						},
 					},
@@ -299,10 +299,10 @@ func (s *S) TestImageIDWithTsuruYamlNoHealthcheck(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(imd.CustomData, check.DeepEquals, map[string]interface{}{
 		"healthcheck": map[string]interface{}{
-			"method": "",
-			"status": 0,
-			"scheme": "",
 			"path":   "",
+			"method": "",
+			"status": float64(0),
+			"scheme": "",
 		},
 		"hooks": map[string]interface{}{
 			"build": []interface{}{"./build1", "./build2"},

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -298,12 +298,6 @@ func (s *S) TestImageIDWithTsuruYamlNoHealthcheck(c *check.C) {
 	imd, err := image.GetImageMetaData(img)
 	c.Assert(err, check.IsNil)
 	c.Assert(imd.CustomData, check.DeepEquals, map[string]interface{}{
-		"healthcheck": map[string]interface{}{
-			"path":   "",
-			"method": "",
-			"status": float64(0),
-			"scheme": "",
-		},
 		"hooks": map[string]interface{}{
 			"build": []interface{}{"./build1", "./build2"},
 			"restart": map[string]interface{}{
@@ -311,7 +305,6 @@ func (s *S) TestImageIDWithTsuruYamlNoHealthcheck(c *check.C) {
 				"after":  []interface{}{"./after.sh"},
 			},
 		},
-		"kubernetes": map[string]interface{}{},
 	})
 }
 

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 
 	"github.com/tsuru/tsuru/app/image"
@@ -135,6 +136,7 @@ func (s *S) TestImageIDWithExposedPorts(c *check.C) {
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	imd, err := image.GetImageMetaData(img)
 	c.Assert(err, check.IsNil)
+	sort.Strings(imd.ExposedPorts)
 	c.Assert(imd.ExposedPorts, check.DeepEquals, []string{"8000/tcp", "8001/tcp"})
 }
 

--- a/cmd/tsurud/migrate.go
+++ b/cmd/tsurud/migrate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsuru/gnuflag"
 	"github.com/tsuru/tablecli"
 	"github.com/tsuru/tsuru/app"
+	appImageMigrate "github.com/tsuru/tsuru/app/image/migrate"
 	appMigrate "github.com/tsuru/tsuru/app/migrate"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/cmd"
@@ -96,6 +97,10 @@ func init() {
 		log.Fatalf("unable to register migration: %s", err)
 	}
 	err = migration.Register("migrate-apps-kubernetes-crd", kubeMigrate.MigrateAppsCRDs)
+	if err != nil {
+		log.Fatalf("unable to register migration: %s", err)
+	}
+	err = migration.Register("migrate-app-image-exposed-ports", appImageMigrate.MigrateExposedPorts)
 	if err != nil {
 		log.Fatalf("unable to register migration: %s", err)
 	}

--- a/provision/docker/actions.go
+++ b/provision/docker/actions.go
@@ -547,7 +547,7 @@ var setRouterHealthcheck = action.Action{
 		if writer == nil {
 			writer = ioutil.Discard
 		}
-		newHCData := yamlData.Healthcheck.ToRouterHC()
+		newHCData := yamlData.ToRouterHC()
 		msg := fmt.Sprintf("Path: %s", newHCData.Path)
 		if newHCData.Status != 0 {
 			msg = fmt.Sprintf("%s, Status: %d", msg, newHCData.Status)
@@ -576,7 +576,7 @@ var setRouterHealthcheck = action.Action{
 			if err != nil {
 				return err
 			}
-			return hcRouter.SetHealthcheck(args.app.GetName(), yamlData.Healthcheck.ToRouterHC())
+			return hcRouter.SetHealthcheck(args.app.GetName(), yamlData.ToRouterHC())
 		})
 		return newContainers, err
 	},
@@ -587,7 +587,7 @@ var setRouterHealthcheck = action.Action{
 		if err != nil {
 			log.Errorf("[set-router-healthcheck:Backward] Error getting yaml data: %s", err)
 		}
-		hcData := yamlData.Healthcheck.ToRouterHC()
+		hcData := yamlData.ToRouterHC()
 		err = runInRouters(args.app, func(r router.Router) error {
 			hcRouter, ok := r.(router.CustomHealthcheckRouter)
 			if !ok {

--- a/provision/docker/containers.go
+++ b/provision/docker/containers.go
@@ -94,6 +94,10 @@ func (p *dockerProvisioner) runReplaceUnitsPipeline(w io.Writer, a provision.App
 	if err != nil {
 		return nil, err
 	}
+	exposedPort := ""
+	if len(imageData.ExposedPorts) > 0 {
+		exposedPort = imageData.ExposedPorts[0]
+	}
 	evt, _ := w.(*event.Event)
 	args := changeUnitsPipelineArgs{
 		app:         a,
@@ -104,7 +108,7 @@ func (p *dockerProvisioner) runReplaceUnitsPipeline(w io.Writer, a provision.App
 		imageID:     imageID,
 		provisioner: p,
 		event:       evt,
-		exposedPort: imageData.ExposedPort,
+		exposedPort: exposedPort,
 	}
 	var pipeline *action.Pipeline
 	if p.isDryMode {

--- a/provision/docker/healthcheck.go
+++ b/provision/docker/healthcheck.go
@@ -27,6 +27,9 @@ func runHealthcheck(cont *container.Container, w io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if yamlData.Healthcheck == nil {
+		return nil
+	}
 	path := yamlData.Healthcheck.Path
 	method := yamlData.Healthcheck.Method
 	match := yamlData.Healthcheck.Match

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -508,6 +508,9 @@ func (p *dockerProvisioner) runRestartAfterHooks(cont *container.Container, w io
 	if err != nil {
 		return err
 	}
+	if yamlData.Hooks == nil {
+		return nil
+	}
 	cmds := yamlData.Hooks.Restart.After
 	for _, cmd := range cmds {
 		err := cont.Exec(p.ClusterClient(), nil, w, w, container.Pty{}, "/bin/sh", "-lc", cmd)

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -424,7 +424,11 @@ func (p *dockerProvisioner) deploy(a provision.App, imageID string, evt *event.E
 		if err = setQuota(a, toAdd); err != nil {
 			return err
 		}
-		_, err = p.runCreateUnitsPipeline(evt, a, toAdd, imageID, imageData.ExposedPort)
+		exposedPort := ""
+		if len(imageData.ExposedPorts) > 0 {
+			exposedPort = imageData.ExposedPorts[0]
+		}
+		_, err = p.runCreateUnitsPipeline(evt, a, toAdd, imageID, exposedPort)
 	} else {
 		toAdd := getContainersToAdd(imageData, containers)
 		if err = setQuota(a, toAdd); err != nil {
@@ -599,7 +603,11 @@ func (p *dockerProvisioner) AddUnits(a provision.App, units uint, process string
 	if err != nil {
 		return err
 	}
-	_, err = p.runCreateUnitsPipeline(w, a, map[string]*containersToAdd{process: {Quantity: int(units)}}, imageID, imageData.ExposedPort)
+	exposedPort := ""
+	if len(imageData.ExposedPorts) > 0 {
+		exposedPort = imageData.ExposedPorts[0]
+	}
+	_, err = p.runCreateUnitsPipeline(w, a, map[string]*containersToAdd{process: {Quantity: int(units)}}, imageID, exposedPort)
 	return err
 }
 

--- a/provision/dockercommon/commands.go
+++ b/provision/dockercommon/commands.go
@@ -108,7 +108,9 @@ func LeanContainerCmdsWithExtra(processName, imageID string, app provision.App, 
 	if err != nil {
 		return nil, "", err
 	}
-	extraCmds = append(extraCmds, yamlData.Hooks.Restart.Before...)
+	if yamlData.Hooks != nil {
+		extraCmds = append(extraCmds, yamlData.Hooks.Restart.Before...)
+	}
 	before := strings.Join(extraCmds, " && ")
 	if before != "" {
 		before += " && "

--- a/provision/env.go
+++ b/provision/env.go
@@ -34,11 +34,15 @@ func EnvsForApp(a App, process string, isDeploy bool) []bind.EnvVar {
 	host, _ := config.GetString("host")
 	envs = append(envs, bind.EnvVar{Name: "TSURU_HOST", Value: host})
 	if !isDeploy {
-		port := WebProcessDefaultPort()
-		envs = append(envs, []bind.EnvVar{
-			{Name: "port", Value: port},
-			{Name: "PORT", Value: port},
-		}...)
+		envs = append(envs, DefaultWebPortEnvs()...)
 	}
 	return envs
+}
+
+func DefaultWebPortEnvs() []bind.EnvVar {
+	port := WebProcessDefaultPort()
+	return []bind.EnvVar{
+		{Name: "port", Value: port},
+		{Name: "PORT", Value: port},
+	}
 }

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1101,11 +1101,11 @@ func loadServicePorts(imgName, processName string) ([]apiv1.ServicePort, error) 
 		}
 	}
 	if len(svcPorts) == 0 {
-		defaultPort, _ := strconv.Atoi(provision.WebProcessDefaultPort())
+		defaultWebPort, _ := strconv.Atoi(provision.WebProcessDefaultPort())
 		svcPorts = append(svcPorts, apiv1.ServicePort{
-			Protocol:   "TCP",
-			Port:       int32(defaultPort),
-			TargetPort: intstr.FromInt(defaultPort),
+			Protocol:   apiv1.ProtocolTCP,
+			Port:       int32(defaultWebPort),
+			TargetPort: intstr.FromInt(defaultWebPort),
 			Name:       defaultHttpPortName,
 		})
 	}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1149,14 +1149,20 @@ func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlDa
 		return ports, nil
 	}
 
-	defaultPort, _ := strconv.Atoi(provision.WebProcessDefaultPort())
+	defaultPort := defaultKubernetesPodPortConfig()
+	defaultPort.TargetPort = getTargetPortForImage(imgName)
 	return []provision.TsuruYamlKubernetesPodPortConfig{
-		{
-			Protocol:   "TCP",
-			Port:       defaultPort,
-			TargetPort: getTargetPortForImage(imgName),
-		},
+		defaultPort,
 	}, nil
+}
+
+func defaultKubernetesPodPortConfig() provision.TsuruYamlKubernetesPodPortConfig {
+	defaultPort, _ := strconv.Atoi(provision.WebProcessDefaultPort())
+	return provision.TsuruYamlKubernetesPodPortConfig{
+		Protocol:   "TCP",
+		Port:       defaultPort,
+		TargetPort: defaultPort,
+	}
 }
 
 func imageTagAndPush(client *ClusterClient, a provision.App, oldImage, newImage string) (InspectData, error) {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1132,20 +1132,20 @@ func getTargetPortForImage(imgName string) int {
 }
 
 func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlData, process string) ([]provision.TsuruYamlKubernetesPodPortConfig, error) {
-	processNames := make(map[string]bool)
+	portConfigFound := false
 	var ports []provision.TsuruYamlKubernetesPodPortConfig
 	for _, group := range tsuruYamlData.Kubernetes.Groups {
 		for podName, podConfig := range group {
 			if podName == process {
-				if processNames[podName] {
+				if portConfigFound {
 					return nil, fmt.Errorf("duplicated process name: %s", podName)
 				}
-				processNames[podName] = true
+				portConfigFound = true
 				ports = podConfig.Ports
 			}
 		}
 	}
-	if ports != nil {
+	if portConfigFound {
 		return ports, nil
 	}
 

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1124,9 +1124,6 @@ func getTargetPortsForImage(imgName string) []string {
 	if len(imageData.ExposedPorts) > 0 {
 		return imageData.ExposedPorts
 	}
-	if imageData.ExposedPort != "" {
-		return []string{imageData.ExposedPort}
-	}
 	return []string{provision.WebProcessDefaultPort() + "/tcp"}
 }
 

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1145,9 +1145,9 @@ func extractPortNumberAndProtocol(port string) (int, string, error) {
 	return portInt, parts[1], err
 }
 
-func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlData, process string) ([]provision.TsuruYamlKubernetesPodPortConfig, error) {
+func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlData, process string) ([]provision.TsuruYamlKubernetesProcessPortConfig, error) {
 	portConfigFound := false
-	var ports []provision.TsuruYamlKubernetesPodPortConfig
+	var ports []provision.TsuruYamlKubernetesProcessPortConfig
 	if tsuruYamlData.Kubernetes != nil {
 		for _, group := range tsuruYamlData.Kubernetes.Groups {
 			for podName, podConfig := range group {
@@ -1170,7 +1170,7 @@ func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlDa
 
 	defaultPort := defaultKubernetesPodPortConfig()
 	targetPorts := getTargetPortsForImage(imgName)
-	ports = make([]provision.TsuruYamlKubernetesPodPortConfig, len(targetPorts))
+	ports = make([]provision.TsuruYamlKubernetesProcessPortConfig, len(targetPorts))
 	for i := range ports {
 		portInt, protocol, err := extractPortNumberAndProtocol(targetPorts[i])
 		if err != nil {
@@ -1191,9 +1191,9 @@ func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlDa
 	return ports, nil
 }
 
-func defaultKubernetesPodPortConfig() provision.TsuruYamlKubernetesPodPortConfig {
+func defaultKubernetesPodPortConfig() provision.TsuruYamlKubernetesProcessPortConfig {
 	defaultPort, _ := strconv.Atoi(provision.WebProcessDefaultPort())
-	return provision.TsuruYamlKubernetesPodPortConfig{
+	return provision.TsuruYamlKubernetesProcessPortConfig{
 		Name:       defaultHttpPortName,
 		Protocol:   "TCP",
 		Port:       defaultPort,

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1124,18 +1124,15 @@ func getTargetPortsForImage(imgName string) []int {
 	imageData, _ := image.GetImageMetaData(imgName)
 	if len(imageData.ExposedPorts) > 0 {
 		for _, exposedPort := range imageData.ExposedPorts {
-			// TODO: extract duplicated code
-			parts := strings.SplitN(exposedPort, "/", 2)
-			if len(parts) == 2 {
-				portInt, _ := strconv.Atoi(parts[0])
+			portInt, err := extractPortNumber(exposedPort)
+			if err == nil {
 				ports = append(ports, portInt)
 			}
 		}
 	}
 	if len(ports) == 0 && imageData.ExposedPort != "" {
-		parts := strings.SplitN(imageData.ExposedPort, "/", 2)
-		if len(parts) == 2 {
-			portInt, _ := strconv.Atoi(parts[0])
+		portInt, err := extractPortNumber(imageData.ExposedPort)
+		if err == nil {
 			ports = append(ports, portInt)
 		}
 	}
@@ -1144,6 +1141,14 @@ func getTargetPortsForImage(imgName string) []int {
 		ports = append(ports, portInt)
 	}
 	return ports
+}
+
+func extractPortNumber(port string) (int, error) {
+	parts := strings.SplitN(port, "/", 2)
+	if len(parts) != 2 {
+		return 0, errors.New("invalid port: " + port)
+	}
+	return strconv.Atoi(parts[0])
 }
 
 func getProcessPortsForImage(imgName string, tsuruYamlData provision.TsuruYamlData, process string) ([]provision.TsuruYamlKubernetesPodPortConfig, error) {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -841,9 +841,9 @@ func (s *S) TestServiceManagerDeployServiceWithKubernetesPorts(c *check.C) {
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
-				"mypod1": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod1": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"web": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{
 								Name:       "port1",
 								Protocol:   "UDP",
@@ -860,9 +860,9 @@ func (s *S) TestServiceManagerDeployServiceWithKubernetesPorts(c *check.C) {
 						},
 					},
 				},
-				"mypod2": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod2": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"p2": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Name: "myport"},
 						},
 					},
@@ -949,16 +949,16 @@ func (s *S) TestServiceManagerDeployServiceWithKubernetesPortsDuplicatedProcess(
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
-				"mypod1": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod1": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"web": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{TargetPort: 8080},
 						},
 					},
 				},
-				"mypod2": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod2": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"web": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Name: "myport"},
 						},
 					},

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -333,7 +333,7 @@ func (s *S) TestServiceManagerDeployServiceWithPoolNamespaces(c *check.C) {
 	c.Assert(atomic.LoadInt32(&counter), check.Equals, int32(len(processes)+1))
 }
 
-func (s *S) TestServiceManagerDeployServiceCustomPort(c *check.C) {
+func (s *S) TestServiceManagerDeployServiceCustomPorts(c *check.C) {
 	waitDep := s.mock.DeploymentReactions(c)
 	defer waitDep()
 	m := serviceManager{client: s.clusterClient}
@@ -341,9 +341,9 @@ func (s *S) TestServiceManagerDeployServiceCustomPort(c *check.C) {
 	err := app.CreateApp(a, s.user)
 	c.Assert(err, check.IsNil)
 	imgData := image.ImageMetadata{
-		Name:        "myimg",
-		ExposedPort: "7777/tcp",
-		Processes:   map[string][]string{"p1": {"cmd1"}},
+		Name:         "myimg",
+		ExposedPorts: []string{"7777/tcp", "7778/tcp"},
+		Processes:    map[string][]string{"p1": {"cmd1"}},
 	}
 	err = imgData.Save()
 	c.Assert(err, check.IsNil)
@@ -391,9 +391,15 @@ func (s *S) TestServiceManagerDeployServiceCustomPort(c *check.C) {
 			Ports: []apiv1.ServicePort{
 				{
 					Protocol:   "TCP",
-					Port:       int32(8888),
+					Port:       int32(7777),
 					TargetPort: intstr.FromInt(7777),
 					Name:       "http-default-1",
+				},
+				{
+					Protocol:   "TCP",
+					Port:       int32(7778),
+					TargetPort: intstr.FromInt(7778),
+					Name:       "http-default-2",
 				},
 			},
 			Type:                  apiv1.ServiceTypeNodePort,

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -342,7 +342,7 @@ func (s *S) TestServiceManagerDeployServiceCustomPorts(c *check.C) {
 	c.Assert(err, check.IsNil)
 	imgData := image.ImageMetadata{
 		Name:         "myimg",
-		ExposedPorts: []string{"7777/tcp", "7778/tcp"},
+		ExposedPorts: []string{"7777/tcp", "7778/udp"},
 		Processes:    map[string][]string{"p1": {"cmd1"}},
 	}
 	err = imgData.Save()
@@ -396,7 +396,7 @@ func (s *S) TestServiceManagerDeployServiceCustomPorts(c *check.C) {
 					Name:       "http-default-1",
 				},
 				{
-					Protocol:   "TCP",
+					Protocol:   "UDP",
 					Port:       int32(7778),
 					TargetPort: intstr.FromInt(7778),
 					Name:       "http-default-2",

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -225,7 +225,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 					Protocol:   "TCP",
 					Port:       int32(8888),
 					TargetPort: intstr.FromInt(8888),
-					Name:       "http-default",
+					Name:       "http-default-1",
 				},
 			},
 			Type:                  apiv1.ServiceTypeNodePort,
@@ -392,7 +392,7 @@ func (s *S) TestServiceManagerDeployServiceCustomPort(c *check.C) {
 					Protocol:   "TCP",
 					Port:       int32(8888),
 					TargetPort: intstr.FromInt(7777),
-					Name:       "http-default",
+					Name:       "http-default-1",
 				},
 			},
 			Type:                  apiv1.ServiceTypeNodePort,
@@ -818,6 +818,124 @@ func (s *S) TestServiceManagerDeployServiceWithRestartHooks(c *check.C) {
 	cmd = dep.Spec.Template.Spec.Containers[0].Command
 	c.Assert(cmd, check.HasLen, 3)
 	c.Assert(cmd[2], check.Matches, `.*before cmd1 && before cmd2 && exec proc2$`)
+}
+
+func (s *S) TestServiceManagerDeployServiceWithKubernetesPorts(c *check.C) {
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(a, s.user)
+	c.Assert(err, check.IsNil)
+	err = image.SaveImageCustomData("myimg", map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "proc1",
+			"p2":  "proc2",
+		},
+		"kubernetes": provision.TsuruYamlKubernetesConfig{
+			Groups: map[string]provision.TsuruYamlKubernetesGroup{
+				"mypod1": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"web": {
+						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+							{
+								Name:       "port1",
+								Protocol:   "UDP",
+								TargetPort: 8080,
+							},
+							{
+								Protocol: "TCP",
+								Port:     9000,
+							},
+							{
+								Port:       8000,
+								TargetPort: 8001,
+							},
+						},
+					},
+				},
+				"mypod2": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"p2": {
+						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+							{Name: "myport"},
+						},
+					},
+				},
+				"mypod3-ignored": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"web": {
+						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+							{
+								TargetPort: 8123,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
+		"web": servicecommon.ProcessState{Start: true},
+		"p2":  servicecommon.ProcessState{Start: true},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	waitDep()
+	ns, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-web", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(dep.Spec.Template.Spec.Containers[0].Ports, check.DeepEquals, []apiv1.ContainerPort{
+		{ContainerPort: 8080},
+		{ContainerPort: 9000},
+		{ContainerPort: 8001},
+	})
+	dep, err = s.client.Clientset.AppsV1beta2().Deployments(ns).Get("myapp-p2", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(dep.Spec.Template.Spec.Containers[0].Ports, check.DeepEquals, []apiv1.ContainerPort{
+		{ContainerPort: 8888},
+	})
+
+	srv, err := s.client.CoreV1().Services(ns).Get("myapp-web", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(srv.Spec.Ports, check.DeepEquals, []apiv1.ServicePort{
+		{
+			Name:       "port1",
+			Protocol:   "UDP",
+			Port:       int32(8080),
+			TargetPort: intstr.FromInt(8080),
+		},
+		{
+			Name:       "http-default-2",
+			Protocol:   "TCP",
+			Port:       int32(9000),
+			TargetPort: intstr.FromInt(9000),
+		},
+		{
+			Name:       "http-default-3",
+			Port:       int32(8000),
+			TargetPort: intstr.FromInt(8001),
+		},
+	})
+	srv, err = s.client.CoreV1().Services(ns).Get("myapp-p2", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(srv.Spec.Ports, check.DeepEquals, []apiv1.ServicePort{
+		{
+			Name:       "myport",
+			Port:       int32(8888),
+			TargetPort: intstr.FromInt(8888),
+		},
+	})
+
+	srv, err = s.client.CoreV1().Services(ns).Get("myapp-web-units", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(srv.Spec.Ports, check.DeepEquals, []apiv1.ServicePort{
+		{
+			Name:       "http-headless",
+			Protocol:   "UDP",
+			Port:       int32(8888),
+			TargetPort: intstr.FromInt(8080),
+		},
+	})
 }
 
 func (s *S) TestServiceManagerDeployServiceWithRegistryAuth(c *check.C) {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -172,6 +172,7 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 								{Name: "TSURU_HOST", Value: ""},
 								{Name: "port", Value: "8888"},
 								{Name: "PORT", Value: "8888"},
+								{Name: "PORT_p1", Value: "8888"},
 							},
 							Resources: apiv1.ResourceRequirements{
 								Limits:   apiv1.ResourceList{},

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1397,8 +1397,8 @@ func EnvsForApp(a provision.App, process, imageName string, isDeploy bool) []bin
 	if err != nil {
 		return append(envs, defaultWebPortEnvs()...)
 	}
-	portsConfig := getProcessPortsForImage(imageName, yamlData, process)
-	if len(portsConfig) == 0 {
+	portsConfig, err := getProcessPortsForImage(imageName, yamlData, process)
+	if err != nil || len(portsConfig) == 0 {
 		return append(envs, defaultWebPortEnvs()...)
 	}
 

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1404,7 +1404,11 @@ func EnvsForApp(a provision.App, process, imageName string, isDeploy bool) []bin
 
 	portValue := make([]string, len(portsConfig))
 	for i, portConfig := range portsConfig {
-		portValue[i] = fmt.Sprintf("%d", portConfig.TargetPort)
+		targetPort := portConfig.TargetPort
+		if targetPort == 0 {
+			targetPort = portConfig.Port
+		}
+		portValue[i] = fmt.Sprintf("%d", targetPort)
 	}
 	return append(envs, bind.EnvVar{Name: fmt.Sprintf("PORT_%s", process), Value: strings.Join(portValue, ",")})
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1439,7 +1439,7 @@ func removeDefaultPortEnvs(envs []bind.EnvVar) []bind.EnvVar {
 	return envsWithoutPort
 }
 
-func isDefaultPort(portsConfig []provision.TsuruYamlKubernetesPodPortConfig) bool {
+func isDefaultPort(portsConfig []provision.TsuruYamlKubernetesProcessPortConfig) bool {
 	if len(portsConfig) != 1 {
 		return false
 	}

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1399,7 +1399,7 @@ func EnvsForApp(a provision.App, process, imageName string, isDeploy bool) []bin
 	}
 	portsConfig, err := getProcessPortsForImage(imageName, yamlData, process)
 	if err != nil || len(portsConfig) == 0 {
-		return append(envs, provision.DefaultWebPortEnvs()...)
+		return removeDefaultPortEnvs(envs)
 	}
 
 	portValue := make([]string, len(portsConfig))
@@ -1412,23 +1412,28 @@ func EnvsForApp(a provision.App, process, imageName string, isDeploy bool) []bin
 	}
 	portEnv := bind.EnvVar{Name: fmt.Sprintf("PORT_%s", process), Value: strings.Join(portValue, ",")}
 	if !isDefaultPort(portsConfig) {
-		envsWithoutPort := []bind.EnvVar{}
-		defaultPortEnvs := provision.DefaultWebPortEnvs()
-		for _, env := range envs {
-			isDefaultPortEnv := false
-			for _, defaultEnv := range defaultPortEnvs {
-				if env.Name == defaultEnv.Name {
-					isDefaultPortEnv = true
-					break
-				}
-			}
-			if !isDefaultPortEnv {
-				envsWithoutPort = append(envsWithoutPort, env)
-			}
-		}
-		envs = envsWithoutPort
+		envs = removeDefaultPortEnvs(envs)
 	}
 	return append(envs, portEnv)
+}
+
+func removeDefaultPortEnvs(envs []bind.EnvVar) []bind.EnvVar {
+	envsWithoutPort := []bind.EnvVar{}
+	defaultPortEnvs := provision.DefaultWebPortEnvs()
+	for _, env := range envs {
+		isDefaultPortEnv := false
+		for _, defaultEnv := range defaultPortEnvs {
+			if env.Name == defaultEnv.Name {
+				isDefaultPortEnv = true
+				break
+			}
+		}
+		if !isDefaultPortEnv {
+			envsWithoutPort = append(envsWithoutPort, env)
+		}
+	}
+
+	return envsWithoutPort
 }
 
 func isDefaultPort(portsConfig []provision.TsuruYamlKubernetesPodPortConfig) bool {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1398,7 +1398,10 @@ func EnvsForApp(a provision.App, process, imageName string, isDeploy bool) []bin
 		return append(envs, provision.DefaultWebPortEnvs()...)
 	}
 	portsConfig, err := getProcessPortsForImage(imageName, yamlData, process)
-	if err != nil || len(portsConfig) == 0 {
+	if err != nil {
+		return envs
+	}
+	if len(portsConfig) == 0 {
 		return removeDefaultPortEnvs(envs)
 	}
 

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2213,37 +2213,37 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
-				"mypod1": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod1": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc1": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{TargetPort: 8080},
 							{Port: 9000},
 						},
 					},
 				},
-				"mypod2": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod2": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc2": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{TargetPort: 8000},
 						},
 					},
 				},
-				"mypod3": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod3": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc3": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Port: 8000, TargetPort: 8080},
 						},
 					},
 				},
-				"mypod5": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod5": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc5": {},
 					"proc6": {
-						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+						Ports: []provision.TsuruYamlKubernetesProcessPortConfig{
 							{Port: 8000},
 						},
 					},
 				},
-				"mypod6": map[string]provision.TsuruYamlKubernetesPodConfig{
+				"mypod6": map[string]provision.TsuruYamlKubernetesProcessConfig{
 					"proc6": {},
 				},
 			},

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2206,7 +2206,8 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 			"proc1": "python proc1.py",
 			"proc2": "python proc2.py",
 			"proc3": "python proc3.py",
-			"proc4": "python worker.py",
+			"proc4": "python proc4.py",
+			"proc5": "python worker.py",
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
@@ -2231,6 +2232,9 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 							{Port: 8000, TargetPort: 8080},
 						},
 					},
+				},
+				"mypod5": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"proc5": {},
 				},
 			},
 		},
@@ -2271,5 +2275,12 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 		{Name: "port", Value: "8888"},
 		{Name: "PORT", Value: "8888"},
 		{Name: "PORT_proc4", Value: "8888"},
+	})
+
+	envs = EnvsForApp(fa, "proc5", "myimg:v2", false)
+	c.Assert(envs, check.DeepEquals, []bind.EnvVar{
+		{Name: "e1", Value: "v1"},
+		{Name: "TSURU_PROCESSNAME", Value: "proc5"},
+		{Name: "TSURU_HOST", Value: ""},
 	})
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -802,6 +802,7 @@ func (s *S) TestRegisterUnitDeployUnit(c *check.C) {
 			"web":    {"python myapp.py"},
 			"worker": {"python myworker.py"},
 		},
+		ExposedPorts: []string{},
 	})
 }
 

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2209,6 +2209,7 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 			"proc3": "python proc3.py",
 			"proc4": "python proc4.py",
 			"proc5": "python worker.py",
+			"proc6": "python proc6.py",
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
@@ -2236,6 +2237,14 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 				},
 				"mypod5": map[string]provision.TsuruYamlKubernetesPodConfig{
 					"proc5": {},
+					"proc6": {
+						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+							{Port: 8000},
+						},
+					},
+				},
+				"mypod6": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"proc6": {},
 				},
 			},
 		},
@@ -2283,5 +2292,14 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 		{Name: "e1", Value: "v1"},
 		{Name: "TSURU_PROCESSNAME", Value: "proc5"},
 		{Name: "TSURU_HOST", Value: ""},
+	})
+
+	envs = EnvsForApp(fa, "proc6", "myimg:v2", false)
+	c.Assert(envs, check.DeepEquals, []bind.EnvVar{
+		{Name: "e1", Value: "v1"},
+		{Name: "TSURU_PROCESSNAME", Value: "proc6"},
+		{Name: "TSURU_HOST", Value: ""},
+		{Name: "port", Value: "8888"},
+		{Name: "PORT", Value: "8888"},
 	})
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2181,7 +2181,8 @@ func (s *S) TestEnvsForApp(c *check.C) {
 		"processes": map[string]interface{}{
 			"proc1": "python proc1.py",
 			"proc2": "python proc2.py",
-			"proc3": "python myworker.py",
+			"proc3": "python proc3.py",
+			"proc4": "python worker.py",
 		},
 		"kubernetes": provision.TsuruYamlKubernetesConfig{
 			Groups: map[string]provision.TsuruYamlKubernetesGroup{
@@ -2189,7 +2190,7 @@ func (s *S) TestEnvsForApp(c *check.C) {
 					"proc1": {
 						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
 							{TargetPort: 8080},
-							{TargetPort: 9000},
+							{Port: 9000},
 						},
 					},
 				},
@@ -2197,6 +2198,13 @@ func (s *S) TestEnvsForApp(c *check.C) {
 					"proc2": {
 						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
 							{TargetPort: 8000},
+						},
+					},
+				},
+				"mypod3": map[string]provision.TsuruYamlKubernetesPodConfig{
+					"proc3": {
+						Ports: []provision.TsuruYamlKubernetesPodPortConfig{
+							{Port: 8000, TargetPort: 8080},
 						},
 					},
 				},
@@ -2234,6 +2242,16 @@ func (s *S) TestEnvsForApp(c *check.C) {
 		{Name: "TSURU_HOST", Value: ""},
 		{Name: "port", Value: "8888"},
 		{Name: "PORT", Value: "8888"},
-		{Name: "PORT_proc3", Value: "8888"},
+		{Name: "PORT_proc3", Value: "8080"},
+	})
+
+	envs = EnvsForApp(fa, "proc4", "myimg:v2", false)
+	c.Assert(envs, check.DeepEquals, []bind.EnvVar{
+		{Name: "e1", Value: "v1"},
+		{Name: "TSURU_PROCESSNAME", Value: "proc4"},
+		{Name: "TSURU_HOST", Value: ""},
+		{Name: "port", Value: "8888"},
+		{Name: "PORT", Value: "8888"},
+		{Name: "PORT_proc4", Value: "8888"},
 	})
 }

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -674,9 +674,9 @@ func (e *Error) Error() string {
 }
 
 type TsuruYamlData struct {
-	Hooks       TsuruYamlHooks            `json:"hooks" bson:",omitempty"`
-	Healthcheck TsuruYamlHealthcheck      `json:"healthcheck" bson:",omitempty"`
-	Kubernetes  TsuruYamlKubernetesConfig `json:"kubernetes,omitempty" bson:",omitempty"`
+	Hooks       *TsuruYamlHooks            `json:"hooks,omitempty" bson:",omitempty"`
+	Healthcheck *TsuruYamlHealthcheck      `json:"healthcheck,omitempty" bson:",omitempty"`
+	Kubernetes  *TsuruYamlKubernetesConfig `json:"kubernetes,omitempty" bson:",omitempty"`
 }
 
 type TsuruYamlHooks struct {
@@ -720,16 +720,17 @@ type TsuruYamlKubernetesPodPortConfig struct {
 	TargetPort int    `json:"target_port,omitempty"`
 }
 
-func (hc TsuruYamlHealthcheck) ToRouterHC() router.HealthcheckData {
-	if hc.UseInRouter {
+func (y TsuruYamlData) ToRouterHC() router.HealthcheckData {
+	hc := y.Healthcheck
+	if hc == nil || !hc.UseInRouter {
 		return router.HealthcheckData{
-			Path:   hc.Path,
-			Status: hc.Status,
-			Body:   hc.RouterBody,
+			Path: "/",
 		}
 	}
 	return router.HealthcheckData{
-		Path: "/",
+		Path:   hc.Path,
+		Status: hc.Status,
+		Body:   hc.RouterBody,
 	}
 }
 

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -674,8 +674,9 @@ func (e *Error) Error() string {
 }
 
 type TsuruYamlData struct {
-	Hooks       TsuruYamlHooks       `bson:",omitempty"`
-	Healthcheck TsuruYamlHealthcheck `bson:",omitempty"`
+	Hooks       TsuruYamlHooks            `bson:",omitempty"`
+	Healthcheck TsuruYamlHealthcheck      `bson:",omitempty"`
+	Kubernetes  TsuruYamlKubernetesConfig `bson:",omitempty"`
 }
 
 type TsuruYamlHooks struct {
@@ -700,6 +701,23 @@ type TsuruYamlHealthcheck struct {
 	AllowedFailures int    `json:"allowed_failures" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
 	IntervalSeconds int    `json:"interval_seconds" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
 	TimeoutSeconds  int    `json:"timeout_seconds" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
+}
+
+type TsuruYamlKubernetesConfig struct {
+	Groups map[string]TsuruYamlKubernetesGroup `bson:",omitempty"`
+}
+
+type TsuruYamlKubernetesPodConfig struct {
+	Ports []TsuruYamlKubernetesPodPortConfig `bson:",omitempty"`
+}
+
+type TsuruYamlKubernetesGroup map[string]TsuruYamlKubernetesPodConfig
+
+type TsuruYamlKubernetesPodPortConfig struct {
+	Name       string `json:"name,omitempty" bson:"name,omitempty"`
+	Protocol   string `json:"protocol,omitempty" bson:"protocol,omitempty"`
+	Port       int    `json:"port,omitempty" bson:"port,omitempty"`
+	TargetPort int    `json:"target_port,omitempty" bson:"target_port,omitempty"`
 }
 
 func (hc TsuruYamlHealthcheck) ToRouterHC() router.HealthcheckData {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -674,50 +674,50 @@ func (e *Error) Error() string {
 }
 
 type TsuruYamlData struct {
-	Hooks       TsuruYamlHooks            `bson:",omitempty"`
-	Healthcheck TsuruYamlHealthcheck      `bson:",omitempty"`
-	Kubernetes  TsuruYamlKubernetesConfig `bson:",omitempty"`
+	Hooks       TsuruYamlHooks            `json:"hooks" bson:",omitempty"`
+	Healthcheck TsuruYamlHealthcheck      `json:"healthcheck" bson:",omitempty"`
+	Kubernetes  TsuruYamlKubernetesConfig `json:"kubernetes,omitempty" bson:",omitempty"`
 }
 
 type TsuruYamlHooks struct {
-	Restart TsuruYamlRestartHooks `bson:",omitempty"`
-	Build   []string              `bson:",omitempty"`
+	Restart TsuruYamlRestartHooks `json:"restart" bson:",omitempty"`
+	Build   []string              `json:"build" bson:",omitempty"`
 }
 
 type TsuruYamlRestartHooks struct {
-	Before []string `bson:",omitempty"`
-	After  []string `bson:",omitempty"`
+	Before []string `json:"before" bson:",omitempty"`
+	After  []string `json:"after" bson:",omitempty"`
 }
 
 type TsuruYamlHealthcheck struct {
-	Path            string
-	Method          string
-	Status          int
-	Scheme          string
-	Match           string `bson:",omitempty"`
-	RouterBody      string `json:"router_body" yaml:"router_body" bson:"router_body,omitempty"`
-	UseInRouter     bool   `json:"use_in_router" yaml:"use_in_router" bson:"use_in_router,omitempty"`
-	ForceRestart    bool   `json:"force_restart" yaml:"force_restart" bson:"force_restart,omitempty"`
-	AllowedFailures int    `json:"allowed_failures" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
-	IntervalSeconds int    `json:"interval_seconds" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
-	TimeoutSeconds  int    `json:"timeout_seconds" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
+	Path            string `json:"path"`
+	Method          string `json:"method"`
+	Status          int    `json:"status"`
+	Scheme          string `json:"scheme"`
+	Match           string `json:"match,omitempty" bson:",omitempty"`
+	RouterBody      string `json:"router_body,omitempty" yaml:"router_body" bson:"router_body,omitempty"`
+	UseInRouter     bool   `json:"use_in_router,omitempty" yaml:"use_in_router" bson:"use_in_router,omitempty"`
+	ForceRestart    bool   `json:"force_restart,omitempty" yaml:"force_restart" bson:"force_restart,omitempty"`
+	AllowedFailures int    `json:"allowed_failures,omitempty" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
+	IntervalSeconds int    `json:"interval_seconds,omitempty" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
+	TimeoutSeconds  int    `json:"timeout_seconds,omitempty" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
 }
 
 type TsuruYamlKubernetesConfig struct {
-	Groups map[string]TsuruYamlKubernetesGroup `bson:",omitempty"`
-}
-
-type TsuruYamlKubernetesPodConfig struct {
-	Ports []TsuruYamlKubernetesPodPortConfig `bson:",omitempty"`
+	Groups map[string]TsuruYamlKubernetesGroup `json:"groups,omitempty"`
 }
 
 type TsuruYamlKubernetesGroup map[string]TsuruYamlKubernetesPodConfig
 
+type TsuruYamlKubernetesPodConfig struct {
+	Ports []TsuruYamlKubernetesPodPortConfig `json:"ports"`
+}
+
 type TsuruYamlKubernetesPodPortConfig struct {
-	Name       string `json:"name,omitempty" bson:"name,omitempty"`
-	Protocol   string `json:"protocol,omitempty" bson:"protocol,omitempty"`
-	Port       int    `json:"port,omitempty" bson:"port,omitempty"`
-	TargetPort int    `json:"target_port,omitempty" bson:"target_port,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Protocol   string `json:"protocol,omitempty"`
+	Port       int    `json:"port,omitempty"`
+	TargetPort int    `json:"target_port,omitempty"`
 }
 
 func (hc TsuruYamlHealthcheck) ToRouterHC() router.HealthcheckData {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -707,13 +707,13 @@ type TsuruYamlKubernetesConfig struct {
 	Groups map[string]TsuruYamlKubernetesGroup `json:"groups,omitempty"`
 }
 
-type TsuruYamlKubernetesGroup map[string]TsuruYamlKubernetesPodConfig
+type TsuruYamlKubernetesGroup map[string]TsuruYamlKubernetesProcessConfig
 
-type TsuruYamlKubernetesPodConfig struct {
-	Ports []TsuruYamlKubernetesPodPortConfig `json:"ports"`
+type TsuruYamlKubernetesProcessConfig struct {
+	Ports []TsuruYamlKubernetesProcessPortConfig `json:"ports"`
 }
 
-type TsuruYamlKubernetesPodPortConfig struct {
+type TsuruYamlKubernetesProcessPortConfig struct {
 	Name       string `json:"name,omitempty"`
 	Protocol   string `json:"protocol,omitempty"`
 	Port       int    `json:"port,omitempty"`

--- a/provision/swarm/healthcheck.go
+++ b/provision/swarm/healthcheck.go
@@ -35,7 +35,6 @@ func toHealthConfig(meta provision.TsuruYamlData, port int) *container.HealthCon
 		}
 		timeoutSeconds = hc.TimeoutSeconds
 		allowedFailures = hc.AllowedFailures
-		timeoutSeconds = hc.TimeoutSeconds
 	}
 	if timeoutSeconds == 0 {
 		timeoutSeconds = 60

--- a/provision/swarm/healthcheck_test.go
+++ b/provision/swarm/healthcheck_test.go
@@ -19,12 +19,12 @@ func (s *S) TestToHealthConfig(c *check.C) {
 	}{
 		{input: provision.TsuruYamlData{}, expected: nil},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Method: "PUT",
 			},
 		}, expected: nil},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Path:   "/",
 				Method: "PUT",
 			},
@@ -38,7 +38,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 			Retries:  1,
 		}},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Path:   "/hc",
 				Status: 201,
 				Scheme: "https",
@@ -53,7 +53,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 			Retries:  1,
 		}},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Path:            "hc",
 				Status:          201,
 				AllowedFailures: 10,
@@ -69,7 +69,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 			Retries:  11,
 		}},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Path:           "hc",
 				TimeoutSeconds: 99,
 			},
@@ -83,13 +83,13 @@ func (s *S) TestToHealthConfig(c *check.C) {
 			Retries:  1,
 		}},
 		{input: provision.TsuruYamlData{
-			Healthcheck: provision.TsuruYamlHealthcheck{
+			Healthcheck: &provision.TsuruYamlHealthcheck{
 				Path:            "hc",
 				Status:          201,
 				AllowedFailures: 10,
 				Match:           "WORK.NG[0-9]+",
 			},
-			Hooks: provision.TsuruYamlHooks{
+			Hooks: &provision.TsuruYamlHooks{
 				Restart: provision.TsuruYamlRestartHooks{
 					After: []string{"my cmd 1", "my cmd 2"},
 				},
@@ -104,7 +104,7 @@ func (s *S) TestToHealthConfig(c *check.C) {
 			Retries:  11,
 		}},
 		{input: provision.TsuruYamlData{
-			Hooks: provision.TsuruYamlHooks{
+			Hooks: &provision.TsuruYamlHooks{
 				Restart: provision.TsuruYamlRestartHooks{
 					After: []string{"my cmd 1", "my cmd 2"},
 				},


### PR DESCRIPTION
This PR adds support to customize exposed ports for each process of an app on Kubernetes. Now we can expose more than one port for each process (both TCP and UDP), or config a process to avoid exposing any ports (like a worker).

This is a working implementation, although there are some limitations that I decided to leave to a future PR:

- healthcheck is set only on the first port of a process. Eventually we need to make this configurable
- the router port is attached to the first exposed port of the web process. We also need to discuss how to better handle this
- documentation is missing

Refs #2213 