### PR TITLE
api: Preserve original request body after parsing arguments

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -5,6 +5,7 @@
 package context
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"net/http"
@@ -48,6 +49,7 @@ func GetBody(r *http.Request) ([]byte, error) {
 	}
 	newReq := r.WithContext(context.WithValue(r.Context(), reqBodyKey, data))
 	*r = *newReq
+	r.Body = ioutil.NopCloser(bytes.NewReader(data))
 	return data, nil
 }
 

--- a/api/service.go
+++ b/api/service.go
@@ -222,7 +222,6 @@ func serviceDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (err er
 //   401: Unauthorized
 //   404: Service not found
 func serviceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	parseFormPreserveBody(r)
 	serviceName := r.URL.Query().Get(":service")
 	s, err := getService(serviceName)
 	if err != nil {

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -5,10 +5,8 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -562,23 +560,6 @@ func servicePlans(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	return json.NewEncoder(w).Encode(plans)
 }
 
-func parseFormPreserveBody(r *http.Request) {
-	var buf bytes.Buffer
-	var readCloser struct {
-		io.Reader
-		io.Closer
-	}
-	if r.Body != nil {
-		readCloser.Reader = io.TeeReader(r.Body, &buf)
-		readCloser.Closer = r.Body
-		r.Body = &readCloser
-	}
-	r.ParseForm()
-	if buf.Len() > 0 {
-		readCloser.Reader = &buf
-	}
-}
-
 // title: service instance proxy
 // path: /services/{service}/proxy/{instance}
 // method: "*"
@@ -586,7 +567,6 @@ func parseFormPreserveBody(r *http.Request) {
 //   401: Unauthorized
 //   404: Instance not found
 func serviceInstanceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
-	parseFormPreserveBody(r)
 	serviceName := r.URL.Query().Get(":service")
 	instanceName := r.URL.Query().Get(":instance")
 	serviceInstance, err := getServiceInstanceOrError(serviceName, instanceName)


### PR DESCRIPTION
This fixes the service proxy not forwarding a json body because it was being consumed during event creation.