### PR TITLE
integration: add node-container to ensure integration CA is installed

### DIFF
--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -188,6 +188,7 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 					Labels: ls.ToLabels(),
 				},
 				Spec: apiv1.PodSpec{
+					HostPID:            config.HostConfig.PidMode == "host",
 					ImagePullSecrets:   pullSecrets,
 					ServiceAccountName: serviceAccountName,
 					Affinity:           affinity,


### PR DESCRIPTION
This also required a change to allow setting hostPID: true in DaemonSets based on node-containers.