### PR TITLE
provision/kubernetes: use node informer for node listing

### DIFF
--- a/provision/kubernetes/node.go
+++ b/provision/kubernetes/node.go
@@ -94,3 +94,7 @@ func (n *kubernetesNodeWrapper) ip() string {
 	}
 	return tsuruNet.URLToHost(n.Address())
 }
+
+func (n *kubernetesNodeWrapper) RawNode() *apiv1.Node {
+	return n.node
+}

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -41,6 +41,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/remotecommand"
 )
@@ -95,26 +96,6 @@ func (s *S) TestListNodesFilteringByAddress(c *check.C) {
 	nodes, err := s.p.ListNodes([]string{"192.168.99.1"})
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
-}
-
-func (s *S) TestListNodesTimeoutShort(c *check.C) {
-	wantedTimeout := 1.0
-	config.Set("kubernetes:api-short-timeout", wantedTimeout)
-	defer config.Unset("kubernetes")
-	block := make(chan bool)
-	blackhole := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-block
-	}))
-	defer func() { close(block); blackhole.Close() }()
-	s.mock.MockfakeNodes(c, blackhole.URL)
-	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
-	err := app.CreateApp(a, s.user)
-	c.Assert(err, check.IsNil)
-	t0 := time.Now()
-	ClientForConfig = defaultClientForConfig
-	_, err = s.p.ListNodes([]string{})
-	c.Assert(err, check.ErrorMatches, `(?is).*timeout.*`)
-	c.Assert(time.Since(t0) < time.Duration(wantedTimeout*float64(3*time.Second)), check.Equals, true)
 }
 
 func (s *S) TestRemoveNode(c *check.C) {
@@ -300,15 +281,17 @@ func (s *S) TestUpdateNode(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Pool:    "p2",
-		Metadata: map[string]string{
-			"m1": "",
-			"m2": "v2",
-		},
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Pool:    "p2",
+			Metadata: map[string]string{
+				"m1": "",
+				"m2": "v2",
+			},
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -336,15 +319,17 @@ func (s *S) TestUpdateNodeWithIaaSID(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Pool:    "p2",
-		Metadata: map[string]string{
-			"m1": "",
-			"m2": "v2",
-		},
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Pool:    "p2",
+			Metadata: map[string]string{
+				"m1": "",
+				"m2": "v2",
+			},
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -390,12 +375,14 @@ func (s *S) TestUpdateNodeWithIaaSIDPreviousEmpty(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = s.p.AddNode(provision.AddNodeOptions{
-		Address: "my-node-addr",
-		Pool:    "p2",
-		IaaSID:  "valid-iaas-id",
+	s.waitNodeUpdate(c, func() {
+		err = s.p.AddNode(provision.AddNodeOptions{
+			Address: "my-node-addr",
+			Pool:    "p2",
+			IaaSID:  "valid-iaas-id",
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -416,14 +403,16 @@ func (s *S) TestUpdateNodeNoPool(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Metadata: map[string]string{
-			"m1": "",
-			"m2": "v2",
-		},
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Metadata: map[string]string{
+				"m1": "",
+				"m2": "v2",
+			},
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -459,13 +448,15 @@ func (s *S) TestUpdateNodeRemoveInProgressTaint(c *check.C) {
 	})
 	_, err = s.client.CoreV1().Nodes().Update(n1)
 	c.Assert(err, check.IsNil)
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Pool:    "p2",
-		Metadata: map[string]string{
-			"m1": "",
-			"m2": "v2",
-		},
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Pool:    "p2",
+			Metadata: map[string]string{
+				"m1": "",
+				"m2": "v2",
+			},
+		})
 	})
 	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
@@ -492,11 +483,13 @@ func (s *S) TestUpdateNodeToggleDisableTaint(c *check.C) {
 		Pool:    "p1",
 	})
 	c.Assert(err, check.IsNil)
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Disable: true,
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Disable: true,
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err := s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -516,11 +509,13 @@ func (s *S) TestUpdateNodeToggleDisableTaint(c *check.C) {
 	c.Assert(nodes[0].(*kubernetesNodeWrapper).node.Spec.Taints, check.DeepEquals, []apiv1.Taint{
 		{Key: "tsuru.io/disabled", Effect: apiv1.TaintEffectNoSchedule},
 	})
-	err = s.p.UpdateNode(provision.UpdateNodeOptions{
-		Address: "my-node-addr",
-		Enable:  true,
+	s.waitNodeUpdate(c, func() {
+		err = s.p.UpdateNode(provision.UpdateNodeOptions{
+			Address: "my-node-addr",
+			Enable:  true,
+		})
+		c.Assert(err, check.IsNil)
 	})
-	c.Assert(err, check.IsNil)
 	nodes, err = s.p.ListNodes(nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, 1)
@@ -608,28 +603,25 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 	s.mock.MockfakeNodes(c, srv.URL)
 	for _, a := range []provision.App{a1, a2} {
 		for i := 1; i <= 2; i++ {
-			_, err := s.client.CoreV1().Pods("default").Create(&apiv1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%d", a.GetName(), i),
-					Labels: map[string]string{
-						"tsuru.io/app-name":     a.GetName(),
-						"tsuru.io/app-process":  "web",
-						"tsuru.io/app-platform": "python",
+			s.waitPodUpdate(c, func() {
+				_, err := s.client.CoreV1().Pods("default").Create(&apiv1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("%s-%d", a.GetName(), i),
+						Labels: map[string]string{
+							"tsuru.io/app-name":     a.GetName(),
+							"tsuru.io/app-process":  "web",
+							"tsuru.io/app-platform": "python",
+						},
+						Namespace: "default",
 					},
-					Namespace: "default",
-				},
-				Spec: apiv1.PodSpec{
-					NodeName: fmt.Sprintf("n%d", i),
-				},
+					Spec: apiv1.PodSpec{
+						NodeName: fmt.Sprintf("n%d", i),
+					},
+				})
+				c.Assert(err, check.IsNil)
 			})
-			c.Assert(err, check.IsNil)
 		}
 	}
-	listNodesCalls := 0
-	s.client.PrependReactor("list", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
-		listNodesCalls++
-		return testing.RunReactionsAfter(&s.client.Fake, action)
-	})
 	_, err := s.client.CoreV1().Services("default").Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-web",
@@ -661,7 +653,6 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 	units, err := s.p.Units(a1, a2)
 	c.Assert(err, check.IsNil)
 	c.Assert(units, check.HasLen, 4)
-	c.Assert(listNodesCalls, check.Equals, 1)
 	sort.Slice(units, func(i, j int) bool {
 		return units[i].ID < units[j].ID
 	})
@@ -746,14 +737,16 @@ func (s *S) TestUnitsSkipTerminating(c *check.C) {
 	podlist, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(podlist.Items), check.Equals, 2)
-	for _, p := range podlist.Items {
-		if p.Labels["tsuru.io/app-process"] == "worker" {
-			deadline := int64(10)
-			p.Spec.ActiveDeadlineSeconds = &deadline
-			_, err = s.client.CoreV1().Pods("default").Update(&p)
-			c.Assert(err, check.IsNil)
+	s.waitPodUpdate(c, func() {
+		for _, p := range podlist.Items {
+			if p.Labels["tsuru.io/app-process"] == "worker" {
+				deadline := int64(10)
+				p.Spec.ActiveDeadlineSeconds = &deadline
+				_, err = s.client.CoreV1().Pods("default").Update(&p)
+				c.Assert(err, check.IsNil)
+			}
 		}
-	}
+	})
 	units, err := s.p.Units(a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
@@ -781,14 +774,16 @@ func (s *S) TestUnitsSkipEvicted(c *check.C) {
 	podlist, err := s.client.CoreV1().Pods(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(podlist.Items), check.Equals, 2)
-	for _, p := range podlist.Items {
-		if p.Labels["tsuru.io/app-process"] == "worker" {
-			p.Status.Phase = apiv1.PodFailed
-			p.Status.Reason = "Evicted"
-			_, err = s.client.CoreV1().Pods("default").Update(&p)
-			c.Assert(err, check.IsNil)
+	s.waitPodUpdate(c, func() {
+		for _, p := range podlist.Items {
+			if p.Labels["tsuru.io/app-process"] == "worker" {
+				p.Status.Phase = apiv1.PodFailed
+				p.Status.Reason = "Evicted"
+				_, err = s.client.CoreV1().Pods("default").Update(&p)
+				c.Assert(err, check.IsNil)
+			}
 		}
-	}
+	})
 	units, err := s.p.Units(a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
@@ -2012,7 +2007,6 @@ func (s *S) TestGetKubeConfig(c *check.C) {
 	config.Set("kubernetes:deploy-sidecar-image", "img1")
 	config.Set("kubernetes:deploy-inspect-image", "img2")
 	config.Set("kubernetes:api-timeout", 10)
-	config.Set("kubernetes:api-short-timeout", 0.5)
 	config.Set("kubernetes:pod-ready-timeout", 6)
 	config.Set("kubernetes:pod-running-timeout", 2*60)
 	config.Set("kubernetes:deployment-progress-timeout", 3*60)
@@ -2024,7 +2018,6 @@ func (s *S) TestGetKubeConfig(c *check.C) {
 		DeploySidecarImage:                  "img1",
 		DeployInspectImage:                  "img2",
 		APITimeout:                          10 * time.Second,
-		APIShortTimeout:                     500 * time.Millisecond,
 		PodReadyTimeout:                     6 * time.Second,
 		PodRunningTimeout:                   2 * time.Minute,
 		DeploymentProgressTimeout:           3 * time.Minute,
@@ -2040,7 +2033,6 @@ func (s *S) TestGetKubeConfigDefaults(c *check.C) {
 		DeploySidecarImage:                  "tsuru/deploy-agent:0.8.3",
 		DeployInspectImage:                  "tsuru/deploy-agent:0.8.3",
 		APITimeout:                          60 * time.Second,
-		APIShortTimeout:                     5 * time.Second,
 		PodReadyTimeout:                     time.Minute,
 		PodRunningTimeout:                   10 * time.Minute,
 		DeploymentProgressTimeout:           10 * time.Minute,
@@ -2306,6 +2298,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeOtherCluster(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	s.client = client2
+	s.factory = informers.NewSharedInformerFactory(s.client, 1)
 	s.mock = testing.NewKubeMock(s.client, s.p, s.factory)
 	s.mock.IgnorePool = true
 	s.client.ApiExtensionsClientset.PrependReactor("create", "customresourcedefinitions", s.mock.CRDReaction(c))
@@ -2372,6 +2365,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeWithTwoBindsOtherCluster(c *check.
 	})
 	c.Assert(err, check.IsNil)
 	s.client = client2
+	s.factory = informers.NewSharedInformerFactory(s.client, 1)
 	s.mock = testing.NewKubeMock(s.client, s.p, s.factory)
 	s.mock.IgnorePool = true
 	s.mock.IgnoreAppName = true

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -6,7 +6,10 @@ package kubernetes
 
 import (
 	"math/rand"
+	"reflect"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app"
@@ -27,8 +30,10 @@ import (
 	"github.com/tsuru/tsuru/types/quota"
 	"golang.org/x/crypto/bcrypt"
 	check "gopkg.in/check.v1"
+	apiv1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -51,7 +56,6 @@ type S struct {
 
 var suiteInstance = &S{}
 var _ = check.Suite(suiteInstance)
-var defaultClientForConfig = ClientForConfig
 
 func Test(t *testing.T) {
 	suiteInstance.t = t
@@ -185,5 +189,40 @@ func (s *S) SetUpTest(c *check.C) {
 			ret[pool] = *clust
 		}
 		return ret, nil
+	}
+}
+
+func (s *S) waitNodeUpdate(c *check.C, fn func()) {
+	s.mock.WaitNodeUpdate(c, fn)
+}
+
+func sortPods(pods []*apiv1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+}
+
+func (s *S) waitPodUpdate(c *check.C, fn func()) {
+	controller, err := getClusterController(s.p, s.clusterClient)
+	c.Assert(err, check.IsNil)
+	podInformer, err := controller.getPodInformer()
+	c.Assert(err, check.IsNil)
+	pods, err := podInformer.Lister().List(labels.Everything())
+	c.Assert(err, check.IsNil)
+	fn()
+	timeout := time.After(5 * time.Second)
+	for {
+		podsAfter, err := podInformer.Lister().List(labels.Everything())
+		c.Assert(err, check.IsNil)
+		sortPods(pods)
+		sortPods(podsAfter)
+		if !reflect.DeepEqual(pods, podsAfter) {
+			return
+		}
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-timeout:
+			c.Fatal("timeout waiting for node changes")
+		}
 	}
 }


### PR DESCRIPTION
We already had a node informer instance we just didn't use it everywhere yet. This PR changes this, now it's used everywhere we need to list nodes. This was made to address performance problems in /nodes calls which should be much faster now.
This change had an annoying impact on tests though. We must wait for a while after calls to Create()/Update() a node since these changes must be received by the informer loop and the in-memory cache updated. Some helper test functions were created to make waiting these changes easier.