### PR TITLE
app: no error on app create when log db unavailable

### DIFF
--- a/app/actions.go
+++ b/app/actions.go
@@ -120,12 +120,11 @@ func createApp(app *App) error {
 	}
 
 	logConn, err := db.LogConn()
-	if err != nil {
-		return err
+	if err == nil {
+		defer logConn.Close()
+		logConn.CreateAppLogCollection(app.Name)
 	}
-	defer logConn.Close()
-	_, err = logConn.CreateAppLogCollection(app.Name)
-	return err
+	return nil
 }
 
 func removeApp(app *App) error {

--- a/app/app.go
+++ b/app/app.go
@@ -1772,7 +1772,11 @@ func (app *App) Log(message, source, unit string) error {
 			return err
 		}
 		defer conn.Close()
-		return conn.AppLogCollection(app.Name).Insert(logs...)
+		coll, err := conn.CreateAppLogCollection(app.Name)
+		if err != nil {
+			return err
+		}
+		return coll.Insert(logs...)
 	}
 	return nil
 }

--- a/app/log.go
+++ b/app/log.go
@@ -319,7 +319,11 @@ func (d *appLogDispatcher) flush(msgs []interface{}, lastMessage *msgWithTS) err
 		log.Errorf("[log flusher] unable to connect to mongodb: %s", err)
 		return err
 	}
-	coll := conn.AppLogCollection(d.appName)
+	coll, err := conn.CreateAppLogCollection(d.appName)
+	if err != nil {
+		log.Errorf("[log flusher] unable to create collection in mongodb: %s", err)
+		return err
+	}
 	err = coll.Insert(msgs...)
 	coll.Close()
 	if err != nil {


### PR DESCRIPTION
This commit also ensures that we retry collection creation before Insert
operations in the log database.