### PR TITLE
provision/kubernetes: set default flags in kontainer-engine cluster

### DIFF
--- a/integration/install_config_test.go
+++ b/integration/install_config_test.go
@@ -99,7 +99,7 @@ func setupGenericClusters() map[string]*genericKubeCluster {
 		"gke": {
 			createData: map[string]string{
 				"driver":       "googlekubernetesengine",
-				"node-count":   "1",
+				"node-count":   "2",
 				"zone":         os.Getenv("GCE_ZONE"),
 				"project-id":   os.Getenv("GCE_PROJECT_ID"),
 				"machine-type": os.Getenv("GCE_MACHINE_TYPE"),

--- a/provision/kubernetes/provider/provider.go
+++ b/provision/kubernetes/provider/provider.go
@@ -153,6 +153,22 @@ func baseClusterSpec(driver string) v3.ClusterSpec {
 	}
 }
 
+func setFlagDefault(config v3.MapStringInterface, name string, flag *types.Flag) {
+	if flag.Default == nil {
+		return
+	}
+	switch flag.Type {
+	case types.IntType:
+		config[name] = flag.Default.DefaultInt
+	case types.StringType:
+		config[name] = flag.Default.DefaultString
+	case types.StringSliceType:
+		config[name] = flag.Default.DefaultStringSlice
+	case types.BoolType:
+		config[name] = flag.Default.DefaultBool
+	}
+}
+
 func setFlagsToCluster(config v3.MapStringInterface, driverName string, flags *types.DriverFlags, customData map[string]string) error {
 	for k, v := range flags.Options {
 		raw, ok := customData[k]
@@ -161,6 +177,7 @@ func setFlagsToCluster(config v3.MapStringInterface, driverName string, flags *t
 			var err error
 			raw, err = tsuruConfig.GetString(key)
 			if err != nil {
+				setFlagDefault(config, k, v)
 				continue
 			}
 		}


### PR DESCRIPTION
Even though container-engine knows the default values it doesnt use them unless the client explicitly sets them. :(