### PR TITLE
cmd: show error message body if available

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -277,6 +277,14 @@ func (m *Manager) Run(args []string) {
 		if verbosity > 0 {
 			errorMsg = fmt.Sprintf("%+v", err)
 		}
+		if bodyErr, ok := err.(interface {
+			Body() []byte
+		}); ok {
+			body := string(bodyErr.Body())
+			if body != "" {
+				errorMsg = fmt.Sprintf("%s: %s", errorMsg, body)
+			}
+		}
 		if isUnauthorized(err) && name != loginCmdName {
 			errorMsg = fmt.Sprintf(`You're not authenticated or your session has expired. Please use %q command for authentication.`, loginCmdName)
 		}


### PR DESCRIPTION
This is useful for request errors returned by the generated go-tsuruclient