### PR TITLE
Show related kubernetes-services in app-info

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -258,6 +258,12 @@ func appInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if !canRead {
 		return permission.ErrUnauthorized
 	}
+
+	err = a.FillInternalAddresses(r.Context())
+	if err != nil {
+		return err
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(&a)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -112,6 +113,7 @@ type App struct {
 	UUID string
 
 	// InterApp Properties implemented by provision.InterAppProvisioner
+	// it is lazy generated on the first call to FillInternalAddresses
 	InternalAddresses []*provision.AppInternalAddress `json:",omitempty" bson:"-"`
 
 	Quota       quota.Quota
@@ -134,6 +136,22 @@ func (app *App) getBuilder() (builder.Builder, error) {
 	}
 	app.builder, err = builder.GetForProvisioner(p)
 	return app.builder, err
+}
+
+func (app *App) FillInternalAddresses(ctx context.Context) error {
+	provisioner, err := app.getProvisioner()
+	if err != nil {
+		return err
+	}
+
+	if interAppProvisioner, ok := provisioner.(provision.InterAppProvisioner); ok {
+		app.InternalAddresses, err = interAppProvisioner.InternalAddresses(ctx, app)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (app *App) CleanImage(img string) error {

--- a/app/app.go
+++ b/app/app.go
@@ -111,6 +111,9 @@ type App struct {
 	// UUID is a v4 UUID lazily generated on the first call to GetUUID()
 	UUID string
 
+	// InterApp Properties implemented by provision.InterAppProvisioner
+	InternalAddresses []*provision.AppInternalAddress `json:",omitempty" bson:"-"`
+
 	Quota       quota.Quota
 	builder     builder.Builder
 	provisioner provision.Provisioner

--- a/app/app.go
+++ b/app/app.go
@@ -114,7 +114,7 @@ type App struct {
 
 	// InterApp Properties implemented by provision.InterAppProvisioner
 	// it is lazy generated on the first call to FillInternalAddresses
-	InternalAddresses []*provision.AppInternalAddress `json:",omitempty" bson:"-"`
+	InternalAddresses []provision.AppInternalAddress `json:",omitempty" bson:"-"`
 
 	Quota       quota.Quota
 	builder     builder.Builder

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5556,12 +5556,12 @@ func (s *S) TestFillInternalAddresses(c *check.C) {
 	err := app.FillInternalAddresses(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(app.InternalAddresses, check.HasLen, 2)
-	c.Assert(app.InternalAddresses[0], check.DeepEquals, &provision.AppInternalAddress{
+	c.Assert(app.InternalAddresses[0], check.DeepEquals, provision.AppInternalAddress{
 		Domain:   "test-web.fake-cluster.local",
 		Protocol: "TCP",
 		Port:     80,
 	})
-	c.Assert(app.InternalAddresses[1], check.DeepEquals, &provision.AppInternalAddress{
+	c.Assert(app.InternalAddresses[1], check.DeepEquals, provision.AppInternalAddress{
 		Domain:   "test-logs.fake-cluster.local",
 		Protocol: "UDP",
 		Port:     12201,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5550,3 +5550,20 @@ func (s *S) TestGetUUID(c *check.C) {
 	c.Assert(storedApp.UUID, check.Not(check.DeepEquals), "")
 	c.Assert(storedApp.UUID, check.DeepEquals, uuid)
 }
+
+func (s *S) TestFillInternalAddresses(c *check.C) {
+	app := App{Name: "test", TeamOwner: s.team.Name, Pool: s.Pool}
+	err := app.FillInternalAddresses(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(app.InternalAddresses, check.HasLen, 2)
+	c.Assert(app.InternalAddresses[0], check.DeepEquals, &provision.AppInternalAddress{
+		Domain:   "test-web.fake-cluster.local",
+		Protocol: "TCP",
+		Port:     80,
+	})
+	c.Assert(app.InternalAddresses[1], check.DeepEquals, &provision.AppInternalAddress{
+		Domain:   "test-logs.fake-cluster.local",
+		Protocol: "UDP",
+		Port:     12201,
+	})
+}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -941,11 +941,17 @@ func (m *serviceManager) KubernetesInternalAddresses(ctx context.Context, a prov
 	}
 	addresses := []*KubernetesInternalAddress{}
 
-	// TODO: discover app processes
-	processes := []string{
-		"web",
+	tclient, err := TsuruClientForConfig(m.client.restConfig)
+	if err != nil {
+		return nil, err
 	}
-	for _, process := range processes {
+
+	app, err := tclient.TsuruV1().Apps(m.client.Namespace()).Get(a.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for process, _ := range app.Spec.Services {
 		depName := deploymentNameForApp(a, process)
 		service, err := m.client.CoreV1().Services(ns).Get(depName, metav1.GetOptions{})
 

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -928,49 +928,6 @@ func monitorDeployment(ctx context.Context, client *ClusterClient, dep *appsv1.D
 	return revision, nil
 }
 
-type KubernetesInternalAddress struct {
-	Domain   string
-	Protocol apiv1.Protocol
-	Port     int32
-}
-
-func (m *serviceManager) KubernetesInternalAddresses(ctx context.Context, a provision.App) ([]*KubernetesInternalAddress, error) {
-	ns, err := m.client.AppNamespace(a)
-	if err != nil {
-		return nil, err
-	}
-	addresses := []*KubernetesInternalAddress{}
-
-	tclient, err := TsuruClientForConfig(m.client.restConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	app, err := tclient.TsuruV1().Apps(m.client.Namespace()).Get(a.GetName(), metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	for process, _ := range app.Spec.Services {
-		depName := deploymentNameForApp(a, process)
-		service, err := m.client.CoreV1().Services(ns).Get(depName, metav1.GetOptions{})
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to fetch service information, serviceName: %q, namespace: %q", depName, ns)
-		}
-
-		for _, port := range service.Spec.Ports {
-			addresses = append(addresses, &KubernetesInternalAddress{
-				Domain:   service.Spec.ExternalName,
-				Protocol: port.Protocol,
-				Port:     port.Port,
-			})
-		}
-	}
-
-	return addresses, nil
-}
-
 func (m *serviceManager) DeployService(ctx context.Context, a provision.App, process string, labels *provision.LabelSet, replicas int, img string) error {
 	err := ensureNodeContainers(a)
 	if err != nil {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -778,7 +778,7 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 
 		for _, port := range service.Spec.Ports {
 			addresses = append(addresses, &provision.AppInternalAddress{
-				Domain:   service.Spec.ExternalName,
+				Domain:   fmt.Sprintf("%s.%s.svc.cluster.local", depName, ns),
 				Protocol: string(port.Protocol),
 				Port:     port.Port,
 			})

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -768,7 +768,7 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 		return nil, err
 	}
 
-	for process, _ := range app.Spec.Services {
+	for process := range app.Spec.Services {
 		depName := deploymentNameForApp(a, process)
 		service, err := client.CoreV1().Services(ns).Get(depName, metav1.GetOptions{})
 

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -748,7 +748,7 @@ func (p *kubernetesProvisioner) ListNodes(addressFilter []string) ([]provision.N
 	return nodes, nil
 }
 
-func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]*provision.AppInternalAddress, error) {
+func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]provision.AppInternalAddress, error) {
 	client, err := clusterForPool(a.GetPool())
 	if err != nil {
 		return nil, err
@@ -757,7 +757,7 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 	if err != nil {
 		return nil, err
 	}
-	addresses := []*provision.AppInternalAddress{}
+	addresses := []provision.AppInternalAddress{}
 
 	tclient, err := TsuruClientForConfig(client.restConfig)
 	if err != nil {
@@ -784,7 +784,7 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 		}
 
 		for _, port := range service.Spec.Ports {
-			addresses = append(addresses, &provision.AppInternalAddress{
+			addresses = append(addresses, provision.AppInternalAddress{
 				Domain:   fmt.Sprintf("%s.%s.svc.cluster.local", depName, ns),
 				Protocol: string(port.Protocol),
 				Port:     port.Port,

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -768,7 +769,13 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 		return nil, err
 	}
 
+	processes := []string{}
 	for process := range app.Spec.Services {
+		processes = append(processes, process)
+	}
+	sort.Strings(processes)
+
+	for _, process := range processes {
 		depName := deploymentNameForApp(a, process)
 		service, err := client.CoreV1().Services(ns).Get(depName, metav1.GetOptions{})
 

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -775,9 +775,18 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 	}
 	sort.Strings(processes)
 
+	controller, err := getClusterController(p, client)
+	if err != nil {
+		return nil, err
+	}
+	svcInformer, err := controller.getServiceInformer()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, process := range processes {
 		depName := deploymentNameForApp(a, process)
-		service, err := client.CoreV1().Services(ns).Get(depName, metav1.GetOptions{})
+		service, err := svcInformer.Lister().Services(ns).Get(depName)
 
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to fetch service information, serviceName: %q, namespace: %q", depName, ns)

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1289,17 +1289,17 @@ func (s *S) TestInternalAddresses(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	c.Assert(addrs[0], check.DeepEquals, &provision.AppInternalAddress{
+	c.Assert(addrs[0], check.DeepEquals, provision.AppInternalAddress{
 		Domain:   "myapp-jobs.default.svc.cluster.local",
 		Protocol: "UDP",
 		Port:     12201,
 	})
-	c.Assert(addrs[1], check.DeepEquals, &provision.AppInternalAddress{
+	c.Assert(addrs[1], check.DeepEquals, provision.AppInternalAddress{
 		Domain:   "myapp-web.default.svc.cluster.local",
 		Protocol: "TCP",
 		Port:     80,
 	})
-	c.Assert(addrs[2], check.DeepEquals, &provision.AppInternalAddress{
+	c.Assert(addrs[2], check.DeepEquals, provision.AppInternalAddress{
 		Domain:   "myapp-web.default.svc.cluster.local",
 		Protocol: "TCP",
 		Port:     443,

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -389,6 +389,18 @@ type UpdatableProvisioner interface {
 	UpdateApp(old, new App, w io.Writer) error
 }
 
+// InterAppProvisioner is a provisioner that allows an app to comunicate with each other
+// using internal dns and own load balancers provided by provisioner.
+type InterAppProvisioner interface {
+	InternalAddresses(ctx context.Context, a App) ([]*AppInternalAddress, error)
+}
+
+type AppInternalAddress struct {
+	Domain   string
+	Protocol string
+	Port     int32
+}
+
 // MessageProvisioner is a provisioner that provides a welcome message for
 // logging.
 type MessageProvisioner interface {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -392,7 +392,7 @@ type UpdatableProvisioner interface {
 // InterAppProvisioner is a provisioner that allows an app to comunicate with each other
 // using internal dns and own load balancers provided by provisioner.
 type InterAppProvisioner interface {
-	InternalAddresses(ctx context.Context, a App) ([]*AppInternalAddress, error)
+	InternalAddresses(ctx context.Context, a App) ([]AppInternalAddress, error)
 }
 
 type AppInternalAddress struct {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1377,8 +1377,8 @@ func (p *FakeProvisioner) UpdateApp(old, new provision.App, w io.Writer) error {
 	return nil
 }
 
-func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]*provision.AppInternalAddress, error) {
-	return []*provision.AppInternalAddress{
+func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]provision.AppInternalAddress, error) {
+	return []provision.AppInternalAddress{
 		{
 			Domain:   fmt.Sprintf("%s-web.fake-cluster.local", a.GetName()),
 			Port:     80,

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -5,6 +5,7 @@
 package provisiontest
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,6 +36,7 @@ var (
 	uniqueIpCounter     int32 = 0
 
 	_ provision.NodeProvisioner      = &FakeProvisioner{}
+	_ provision.InterAppProvisioner  = &FakeProvisioner{}
 	_ provision.UpdatableProvisioner = &FakeProvisioner{}
 	_ provision.Provisioner          = &FakeProvisioner{}
 	_ provision.App                  = &FakeApp{}
@@ -1373,6 +1375,22 @@ func (p *FakeProvisioner) UpdateApp(old, new provision.App, w io.Writer) error {
 	provApp.app = new
 	p.apps[old.GetName()] = provApp
 	return nil
+}
+
+func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]*provision.AppInternalAddress, error) {
+	return []*provision.AppInternalAddress{
+		{
+			Domain:   fmt.Sprintf("%s-web.fake-cluster.local", a.GetName()),
+			Port:     80,
+			Protocol: "TCP",
+		},
+		{
+			Domain:   fmt.Sprintf("%s-logs.fake-cluster.local", a.GetName()),
+			Port:     12201,
+			Protocol: "UDP",
+		},
+	}, nil
+
 }
 
 func stringInArray(value string, array []string) bool {


### PR DESCRIPTION
Implementation of issue: #2295 

- [x] Initial draft
- [x] Discover app processes
- [x] Tests and mocks
- [x] integrate new provisioner method in HTTP API `GET /apps/:appName`
- [ ] create merge-request to `tsuru-client` using new API.