### PR TITLE
api/tracker,event: add instance information from tracker to created events

### DIFF
--- a/api/tracker/tracker_test.go
+++ b/api/tracker/tracker_test.go
@@ -6,7 +6,6 @@ package tracker
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/tsuru/config"
@@ -25,9 +24,6 @@ var _ = check.Suite(&S{})
 func (s *S) SetUpSuite(c *check.C) {
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "api_tracker_pkg_tests")
-	if runtime.GOOS == "darwin" {
-		config.Set("tracker:interface", "en0")
-	}
 }
 
 func (s *S) TearDownSuite(c *check.C) {
@@ -53,4 +49,14 @@ func (s *S) Test_InstanceService(c *check.C) {
 	c.Assert(instances, check.HasLen, 1)
 	c.Assert(instances[0].Name, check.Not(check.Equals), "")
 	c.Assert(len(instances[0].Addresses) > 0, check.Equals, true)
+}
+
+func (s *S) Test_InstanceService_CurrentInstance(c *check.C) {
+	svc, err := InstanceService()
+	c.Assert(err, check.IsNil)
+	svc.(*instanceTracker).Shutdown(context.Background())
+	instance, err := svc.CurrentInstance()
+	c.Assert(err, check.IsNil)
+	c.Assert(instance.Name, check.Not(check.Equals), "")
+	c.Assert(len(instance.Addresses) > 0, check.Equals, true)
 }

--- a/applog/aggregator_test.go
+++ b/applog/aggregator_test.go
@@ -28,6 +28,10 @@ func (m *mockInstanceService) LiveInstances() ([]tracker.TrackedInstance, error)
 	return m.instances, nil
 }
 
