### PR TITLE
router/api: expand env var on custom header value

### DIFF
--- a/router/api/router.go
+++ b/router/api/router.go
@@ -119,8 +119,8 @@ func createRouter(routerName, configPrefix string) (router.Router, error) {
 			if !okK || !okV {
 				return nil, errors.Errorf("invalid header configuration: %v. Expected string got %s and %s", headers, k, v)
 			}
-			value, _ := config.Get(fmt.Sprintf("%s:headers:%s", configPrefix, k))
-			headerMap[k] = value.(string)
+			value, _ := config.GetString(fmt.Sprintf("%s:headers:%s", configPrefix, k))
+			headerMap[k] = value
 		}
 	}
 	baseRouter := &apiRouter{

--- a/router/api/router.go
+++ b/router/api/router.go
@@ -119,7 +119,8 @@ func createRouter(routerName, configPrefix string) (router.Router, error) {
 			if !okK || !okV {
 				return nil, errors.Errorf("invalid header configuration: %v. Expected string got %s and %s", headers, k, v)
 			}
-			headerMap[k] = v
+			value, _ := config.Get(fmt.Sprintf("%s:headers:%s", configPrefix, k))
+			headerMap[k] = value.(string)
 		}
 	}
 	baseRouter := &apiRouter{


### PR DESCRIPTION
Fixes not expanded env var on custom header value