### PR TITLE
api: fix token info version

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -421,7 +421,7 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.4", "GET", "/volumeplans", AuthorizationRequiredHandler(volumePlansList))
 
 	m.Add("1.6", "GET", "/tokens", AuthorizationRequiredHandler(tokenList))
-	m.Add("1.6", "GET", "/tokens/{token_id}", AuthorizationRequiredHandler(tokenInfo))
+	m.Add("1.7", "GET", "/tokens/{token_id}", AuthorizationRequiredHandler(tokenInfo))
 	m.Add("1.6", "POST", "/tokens", AuthorizationRequiredHandler(tokenCreate))
 	m.Add("1.6", "DELETE", "/tokens/{token_id}", AuthorizationRequiredHandler(tokenDelete))
 	m.Add("1.6", "PUT", "/tokens/{token_id}", AuthorizationRequiredHandler(tokenUpdate))

--- a/api/team_token_test.go
+++ b/api/team_token_test.go
@@ -247,7 +247,7 @@ func (s *S) TestTeamTokenInfo(c *check.C) {
 	}, s.token)
 	c.Assert(err, check.IsNil)
 
-	request, err := http.NewRequest("GET", "/1.6/tokens/id1", nil)
+	request, err := http.NewRequest("GET", "/1.7/tokens/id1", nil)
 	c.Assert(err, check.IsNil)
 	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
Token info route was actually introduced in tsuru 1.7