### PR TITLE
provision/kubernetes: move deployment and daemonset to v1 from v1beta1

### DIFF
--- a/docs/managing/provisioners.rst
+++ b/docs/managing/provisioners.rst
@@ -80,7 +80,7 @@ intercommunication directly between containers.
 Node containers, e.g big-sibling, are also created as Swarm services with mode
 set to ``Global``, which ensures they run every node.
 
-kubernetes provisioner
+Kubernetes provisioner
 ----------------------
 
 The ``kubernetes`` provisioner uses `Kubernetes <https://kubernetes.io/>`_ to
@@ -106,3 +106,11 @@ the Kubernetes API server.
 
 Tsuru supports some Kubernetes-specific configurations, check
 :doc:`tsuru.yaml docs </using/tsuru.yaml>` for more details.
+
+Kubernetes compatibility
+========================
+
+These are the Kubernetes versions that were tested with each tsuru release:
+
+* tsuru <=1.6.2: kubernetes 1.8.x to 1.10.x
+* tsuru >=1.7.0: kubernetes 1.10.x to 1.12.x

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -23,7 +23,7 @@ import (
 	tsuruv1 "github.com/tsuru/tsuru/provision/kubernetes/pkg/apis/tsuru/v1"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/set"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -208,13 +208,13 @@ func allNewPodsRunning(client *ClusterClient, a provision.App, process string, d
 	if err != nil {
 		return false, err
 	}
-	replicaSets, err := client.AppsV1beta2().ReplicaSets(ns).List(metav1.ListOptions{
+	replicaSets, err := client.AppsV1().ReplicaSets(ns).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set(ls.ToSelector())).String(),
 	})
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
-	var replica *v1beta2.ReplicaSet
+	var replica *appsv1.ReplicaSet
 	for i, rs := range replicaSets.Items {
 		if rs.Annotations != nil && rs.Annotations[replicaDepRevision] == depRevision {
 			replica = &replicaSets.Items[i]
@@ -398,12 +398,12 @@ func propagationPtr(p metav1.DeletionPropagation) *metav1.DeletionPropagation {
 }
 
 func cleanupReplicas(client *ClusterClient, opts metav1.ListOptions, namespace string) error {
-	replicas, err := client.AppsV1beta2().ReplicaSets(namespace).List(opts)
+	replicas, err := client.AppsV1().ReplicaSets(namespace).List(opts)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	for _, replica := range replicas.Items {
-		err = client.AppsV1beta2().ReplicaSets(namespace).Delete(replica.Name, &metav1.DeleteOptions{
+		err = client.AppsV1().ReplicaSets(namespace).Delete(replica.Name, &metav1.DeleteOptions{
 			PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 		})
 		if err != nil && !k8sErrors.IsNotFound(err) {
@@ -419,7 +419,7 @@ func cleanupDeployment(client *ClusterClient, a provision.App, process string) e
 	if err != nil {
 		return err
 	}
-	err = client.AppsV1beta2().Deployments(ns).Delete(depName, &metav1.DeleteOptions{
+	err = client.AppsV1().Deployments(ns).Delete(depName, &metav1.DeleteOptions{
 		PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 	})
 	if err != nil && !k8sErrors.IsNotFound(err) {
@@ -444,7 +444,7 @@ func cleanupDeployment(client *ClusterClient, a provision.App, process string) e
 func cleanupDaemonSet(client *ClusterClient, name, pool string) error {
 	dsName := daemonSetName(name, pool)
 	ns := client.PoolNamespace(pool)
-	err := client.AppsV1beta2().DaemonSets(ns).Delete(dsName, &metav1.DeleteOptions{
+	err := client.AppsV1().DaemonSets(ns).Delete(dsName, &metav1.DeleteOptions{
 		PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 	})
 	if err != nil && !k8sErrors.IsNotFound(err) {

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	check "gopkg.in/check.v1"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -424,14 +424,14 @@ func (s *S) TestCleanupDeployment(c *check.C) {
 	c.Assert(err, check.IsNil)
 	ns, err := s.client.AppNamespace(a)
 	c.Assert(err, check.IsNil)
-	_, err = s.client.AppsV1beta2().Deployments(ns).Create(&v1beta2.Deployment{
+	_, err = s.client.AppsV1().Deployments(ns).Create(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1",
 			Namespace: ns,
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.client.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
+	_, err = s.client.AppsV1().ReplicaSets(ns).Create(&appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-xxx",
 			Namespace: ns,
@@ -449,20 +449,20 @@ func (s *S) TestCleanupDeployment(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = cleanupDeployment(s.clusterClient, a, "p1")
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
+	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 0)
 	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 0)
-	replicas, err := s.client.AppsV1beta2().ReplicaSets(ns).List(metav1.ListOptions{})
+	replicas, err := s.client.AppsV1().ReplicaSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(replicas.Items, check.HasLen, 0)
 }
 
 func (s *S) TestCleanupReplicas(c *check.C) {
 	ns := "tsuru_pool"
-	_, err := s.client.AppsV1beta2().ReplicaSets(ns).Create(&v1beta2.ReplicaSet{
+	_, err := s.client.AppsV1().ReplicaSets(ns).Create(&appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-xxx",
 			Namespace: ns,
@@ -486,20 +486,20 @@ func (s *S) TestCleanupReplicas(c *check.C) {
 		LabelSelector: "a=x",
 	}, ns)
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
+	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 0)
 	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(pods.Items, check.HasLen, 0)
-	replicas, err := s.client.AppsV1beta2().ReplicaSets(ns).List(metav1.ListOptions{})
+	replicas, err := s.client.AppsV1().ReplicaSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(replicas.Items, check.HasLen, 0)
 }
 
 func (s *S) TestCleanupDaemonSet(c *check.C) {
 	ns := s.client.PoolNamespace("pool")
-	_, err := s.client.AppsV1beta2().DaemonSets(ns).Create(&v1beta2.DaemonSet{
+	_, err := s.client.AppsV1().DaemonSets(ns).Create(&appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-container-bs-pool-p1",
 			Namespace: ns,
@@ -522,7 +522,7 @@ func (s *S) TestCleanupDaemonSet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = cleanupDaemonSet(s.clusterClient, "bs", "p1")
 	c.Assert(err, check.IsNil)
-	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 0)
 	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -6,7 +6,6 @@ package kubernetes
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -17,14 +16,12 @@ import (
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	provTypes "github.com/tsuru/tsuru/types/provision"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
-
-const alphaAffinityAnnotation = "scheduler.alpha.kubernetes.io/affinity"
 
 type nodeContainerManager struct {
 	app provision.App
@@ -54,7 +51,7 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 	}
 	dsName := daemonSetName(config.Name, pool)
 	ns := client.PoolNamespace(pool)
-	oldDs, err := client.AppsV1beta2().DaemonSets(ns).Get(dsName, metav1.GetOptions{})
+	oldDs, err := client.AppsV1().DaemonSets(ns).Get(dsName, metav1.GetOptions{})
 	if err != nil {
 		if !k8sErrors.IsNotFound(err) {
 			return errors.WithStack(err)
@@ -78,7 +75,6 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 	if len(nodeReq.Values) != 0 {
 		selectors = append(selectors, nodeReq)
 	}
-	affinityAnnotation := map[string]string{}
 	affinity := &apiv1.Affinity{
 		NodeAffinity: &apiv1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
@@ -88,20 +84,12 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 			},
 		},
 	}
-	var affinityData []byte
-	affinityData, err = json.Marshal(affinity)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	affinityAnnotation[alphaAffinityAnnotation] = string(affinityData)
 	if oldDs != nil && placementOnly {
-		if reflect.DeepEqual(oldDs.Spec.Template.ObjectMeta.Annotations, affinityAnnotation) &&
-			reflect.DeepEqual(oldDs.Spec.Template.Spec.Affinity, affinity) {
+		if reflect.DeepEqual(oldDs.Spec.Template.Spec.Affinity, affinity) {
 			return nil
 		}
-		oldDs.Spec.Template.ObjectMeta.Annotations = affinityAnnotation
 		oldDs.Spec.Template.Spec.Affinity = affinity
-		_, err = client.AppsV1beta2().DaemonSets(ns).Update(oldDs)
+		_, err = client.AppsV1().DaemonSets(ns).Update(oldDs)
 		return errors.WithStack(err)
 	}
 	ls := provision.NodeContainerLabels(provision.NodeContainerLabelsOpts{
@@ -179,26 +167,25 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 	if err != nil {
 		return err
 	}
-	ds := &v1beta2.DaemonSet{
+	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsName,
 			Namespace: ns,
 			Labels:    ls.ToLabels(),
 		},
-		Spec: v1beta2.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls.ToNodeContainerSelector(),
 			},
-			UpdateStrategy: v1beta2.DaemonSetUpdateStrategy{
-				Type: v1beta2.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &v1beta2.RollingUpdateDaemonSet{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 					MaxUnavailable: &maxUnavailable,
 				},
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      ls.ToLabels(),
-					Annotations: affinityAnnotation,
+					Labels: ls.ToLabels(),
 				},
 				Spec: apiv1.PodSpec{
 					ImagePullSecrets:   pullSecrets,
@@ -231,9 +218,9 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 		},
 	}
 	if oldDs != nil {
-		_, err = client.AppsV1beta2().DaemonSets(ns).Update(ds)
+		_, err = client.AppsV1().DaemonSets(ns).Update(ds)
 	} else {
-		_, err = client.AppsV1beta2().DaemonSets(ns).Create(ds)
+		_, err = client.AppsV1().DaemonSets(ns).Create(ds)
 	}
 	return errors.WithStack(err)
 }

--- a/provision/kubernetes/nodecontainer_test.go
+++ b/provision/kubernetes/nodecontainer_test.go
@@ -5,7 +5,6 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"sync/atomic"
 	"time"
 
@@ -19,8 +18,7 @@ import (
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
-	"k8s.io/api/apps/v1beta2"
-	apiv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,11 +100,11 @@ func (s *S) TestManagerDeployNodeContainerMultiClusterNoApp(c *check.C) {
 	err = m.DeployNodeContainer(&nc, "", servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 
-	daemons, err := client1.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err := client1.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 1)
 
-	daemons, err = client2.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err = client2.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 1)
 }
@@ -129,11 +127,11 @@ func (s *S) TestManagerDeployNodeContainerMultiClusterWithApp(c *check.C) {
 	err = m.DeployNodeContainer(&nc, "", servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 
-	daemons, err := client1.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err := client1.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 0)
 
-	daemons, err = client2.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err = client2.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 1)
 
@@ -144,11 +142,11 @@ func (s *S) TestManagerDeployNodeContainerMultiClusterWithApp(c *check.C) {
 	err = m.DeployNodeContainer(&nc, "", servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 
-	daemons, err = client1.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err = client1.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 1)
 
-	daemons, err = client2.AppsV1beta2().DaemonSets("default").List(metav1.ListOptions{})
+	daemons, err = client2.AppsV1().DaemonSets("default").List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Check(daemons.Items, check.HasLen, 1)
 }
@@ -176,10 +174,10 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 	ns := s.client.PoolNamespace(pool)
-	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-pool-mypool", metav1.GetOptions{})
+	daemon, err := s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-pool-mypool", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	trueVar := true
 	maxUnavailable := intstr.FromString("20%")
@@ -197,9 +195,7 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 			},
 		},
 	}
-	affinityData, err := json.Marshal(expectedAffinity)
-	c.Assert(err, check.IsNil)
-	c.Assert(daemon, check.DeepEquals, &v1beta2.DaemonSet{
+	c.Assert(daemon, check.DeepEquals, &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-container-bs-pool-mypool",
 			Namespace: ns,
@@ -211,16 +207,16 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 				"tsuru.io/node-container-pool": pool,
 			},
 		},
-		Spec: v1beta2.DaemonSetSpec{
+		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"tsuru.io/node-container-name": "bs",
 					"tsuru.io/node-container-pool": pool,
 				},
 			},
-			UpdateStrategy: v1beta2.DaemonSetUpdateStrategy{
-				Type: v1beta2.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &v1beta2.RollingUpdateDaemonSet{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 					MaxUnavailable: &maxUnavailable,
 				},
 			},
@@ -232,9 +228,6 @@ func (s *S) TestManagerDeployNodeContainer(c *check.C) {
 						"tsuru.io/provisioner":         "kubernetes",
 						"tsuru.io/node-container-name": "bs",
 						"tsuru.io/node-container-pool": pool,
-					},
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/affinity": string(affinityData),
 					},
 				},
 				Spec: apiv1.PodSpec{
@@ -301,8 +294,8 @@ func (s *S) TestManagerDeployNodeContainerWithPoolNamespaces(c *check.C) {
 	var counter int32
 	s.client.PrependReactor("create", "daemonsets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		atomic.AddInt32(&counter, 1)
-		s.client.AppsV1beta2()
-		ns, ok := action.(ktesting.CreateAction).GetObject().(*apiv1beta2.DaemonSet)
+		s.client.AppsV1()
+		ns, ok := action.(ktesting.CreateAction).GetObject().(*appsv1.DaemonSet)
 		c.Assert(ok, check.Equals, true)
 		c.Assert(ns.ObjectMeta.Namespace, check.Equals, s.client.PoolNamespace(pool))
 		return kTesting.RunReactionsAfter(&s.client.Fake, action)
@@ -351,7 +344,7 @@ func (s *S) TestManagerDeployNodeContainerWithFilter(c *check.C) {
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Exclude: []string{"p1", "p2"}}, false)
 	c.Assert(err, check.IsNil)
 	ns := s.client.PoolNamespace("")
-	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err := s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity := &apiv1.Affinity{
 		NodeAffinity: &apiv1.NodeAffinity{
@@ -372,15 +365,10 @@ func (s *S) TestManagerDeployNodeContainerWithFilter(c *check.C) {
 			},
 		},
 	}
-	affinityData, err := json.Marshal(expectedAffinity)
-	c.Assert(err, check.IsNil)
-	c.Assert(daemon.Spec.Template.ObjectMeta.Annotations, check.DeepEquals, map[string]string{
-		"scheduler.alpha.kubernetes.io/affinity": string(affinityData),
-	})
 	c.Assert(daemon.Spec.Template.Spec.Affinity, check.DeepEquals, expectedAffinity)
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Include: []string{"p1"}}, false)
 	c.Assert(err, check.IsNil)
-	daemon, err = s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err = s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity = &apiv1.Affinity{
 		NodeAffinity: &apiv1.NodeAffinity{
@@ -401,11 +389,6 @@ func (s *S) TestManagerDeployNodeContainerWithFilter(c *check.C) {
 			},
 		},
 	}
-	affinityData, err = json.Marshal(expectedAffinity)
-	c.Assert(err, check.IsNil)
-	c.Assert(daemon.Spec.Template.ObjectMeta.Annotations, check.DeepEquals, map[string]string{
-		"scheduler.alpha.kubernetes.io/affinity": string(affinityData),
-	})
 	c.Assert(daemon.Spec.Template.Spec.Affinity, check.DeepEquals, expectedAffinity)
 }
 
@@ -425,10 +408,10 @@ func (s *S) TestManagerDeployNodeContainerBSSpecialMount(c *check.C) {
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 	ns := s.client.PoolNamespace(pool)
-	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-big-sibling-pool-main", metav1.GetOptions{})
+	daemon, err := s.client.AppsV1().DaemonSets(ns).Get("node-container-big-sibling-pool-main", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemon.Spec.Template.Spec.Volumes, check.DeepEquals, []apiv1.Volume{
 		{
@@ -490,10 +473,10 @@ func (s *S) TestManagerDeployNodeContainerBSMultiCluster(c *check.C) {
 	err = m.DeployNodeContainer(&c1, pool, servicecommon.PoolFilter{}, false)
 	c.Assert(err, check.IsNil)
 	ns := s.client.PoolNamespace("pool")
-	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-big-sibling-pool-main", metav1.GetOptions{})
+	daemon, err := s.client.AppsV1().DaemonSets(ns).Get("node-container-big-sibling-pool-main", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedVolumes := []apiv1.Volume{
 		{
@@ -534,7 +517,7 @@ func (s *S) TestManagerDeployNodeContainerBSMultiCluster(c *check.C) {
 
 func (s *S) TestManagerDeployNodeContainerPlacementOnly(c *check.C) {
 	reaction := func(action ktesting.Action) (bool, runtime.Object, error) {
-		ds := action.(ktesting.CreateAction).GetObject().(*v1beta2.DaemonSet)
+		ds := action.(ktesting.CreateAction).GetObject().(*appsv1.DaemonSet)
 		ds.ObjectMeta.CreationTimestamp = metav1.Time{Time: time.Now()}
 		return kTesting.RunReactionsAfter(&s.client.Fake, action)
 	}
@@ -561,7 +544,7 @@ func (s *S) TestManagerDeployNodeContainerPlacementOnly(c *check.C) {
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{}, true)
 	c.Assert(err, check.IsNil)
 	ns := s.client.PoolNamespace("")
-	daemon, err := s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err := s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity := &apiv1.Affinity{
 		NodeAffinity: &apiv1.NodeAffinity{
@@ -577,15 +560,10 @@ func (s *S) TestManagerDeployNodeContainerPlacementOnly(c *check.C) {
 			},
 		},
 	}
-	affinityData, err := json.Marshal(expectedAffinity)
-	c.Assert(err, check.IsNil)
-	c.Assert(daemon.Spec.Template.ObjectMeta.Annotations, check.DeepEquals, map[string]string{
-		"scheduler.alpha.kubernetes.io/affinity": string(affinityData),
-	})
 	c.Assert(daemon.Spec.Template.Spec.Affinity, check.DeepEquals, expectedAffinity)
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Exclude: []string{"p1"}}, true)
 	c.Assert(err, check.IsNil)
-	daemon, err = s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err = s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	expectedAffinity = &apiv1.Affinity{
 		NodeAffinity: &apiv1.NodeAffinity{
@@ -606,16 +584,11 @@ func (s *S) TestManagerDeployNodeContainerPlacementOnly(c *check.C) {
 			},
 		},
 	}
-	affinityData, err = json.Marshal(expectedAffinity)
-	c.Assert(err, check.IsNil)
-	c.Assert(daemon.Spec.Template.ObjectMeta.Annotations, check.DeepEquals, map[string]string{
-		"scheduler.alpha.kubernetes.io/affinity": string(affinityData),
-	})
 	c.Assert(daemon.Spec.Template.Spec.Affinity, check.DeepEquals, expectedAffinity)
 	beforeCreation := daemon.CreationTimestamp
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Exclude: []string{"p1"}}, true)
 	c.Assert(err, check.IsNil)
-	daemon, err = s.client.AppsV1beta2().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
+	daemon, err = s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemon.CreationTimestamp, check.DeepEquals, beforeCreation)
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -273,7 +273,7 @@ func (p *kubernetesProvisioner) removeResources(client *ClusterClient, app *tsur
 	multiErrors := tsuruErrors.NewMultiError()
 	for _, d := range app.Spec.Deployments {
 		for _, dd := range d {
-			err := client.AppsV1beta2().Deployments(app.Spec.NamespaceName).Delete(dd, &metav1.DeleteOptions{
+			err := client.AppsV1().Deployments(app.Spec.NamespaceName).Delete(dd, &metav1.DeleteOptions{
 				PropagationPolicy: propagationPtr(metav1.DeletePropagationForeground),
 			})
 			if err != nil && !k8sErrors.IsNotFound(err) {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -37,7 +37,7 @@ import (
 	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/volume"
 	check "gopkg.in/check.v1"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -975,7 +975,7 @@ func (s *S) TestProvisionerDestroy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = s.p.Destroy(a)
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
+	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 0)
 	services, err := s.client.CoreV1().Services(ns).List(metav1.ListOptions{})
@@ -1082,7 +1082,7 @@ func (s *S) TestDeploy(c *check.C) {
 	wait()
 	ns, err := s.client.AppNamespace(a)
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
+	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
 	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web")
@@ -1274,7 +1274,7 @@ func (s *S) TestRollback(c *check.C) {
 	wait()
 	ns, err := s.client.AppNamespace(a)
 	c.Assert(err, check.IsNil)
-	deps, err := s.client.AppsV1beta2().Deployments(ns).List(metav1.ListOptions{})
+	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
 	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web")
@@ -1363,13 +1363,13 @@ func (s *S) TestUpgradeNodeContainer(c *check.C) {
 	err = s.p.UpgradeNodeContainer("bs", "", buf)
 	c.Assert(err, check.IsNil)
 
-	daemons, err := s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("")).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(s.client.PoolNamespace("")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("p1")).List(metav1.ListOptions{})
+	daemons, err = s.client.AppsV1().DaemonSets(s.client.PoolNamespace("p1")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
-	daemons, err = s.client.AppsV1beta2().DaemonSets(s.client.PoolNamespace("p2")).List(metav1.ListOptions{})
+	daemons, err = s.client.AppsV1().DaemonSets(s.client.PoolNamespace("p2")).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 1)
 }
@@ -1379,7 +1379,7 @@ func (s *S) TestRemoveNodeContainer(c *check.C) {
 	defer config.Unset("kubernetes:use-pool-namespaces")
 	s.mock.MockfakeNodes(c)
 	ns := s.client.PoolNamespace("p1")
-	_, err := s.client.AppsV1beta2().DaemonSets(ns).Create(&v1beta2.DaemonSet{
+	_, err := s.client.AppsV1().DaemonSets(ns).Create(&appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "node-container-bs-pool-p1",
 			Namespace: ns,
@@ -1402,7 +1402,7 @@ func (s *S) TestRemoveNodeContainer(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = s.p.RemoveNodeContainer("bs", "p1", ioutil.Discard)
 	c.Assert(err, check.IsNil)
-	daemons, err := s.client.AppsV1beta2().DaemonSets(ns).List(metav1.ListOptions{})
+	daemons, err := s.client.AppsV1().DaemonSets(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(daemons.Items, check.HasLen, 0)
 	pods, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
-	"k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -510,7 +510,7 @@ func (s *KubeMock) deploymentWithPodReaction(c *check.C) (ktesting.ReactionFunc,
 			return RunReactionsAfter(&s.client.Fake, action)
 		}
 		wg.Add(1)
-		dep := action.(ktesting.CreateAction).GetObject().(*v1beta2.Deployment)
+		dep := action.(ktesting.CreateAction).GetObject().(*appsv1.Deployment)
 		var specReplicas int32
 		if dep.Spec.Replicas != nil {
 			specReplicas = *dep.Spec.Replicas


### PR DESCRIPTION
They are generaly available in apps/v1 since kubernetes 1.9