### PR TITLE
provision/kubernetes: update deploy-agent version

### DIFF
--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1430,7 +1430,7 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 	runAsUser := int64(1000)
 	c.Assert(containers[0], check.DeepEquals, apiv1.Container{
 		Name:  "committer-cont",
-		Image: "tsuru/deploy-agent:0.6.0",
+		Image: "tsuru/deploy-agent:0.8.0",
 		VolumeMounts: []apiv1.VolumeMount{
 			{Name: "dockersock", MountPath: dockerSockPath},
 			{Name: "intercontainer", MountPath: buildIntercontainerPath},
@@ -1545,7 +1545,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 	c.Assert(containers, check.DeepEquals, []apiv1.Container{
 		{
 			Name:  "committer-cont",
-			Image: "tsuru/deploy-agent:0.6.0",
+			Image: "tsuru/deploy-agent:0.8.0",
 			VolumeMounts: []apiv1.VolumeMount{
 				{Name: "dockersock", MountPath: dockerSockPath},
 				{Name: "intercontainer", MountPath: buildIntercontainerPath},
@@ -1709,7 +1709,7 @@ func (s *S) TestCreateImageBuildPodContainer(c *check.C) {
 		{Name: "DEPLOYAGENT_RUN_AS_USER", Value: "1000"},
 		{Name: "DEPLOYAGENT_DOCKERFILE_BUILD", Value: "true"},
 	})
-	c.Assert(containers[0].Image, check.DeepEquals, "tsuru/deploy-agent:0.6.0")
+	c.Assert(containers[0].Image, check.DeepEquals, "tsuru/deploy-agent:0.8.0")
 	cmds := cleanCmds(containers[0].Command[2])
 	c.Assert(cmds, check.Equals, `mkdir -p $(dirname /data/context.tar.gz) && cat >/data/context.tar.gz && tsuru_unit_agent`)
 
@@ -1892,7 +1892,7 @@ func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 	c.Assert(containers, check.DeepEquals, []apiv1.Container{
 		{
 			Name:  "committer-cont",
-			Image: "tsuru/deploy-agent:0.6.0",
+			Image: "tsuru/deploy-agent:0.8.0",
 			VolumeMounts: []apiv1.VolumeMount{
 				{Name: "dockersock", MountPath: dockerSockPath},
 				{Name: "intercontainer", MountPath: buildIntercontainerPath},

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -54,7 +54,7 @@ const (
 	defaultPodRunningTimeout                   = 10 * time.Minute
 	defaultDeploymentProgressTimeout           = 10 * time.Minute
 	defaultAttachTimeoutAfterContainerFinished = time.Minute
-	defaultSidecarImageName                    = "tsuru/deploy-agent:0.6.0"
+	defaultSidecarImageName                    = "tsuru/deploy-agent:0.8.0"
 )
 
 type kubernetesProvisioner struct {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1761,8 +1761,8 @@ func (s *S) TestGetKubeConfigDefaults(c *check.C) {
 	config.Unset("kubernetes")
 	kubeConf := getKubeConfig()
 	c.Assert(kubeConf, check.DeepEquals, kubernetesConfig{
-		DeploySidecarImage:                  "tsuru/deploy-agent:0.6.0",
-		DeployInspectImage:                  "tsuru/deploy-agent:0.6.0",
+		DeploySidecarImage:                  "tsuru/deploy-agent:0.8.0",
+		DeployInspectImage:                  "tsuru/deploy-agent:0.8.0",
 		APITimeout:                          60 * time.Second,
 		APIShortTimeout:                     5 * time.Second,
 		PodReadyTimeout:                     time.Minute,


### PR DESCRIPTION
To support apps exposing multiple ports (#2249), the minimal deploy-agent version is 0.8.0