### PR TITLE
read user quota permission + fix security problem

### DIFF
--- a/api/quota.go
+++ b/api/quota.go
@@ -28,11 +28,11 @@ import (
 //   401: Unauthorized
 //   404: User not found
 func getUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) error {
-	allowed := permission.Check(t, permission.PermUserUpdateQuota)
+	email := r.URL.Query().Get(":email")
+	allowed := permission.Check(t, permission.PermUserReadQuota, permission.Context(permTypes.CtxUser, email))
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	email := r.URL.Query().Get(":email")
 	user, err := auth.GetUserByEmail(email)
 	if err == authTypes.ErrUserNotFound {
 		return &errors.HTTP{
@@ -59,7 +59,7 @@ func getUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //   404: User not found
 func changeUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	email := r.URL.Query().Get(":email")
-	allowed := permission.Check(t, permission.PermUserUpdateQuota, permission.Context(permTypes.CtxUser, email))
+	allowed := permission.Check(t, permission.PermUserUpdateQuota)
 	if !allowed {
 		return permission.ErrUnauthorized
 	}

--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -63,6 +63,9 @@ func (s *QuotaSuite) SetUpTest(c *check.C) {
 	}, permission.Permission{
 		Scheme:  permission.PermUserUpdateQuota,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
+	}, permission.Permission{
+		Scheme:  permission.PermUserReadQuota,
+		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
 	var err error
 	s.user, err = auth.ConvertNewUser(s.token.User())

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -214,6 +214,7 @@ var (
 	PermUserDelete                       = PermissionRegistry.get("user.delete")                         // [global user]
 	PermUserRead                         = PermissionRegistry.get("user.read")                           // [global user]
 	PermUserReadEvents                   = PermissionRegistry.get("user.read.events")                    // [global user]
+	PermUserReadQuota                    = PermissionRegistry.get("user.read.quota")                     // [global user]
 	PermUserUpdate                       = PermissionRegistry.get("user.update")                         // [global user]
 	PermUserUpdateKey                    = PermissionRegistry.get("user.update.key")                     // [global user]
 	PermUserUpdateKeyAdd                 = PermissionRegistry.get("user.update.key.add")                 // [global user]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -116,6 +116,7 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 ).add(
 	"user.delete",
 	"user.read.events",
+	"user.read.quota",
 	"user.update.token",
 	"user.update.quota",
 	"user.update.password",


### PR DESCRIPTION
When I was working on issue #2239 , I found a security problem: Any user could update his/her own quota and no permission is required. This should be true about reading my own quota but not about changing it. So I did these steps:

* Added a user.read.quota permission
* Moved user/email context check from changeUserQuota to getUserQuota function
* Updated the tests