### PR TITLE
provision/kubernetes: refactor informers per cluster

### DIFF
--- a/builder/kubernetes/suite_test.go
+++ b/builder/kubernetes/suite_test.go
@@ -137,7 +137,7 @@ func (s *S) SetUpTest(c *check.C) {
 	s.b = &kubernetesBuilder{}
 	s.p = kubeProv.GetProvisioner()
 	s.factory = informers.NewSharedInformerFactory(s.client, time.Minute)
-	kubeProv.InformerFactory = func(client *kubeProv.ClusterClient, _ <-chan struct{}) (informers.SharedInformerFactory, error) {
+	kubeProv.InformerFactory = func(client *kubeProv.ClusterClient) (informers.SharedInformerFactory, error) {
 		return s.factory, nil
 	}
 	s.mock = kubeTesting.NewKubeMock(s.client, s.p, s.factory)

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -555,7 +555,10 @@ func (s *S) TestLabelSetFromMeta(c *check.C) {
 
 func (s *S) TestGetServicePort(c *check.C) {
 	ns := "default"
-	svcInformer, err := s.p.serviceInformerForCluster(s.clusterClient)
+	controller, err := getClusterController(s.clusterClient)
+	c.Assert(err, check.IsNil)
+	defer controller.stop()
+	svcInformer, err := controller.getServiceInformer()
 	c.Assert(err, check.IsNil)
 	_, err = getServicePort(svcInformer, "notfound", ns)
 	c.Assert(err, check.NotNil)

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -555,9 +555,8 @@ func (s *S) TestLabelSetFromMeta(c *check.C) {
 
 func (s *S) TestGetServicePort(c *check.C) {
 	ns := "default"
-	controller, err := getClusterController(s.clusterClient)
+	controller, err := getClusterController(s.p, s.clusterClient)
 	c.Assert(err, check.IsNil)
-	defer controller.stop()
 	svcInformer, err := controller.getServiceInformer()
 	c.Assert(err, check.IsNil)
 	_, err = getServicePort(svcInformer, "notfound", ns)

--- a/provision/kubernetes/monitor.go
+++ b/provision/kubernetes/monitor.go
@@ -6,40 +6,50 @@ package kubernetes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/router/rebuild"
 	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	v1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/informers/internalinterfaces"
 	"k8s.io/client-go/tools/cache"
 )
 
 var (
-	clusterControllers   = map[string]*routerController{}
+	clusterControllers   = map[string]*clusterController{}
 	clusterControllersMu sync.Mutex
 )
 
-type routerController struct {
-	p       *kubernetesProvisioner
-	cluster *ClusterClient
+type clusterController struct {
+	mu              sync.Mutex
+	cluster         *ClusterClient
+	informerFactory informers.SharedInformerFactory
+	podInformer     v1informers.PodInformer
+	serviceInformer v1informers.ServiceInformer
+	nodeInformer    v1informers.NodeInformer
+	stopCh          chan struct{}
 }
 
 func initAllControllers(p *kubernetesProvisioner) error {
 	return forEachCluster(func(client *ClusterClient) error {
-		_, err := newRouterController(p, client)
+		_, err := getClusterController(client)
 		return err
 	})
 }
 
-func newRouterController(p *kubernetesProvisioner, cluster *ClusterClient) (*routerController, error) {
+func getClusterController(cluster *ClusterClient) (*clusterController, error) {
 	clusterControllersMu.Lock()
 	defer clusterControllersMu.Unlock()
 	if c, ok := clusterControllers[cluster.Name]; ok {
 		return c, nil
 	}
-	c := &routerController{
-		p:       p,
+	c := &clusterController{
 		cluster: cluster,
+		stopCh:  make(chan struct{}),
 	}
 	err := c.start()
 	if err != nil {
@@ -49,8 +59,15 @@ func newRouterController(p *kubernetesProvisioner, cluster *ClusterClient) (*rou
 	return c, nil
 }
 
-func (c *routerController) start() error {
-	informer, err := c.p.podInformerForCluster(c.cluster)
+func (c *clusterController) stop() {
+	close(c.stopCh)
+	clusterControllersMu.Lock()
+	defer clusterControllersMu.Unlock()
+	delete(clusterControllers, c.cluster.Name)
+}
+
+func (c *clusterController) start() error {
+	informer, err := c.getPodInformer()
 	if err != nil {
 		return err
 	}
@@ -77,12 +94,12 @@ func (c *routerController) start() error {
 	return nil
 }
 
-func (m *routerController) onAdd(obj interface{}) error {
+func (m *clusterController) onAdd(obj interface{}) error {
 	// Pods are never ready on add, ignore and do nothing
 	return nil
 }
 
-func (c *routerController) onUpdate(oldObj, newObj interface{}) error {
+func (c *clusterController) onUpdate(oldObj, newObj interface{}) error {
 	newPod := oldObj.(*apiv1.Pod)
 	oldPod := newObj.(*apiv1.Pod)
 	if newPod.ResourceVersion == oldPod.ResourceVersion {
@@ -92,7 +109,7 @@ func (c *routerController) onUpdate(oldObj, newObj interface{}) error {
 	return nil
 }
 
-func (c *routerController) onDelete(obj interface{}) error {
+func (c *clusterController) onDelete(obj interface{}) error {
 	if pod, ok := obj.(*apiv1.Pod); ok {
 		c.addPod(pod)
 		return nil
@@ -109,7 +126,7 @@ func (c *routerController) onDelete(obj interface{}) error {
 	return nil
 }
 
-func (c *routerController) addPod(pod *apiv1.Pod) {
+func (c *clusterController) addPod(pod *apiv1.Pod) {
 	labelSet := labelSetFromMeta(&pod.ObjectMeta)
 	appName := labelSet.AppName()
 	if appName == "" {
@@ -122,4 +139,80 @@ func (c *routerController) addPod(pod *apiv1.Pod) {
 	if routerLocal {
 		rebuild.EnqueueRoutesRebuild(appName)
 	}
+}
+
+func (p *clusterController) getPodInformer() (v1informers.PodInformer, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.podInformer != nil {
+		return p.podInformer, nil
+	}
+	err := p.withInformerFactory(func(factory informers.SharedInformerFactory) {
+		p.podInformer = factory.Core().V1().Pods()
+		p.podInformer.Informer()
+	})
+	return p.podInformer, err
+}
+
+func (p *clusterController) getServiceInformer() (v1informers.ServiceInformer, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.serviceInformer != nil {
+		return p.serviceInformer, nil
+	}
+	err := p.withInformerFactory(func(factory informers.SharedInformerFactory) {
+		p.serviceInformer = factory.Core().V1().Services()
+		p.serviceInformer.Informer()
+	})
+	return p.serviceInformer, err
+}
+
+func (p *clusterController) getNodeInformer() (v1informers.NodeInformer, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.nodeInformer != nil {
+		return p.nodeInformer, nil
+	}
+	err := p.withInformerFactory(func(factory informers.SharedInformerFactory) {
+		p.nodeInformer = factory.Core().V1().Nodes()
+		p.nodeInformer.Informer()
+	})
+	return p.nodeInformer, err
+}
+
+func (p *clusterController) withInformerFactory(fn func(factory informers.SharedInformerFactory)) error {
+	factory, err := p.getFactory()
+	if err != nil {
+		return err
+	}
+	fn(factory)
+	factory.Start(p.stopCh)
+	factory.WaitForCacheSync(p.stopCh)
+	return nil
+}
+
+func (p *clusterController) getFactory() (informers.SharedInformerFactory, error) {
+	if p.informerFactory != nil {
+		return p.informerFactory, nil
+	}
+	var err error
+	p.informerFactory, err = InformerFactory(p.cluster, p.stopCh)
+	return p.informerFactory, err
+}
+
+var InformerFactory = func(client *ClusterClient, stopCh <-chan struct{}) (informers.SharedInformerFactory, error) {
+	timeout := client.restConfig.Timeout
+	restConfig := *client.restConfig
+	restConfig.Timeout = 0
+	cli, err := ClientForConfig(&restConfig)
+	if err != nil {
+		return nil, err
+	}
+	tweakFunc := internalinterfaces.TweakListOptionsFunc(func(opts *metav1.ListOptions) {
+		if opts.TimeoutSeconds == nil {
+			timeoutSec := int64(timeout.Seconds())
+			opts.TimeoutSeconds = &timeoutSec
+		}
+	})
+	return informers.NewFilteredSharedInformerFactory(cli, time.Minute, metav1.NamespaceAll, tweakFunc), nil
 }

--- a/provision/kubernetes/monitor.go
+++ b/provision/kubernetes/monitor.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	informerSyncTimeout = time.Minute
+	informerSyncTimeout = 10 * time.Second
 )
 
 type clusterController struct {
@@ -241,7 +241,7 @@ func (c *clusterController) waitForSync(informer cache.SharedInformer) error {
 	ctx, cancel := contextWithCancelByChannel(context.Background(), c.stopCh, informerSyncTimeout)
 	defer cancel()
 	cache.WaitForCacheSync(ctx.Done(), informer.HasSynced)
-	return ctx.Err()
+	return errors.Wrap(ctx.Err(), "error waiting for informer sync")
 }
 
 var InformerFactory = func(client *ClusterClient) (informers.SharedInformerFactory, error) {

--- a/provision/kubernetes/monitor_test.go
+++ b/provision/kubernetes/monitor_test.go
@@ -20,7 +20,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
-func (s *S) TestNewRouterController(c *check.C) {
+func (s *S) TestNewClusterController(c *check.C) {
 	s.clusterClient.CustomData = map[string]string{
 		routerAddressLocalKey: "true",
 	}
@@ -46,8 +46,9 @@ func (s *S) TestNewRouterController(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	defer rebuild.Shutdown(context.Background())
-	_, err = newRouterController(s.p, s.clusterClient)
+	controller, err := getClusterController(s.clusterClient)
 	c.Assert(err, check.IsNil)
+	defer controller.stop()
 	basePod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "pod1",
@@ -67,9 +68,10 @@ func (s *S) TestNewRouterController(c *check.C) {
 }
 
 func (s *S) TestNewRouterControllerSameInstance(c *check.C) {
-	c1, err := newRouterController(s.p, s.clusterClient)
+	c1, err := getClusterController(s.clusterClient)
 	c.Assert(err, check.IsNil)
-	c2, err := newRouterController(s.p, s.clusterClient)
+	defer c1.stop()
+	c2, err := getClusterController(s.clusterClient)
 	c.Assert(err, check.IsNil)
 	c.Assert(c1, check.Equals, c2)
 }

--- a/provision/kubernetes/monitor_test.go
+++ b/provision/kubernetes/monitor_test.go
@@ -46,9 +46,8 @@ func (s *S) TestNewClusterController(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	defer rebuild.Shutdown(context.Background())
-	controller, err := getClusterController(s.clusterClient)
+	_, err = getClusterController(s.p, s.clusterClient)
 	c.Assert(err, check.IsNil)
-	defer controller.stop()
 	basePod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "pod1",
@@ -68,10 +67,9 @@ func (s *S) TestNewClusterController(c *check.C) {
 }
 
 func (s *S) TestNewRouterControllerSameInstance(c *check.C) {
-	c1, err := getClusterController(s.clusterClient)
+	c1, err := getClusterController(s.p, s.clusterClient)
 	c.Assert(err, check.IsNil)
-	defer c1.stop()
-	c2, err := getClusterController(s.clusterClient)
+	c2, err := getClusterController(s.p, s.clusterClient)
 	c.Assert(err, check.IsNil)
 	c.Assert(c1, check.Equals, c2)
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1239,8 +1239,14 @@ func (p *kubernetesProvisioner) UpdateApp(old, new provision.App, w io.Writer) e
 }
 
 func (p *kubernetesProvisioner) Shutdown(ctx context.Context) error {
-	// TODO: close(p.stopCh)
-	return nil
+	err := forEachCluster(func(client *ClusterClient) error {
+		stopClusterController(p, client)
+		return nil
+	})
+	if err == provTypes.ErrNoCluster {
+		return nil
+	}
+	return err
 }
 
 func ensureAppCustomResourceSynced(client *ClusterClient, a provision.App) error {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -191,14 +191,13 @@ func (p *kubernetesProvisioner) InitializeCluster(c *provTypes.Cluster) error {
 	if err != nil {
 		return err
 	}
-	controller, err := getClusterController(clusterClient)
+	controller, isNew, err := getClusterControllerExists(clusterClient)
 	if err != nil {
 		return err
 	}
-	controller.stop()
-	_, err = getClusterController(clusterClient)
-	if err != nil {
-		return err
+	if !isNew {
+		controller.stop()
+		_, err = getClusterController(clusterClient)
 	}
 	return err
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2320,8 +2320,12 @@ func (s *S) TestProvisionerUpdateAppWithVolumeWithTwoBindsOtherCluster(c *check.
 }
 
 func (s *S) TestProvisionerInitialize(c *check.C) {
+	_, ok := s.p.clusterControllers[s.clusterClient.Name]
+	c.Assert(ok, check.Equals, false)
 	err := s.p.Initialize()
 	c.Assert(err, check.IsNil)
+	_, ok = s.p.clusterControllers[s.clusterClient.Name]
+	c.Assert(ok, check.Equals, true)
 }
 
 func (s *S) TestProvisionerInitializeNoClusters(c *check.C) {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -2320,13 +2320,8 @@ func (s *S) TestProvisionerUpdateAppWithVolumeWithTwoBindsOtherCluster(c *check.
 }
 
 func (s *S) TestProvisionerInitialize(c *check.C) {
-	clusterControllers = map[string]*routerController{}
-	_, ok := clusterControllers[s.clusterClient.Name]
-	c.Assert(ok, check.Equals, false)
 	err := s.p.Initialize()
 	c.Assert(err, check.IsNil)
-	_, ok = clusterControllers[s.clusterClient.Name]
-	c.Assert(ok, check.Equals, true)
 }
 
 func (s *S) TestProvisionerInitializeNoClusters(c *check.C) {

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -30,7 +30,6 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/client-go/informers"
-	v1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -79,6 +78,12 @@ func (s *S) TearDownSuite(c *check.C) {
 	s.conn.Close()
 }
 
+func (s *S) TearDownTest(c *check.C) {
+	controller, err := getClusterController(s.clusterClient)
+	c.Assert(err, check.IsNil)
+	controller.stop()
+}
+
 func (s *S) SetUpTest(c *check.C) {
 	err := dbtest.ClearAllCollections(s.conn.Apps().Database)
 	c.Assert(err, check.IsNil)
@@ -116,14 +121,17 @@ func (s *S) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	s.factory = informers.NewSharedInformerFactory(s.client, 1)
+	InformerFactory = func(client *ClusterClient, stopCh <-chan struct{}) (informers.SharedInformerFactory, error) {
+		return s.factory, nil
+	}
 	s.p = &kubernetesProvisioner{
-		informerFactory: map[string]informers.SharedInformerFactory{
-			clus.Name: s.factory,
-		},
-		podInformers:     make(map[string]v1informers.PodInformer),
-		serviceInformers: make(map[string]v1informers.ServiceInformer),
-		nodeInformers:    make(map[string]v1informers.NodeInformer),
-		stopCh:           make(chan struct{}),
+		// informerFactory: map[string]informers.SharedInformerFactory{
+		// 	clus.Name: s.factory,
+		// },
+		// podInformers:     make(map[string]v1informers.PodInformer),
+		// serviceInformers: make(map[string]v1informers.ServiceInformer),
+		// nodeInformers:    make(map[string]v1informers.NodeInformer),
+		// stopCh:           make(chan struct{}),
 	}
 	s.mock = kTesting.NewKubeMock(s.client, s.p, s.factory)
 	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -121,18 +121,10 @@ func (s *S) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	s.factory = informers.NewSharedInformerFactory(s.client, 1)
-	InformerFactory = func(client *ClusterClient, stopCh <-chan struct{}) (informers.SharedInformerFactory, error) {
+	InformerFactory = func(client *ClusterClient) (informers.SharedInformerFactory, error) {
 		return s.factory, nil
 	}
-	s.p = &kubernetesProvisioner{
-		// informerFactory: map[string]informers.SharedInformerFactory{
-		// 	clus.Name: s.factory,
-		// },
-		// podInformers:     make(map[string]v1informers.PodInformer),
-		// serviceInformers: make(map[string]v1informers.ServiceInformer),
-		// nodeInformers:    make(map[string]v1informers.NodeInformer),
-		// stopCh:           make(chan struct{}),
-	}
+	s.p = &kubernetesProvisioner{}
 	s.mock = kTesting.NewKubeMock(s.client, s.p, s.factory)
 	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))
 	s.user = &auth.User{Email: "whiskeyjack@genabackis.com", Password: "123456", Quota: quota.UnlimitedQuota}

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -79,9 +79,7 @@ func (s *S) TearDownSuite(c *check.C) {
 }
 
 func (s *S) TearDownTest(c *check.C) {
-	controller, err := getClusterController(s.clusterClient)
-	c.Assert(err, check.IsNil)
-	controller.stop()
+	stopClusterController(s.p, s.clusterClient)
 }
 
 func (s *S) SetUpTest(c *check.C) {
@@ -124,7 +122,9 @@ func (s *S) SetUpTest(c *check.C) {
 	InformerFactory = func(client *ClusterClient) (informers.SharedInformerFactory, error) {
 		return s.factory, nil
 	}
-	s.p = &kubernetesProvisioner{}
+	s.p = &kubernetesProvisioner{
+		clusterControllers: map[string]*clusterController{},
+	}
 	s.mock = kTesting.NewKubeMock(s.client, s.p, s.factory)
 	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))
 	s.user = &auth.User{Email: "whiskeyjack@genabackis.com", Password: "123456", Quota: quota.UnlimitedQuota}


### PR DESCRIPTION
With @guilhermebr 

This PR simplifies handling informers per cluster and also fixes informers becoming invalid when clusters are updated.