### PR TITLE
provision/kubernetes: omit Service for processes with no exposed ports

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1014,7 +1014,8 @@ func (m *serviceManager) DeployService(ctx context.Context, a provision.App, pro
 				ExternalTrafficPolicy: policy,
 			},
 		}
-		svc, isNew, err := mergeServices(m.client, svc)
+		var isNew bool
+		svc, isNew, err = mergeServices(m.client, svc)
 		if err != nil {
 			return err
 		}

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -481,6 +481,135 @@ func (s *S) TestServiceManagerDeployServiceCustomHeadlessPort(c *check.C) {
 	})
 }
 
+func (s *S) TestServiceManagerDeployServiceNoExposedPorts(c *check.C) {
+	config.Set("kubernetes:headless-service-port", 8889)
+	defer config.Unset("kubernetes:headless-service-port")
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(a, s.user)
+	c.Assert(err, check.IsNil)
+	err = image.SaveImageCustomData("myimg", map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cmd1",
+		},
+		"kubernetes": provTypes.TsuruYamlKubernetesConfig{
+			Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
+				"pod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
+					"p1": {
+						Ports: nil,
+					},
+				},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	err = servicecommon.RunServicePipeline(&m, a, "myimg", servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	waitDep()
+	nsName, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	srv, err := s.client.CoreV1().Services(nsName).Get("myapp-p1-units", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(srv, check.DeepEquals, &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myapp-p1-units",
+			Namespace: nsName,
+			Labels: map[string]string{
+				"app":                           "myapp-p1",
+				"tsuru.io/is-tsuru":             "true",
+				"tsuru.io/is-service":           "true",
+				"tsuru.io/is-build":             "false",
+				"tsuru.io/is-stopped":           "false",
+				"tsuru.io/is-deploy":            "false",
+				"tsuru.io/is-isolated-run":      "false",
+				"tsuru.io/is-headless-service":  "true",
+				"tsuru.io/app-name":             "myapp",
+				"tsuru.io/app-process":          "p1",
+				"tsuru.io/app-process-replicas": "1",
+				"tsuru.io/app-platform":         "",
+				"tsuru.io/app-pool":             "test-default",
+				"tsuru.io/provisioner":          "kubernetes",
+				"tsuru.io/builder":              "",
+			},
+			Annotations: map[string]string{
+				"tsuru.io/router-type": "fake",
+				"tsuru.io/router-name": "fake",
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				"tsuru.io/app-name":        "myapp",
+				"tsuru.io/app-process":     "p1",
+				"tsuru.io/is-build":        "false",
+				"tsuru.io/is-isolated-run": "false",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Protocol:   "TCP",
+					Port:       int32(8889),
+					TargetPort: intstr.FromInt(8888),
+					Name:       "http-headless",
+				},
+			},
+			ClusterIP: "None",
+			Type:      apiv1.ServiceTypeClusterIP,
+		},
+	})
+}
+
+func (s *S) TestServiceManagerDeployServiceNoExposedPortsRemoveExistingService(c *check.C) {
+	config.Set("kubernetes:headless-service-port", 8889)
+	defer config.Unset("kubernetes:headless-service-port")
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(a, s.user)
+	c.Assert(err, check.IsNil)
+	err = image.SaveImageCustomData("myimg1", map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cmd1",
+		},
+	})
+	c.Assert(err, check.IsNil)
+	err = servicecommon.RunServicePipeline(&m, a, "myimg1", servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	waitDep()
+	nsName, err := s.client.AppNamespace(a)
+	c.Assert(err, check.IsNil)
+	_, err = s.client.CoreV1().Services(nsName).Get("myapp-p1", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+
+	err = image.SaveImageCustomData("myimg2", map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cmd1",
+		},
+		"kubernetes": provTypes.TsuruYamlKubernetesConfig{
+			Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
+				"pod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
+					"p1": {
+						Ports: nil,
+					},
+				},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	err = servicecommon.RunServicePipeline(&m, a, "myimg2", servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	}, nil)
+	c.Assert(err, check.IsNil)
+	waitDep()
+	_, err = s.client.CoreV1().Services(nsName).Get("myapp-p1", metav1.GetOptions{})
+	c.Assert(k8sErrors.IsNotFound(err), check.DeepEquals, true)
+}
+
 func (s *S) TestServiceManagerDeployServiceUpdateStates(c *check.C) {
 	waitDep := s.mock.DeploymentReactions(c)
 	defer waitDep()


### PR DESCRIPTION
When a process doesn't expose ports, only the headless service is created.