### PR TITLE
provision/kubernetes: ensure pvc is removed when deleting volume

### DIFF
--- a/provision/kubernetes/volume_test.go
+++ b/provision/kubernetes/volume_test.go
@@ -344,7 +344,7 @@ func (s *S) TestCreateVolumeMultipleNamespacesFail(c *check.C) {
 	err = v.BindApp("otherapp", "/mnt", false)
 	c.Assert(err, check.IsNil)
 	_, _, err = createVolumesForApp(s.clusterClient, a)
-	c.Assert(err, check.ErrorMatches, `multiple namespaces for volume`)
+	c.Assert(err, check.ErrorMatches, `multiple namespaces for volume not allowed: "tsuru-otherpool" and "tsuru-test-default"`)
 }
 
 func (s *S) TestDeleteVolume(c *check.C) {


### PR DESCRIPTION
Since when we're deleting a volume we don't have any binds anymore it's
not possible to use them to find the PVC namespaces. Instead, we list
all PVCs from all namespaces including the volume name label and delete
them all.