+func (m *mockInstanceService) CurrentInstance() (tracker.TrackedInstance, error) {
+	return tracker.TrackedInstance{}, nil
+}
+
 func mockServers(count int, hook func(i int, w http.ResponseWriter, r *http.Request) bool) func() {
 	instanceTracker := &mockInstanceService{}
 	srvs := make([]*httptest.Server, count)

--- a/event/event.go
+++ b/event/event.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	permTypes "github.com/tsuru/tsuru/types/permission"
+	"github.com/tsuru/tsuru/types/tracker"
 )
 
 var (
@@ -210,6 +211,7 @@ type eventData struct {
 	Running         bool
 	Allowed         AllowedPermission
 	AllowedCancel   AllowedPermission
+	Instance        tracker.TrackedInstance
 }
 
 type cancelInfo struct {
@@ -898,6 +900,10 @@ func newEvt(opts *Opts) (evt *Event, err error) {
 	} else {
 		id.Target = opts.Target
 	}
+	instance, err := servicemanager.InstanceTracker.CurrentInstance()
+	if err != nil {
+		return nil, err
+	}
 	evt = &Event{eventData: eventData{
 		ID:              id,
 		UniqueID:        uniqID,
@@ -912,6 +918,7 @@ func newEvt(opts *Opts) (evt *Event, err error) {
 		Cancelable:      opts.Cancelable,
 		Allowed:         opts.Allowed,
 		AllowedCancel:   opts.AllowedCancel,
+		Instance:        instance,
 	}}
 	evt.Init()
 	maxRetries := 1

--- a/event/migrate/migrate_test.go
+++ b/event/migrate/migrate_test.go
@@ -161,6 +161,7 @@ func (s *S) checkEvtMatch(evt *event.Event, c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(evts, check.HasLen, 1)
 	evt.ID = evts[0].ID
+	evt.Instance = evts[0].Instance
 	c.Assert(&evts[0], check.DeepEquals, evt)
 
 }

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
+	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	eventTypes "github.com/tsuru/tsuru/types/event"
 	permTypes "github.com/tsuru/tsuru/types/permission"
@@ -44,6 +45,7 @@ func (s *S) SetUpTest(c *check.C) {
 	svc, err := WebhookService()
 	c.Assert(err, check.IsNil)
 	s.service = svc.(*webhookService)
+	servicemock.SetMockService(&servicemock.MockService{})
 }
 
 func (s *S) TearDownTest(c *check.C) {

--- a/healer/suite_test.go
+++ b/healer/suite_test.go
@@ -14,6 +14,7 @@ import (
 	iaasTesting "github.com/tsuru/tsuru/iaas/testing"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	"github.com/tsuru/tsuru/router/routertest"
+	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	check "gopkg.in/check.v1"
 )
 
@@ -35,6 +36,7 @@ func (s *S) SetUpSuite(c *check.C) {
 }
 
 func (s *S) SetUpTest(c *check.C) {
+	servicemock.SetMockService(&servicemock.MockService{})
 	config.Unset("iaas:node-protocol")
 	config.Unset("iaas:node-port")
 	HealerInstance = nil

--- a/provision/docker/healer/suite_test.go
+++ b/provision/docker/healer/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tsuru/tsuru/db/dbtest"
 	"github.com/tsuru/tsuru/iaas"
 	"github.com/tsuru/tsuru/queue"
+	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	check "gopkg.in/check.v1"
 )
 
@@ -55,6 +56,7 @@ func (s *S) SetUpTest(c *check.C) {
 		m.Destroy()
 	}
 	os.Setenv("TSURU_TARGET", "http://localhost")
+	servicemock.SetMockService(&servicemock.MockService{})
 }
 
 func (s *S) TearDownTest(c *check.C) {

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/router/routertest"
+	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	check "gopkg.in/check.v1"
@@ -42,6 +43,7 @@ func (s *S) SetUpSuite(c *check.C) {
 }
 
 func (s *S) SetUpTest(c *check.C) {
+	servicemock.SetMockService(&servicemock.MockService{})
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)
 	defer conn.Close()

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	"github.com/tsuru/tsuru/types/service"
+	"github.com/tsuru/tsuru/types/tracker"
 )
 
 // MockService is a struct to use in tests
@@ -27,6 +28,7 @@ type MockService struct {
 	Cluster                   *provision.MockClusterService
 	ServiceBroker             *service.MockServiceBrokerService
 	ServiceBrokerCatalogCache *service.MockServiceBrokerCatalogCacheService
+	InstanceTracker           tracker.InstanceService
 }
 
 // SetMockService return a new MockService and set as a servicemanager
@@ -41,6 +43,7 @@ func SetMockService(m *MockService) {
 	m.Cluster = &provision.MockClusterService{}
 	m.ServiceBroker = &service.MockServiceBrokerService{}
 	m.ServiceBrokerCatalogCache = &service.MockServiceBrokerCatalogCacheService{}
+	m.InstanceTracker = &tracker.MockInstanceService{}
 	servicemanager.AppCache = m.Cache
 	servicemanager.Plan = m.Plan
 	servicemanager.Platform = m.Platform
@@ -51,6 +54,7 @@ func SetMockService(m *MockService) {
 	servicemanager.Cluster = m.Cluster
 	servicemanager.ServiceBroker = m.ServiceBroker
 	servicemanager.ServiceBrokerCatalogCache = m.ServiceBrokerCatalogCache
+	servicemanager.InstanceTracker = m.InstanceTracker
 }
 
 func (m *MockService) ResetCache() {

--- a/types/tracker/tracker.go
+++ b/types/tracker/tracker.go
@@ -16,6 +16,7 @@ type TrackedInstance struct {
 
 type InstanceService interface {
 	LiveInstances() ([]TrackedInstance, error)
+	CurrentInstance() (TrackedInstance, error)
 }
 
 type InstanceStorage interface {

--- a/types/tracker/tracker_mock.go
+++ b/types/tracker/tracker_mock.go
@@ -1,0 +1,27 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tracker
+
+var _ InstanceService = &MockInstanceService{}
+
+// MockInstanceService implements InstanceService interface
+type MockInstanceService struct {
+	OnLiveInstances   func() ([]TrackedInstance, error)
+	OnCurrentInstance func() (TrackedInstance, error)
+}
+
+func (m *MockInstanceService) LiveInstances() ([]TrackedInstance, error) {
+	if m.OnLiveInstances != nil {
+		return m.OnLiveInstances()
+	}
+	return []TrackedInstance{}, nil
+}
+
+func (m *MockInstanceService) CurrentInstance() (TrackedInstance, error) {
+	if m.OnCurrentInstance != nil {
+		return m.OnCurrentInstance()
+	}
+	return TrackedInstance{Name: "hostname", Addresses: []string{"127.0.0.1"}}, nil
+}


### PR DESCRIPTION
This could make it easier to debug pending/frozen events.