### PR TITLE
all: Remove legacy lock system in favor of internal events

### DIFF
--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tsuru/tsuru/repository/repositorytest"
 	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
-	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	permTypes "github.com/tsuru/tsuru/types/permission"
 	"github.com/tsuru/tsuru/types/quota"
@@ -448,7 +447,7 @@ func (s *QuotaSuite) TestChangeAppQuotaAppNotFound(c *check.C) {
 	handler := RunServer(true)
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusNotFound)
-	c.Assert(recorder.Body.String(), check.Equals, appTypes.ErrAppNotFound.Error()+"\n")
+	c.Assert(recorder.Body.String(), check.Equals, "App shangrila not found.\n")
 }
 
 func (s *QuotaSuite) TestChangeAppQuotaLimitLowerThanAllocated(c *check.C) {

--- a/api/server.go
+++ b/api/server.go
@@ -234,8 +234,7 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.0", "Delete", "/apps/{app}/env", AuthorizationRequiredHandler(unsetEnv))
 	m.Add("1.0", "Get", "/apps", AuthorizationRequiredHandler(appList))
 	m.Add("1.0", "Post", "/apps", AuthorizationRequiredHandler(createApp))
-	forceDeleteLockHandler := AuthorizationRequiredHandler(forceDeleteLock)
-	m.Add("1.0", "Delete", "/apps/{app}/lock", forceDeleteLockHandler)
+	m.Add("1.0", "Delete", "/apps/{app}/lock", AuthorizationRequiredHandler(forceDeleteLock))
 	m.Add("1.0", "Put", "/apps/{app}/units", AuthorizationRequiredHandler(addUnits))
 	m.Add("1.0", "Delete", "/apps/{app}/units", AuthorizationRequiredHandler(removeUnits))
 	registerUnitHandler := AuthorizationRequiredHandler(registerUnit)
@@ -496,14 +495,6 @@ func RunServer(dry bool) http.Handler {
 	n.Use(negroni.HandlerFunc(errorHandlingMiddleware))
 	n.Use(negroni.HandlerFunc(setVersionHeadersMiddleware))
 	n.Use(negroni.HandlerFunc(authTokenMiddleware))
-	n.Use(&appLockMiddleware{excludedHandlers: []http.Handler{
-		logPostHandler,
-		runHandler,
-		forceDeleteLockHandler,
-		registerUnitHandler,
-		setUnitStatusHandler,
-		diffDeployHandler,
-	}})
 	n.UseHandler(http.HandlerFunc(runDelayedHandler))
 
 	if !dry {

--- a/misc/check-events.sh
+++ b/misc/check-events.sh
@@ -10,6 +10,7 @@ github.com/tsuru/tsuru/api.addLog
 github.com/tsuru/tsuru/api.logout
 github.com/tsuru/tsuru/api.login
 github.com/tsuru/tsuru/api.samlCallbackLogin
+github.com/tsuru/tsuru/api.forceDeleteLock
 EOF
 )
 ignored=$(echo "$ignored" | sort)

--- a/misc/check-handlers.sh
+++ b/misc/check-handlers.sh
@@ -52,6 +52,7 @@ github.com/tsuru/tsuru/api.nodeContainerInfo
 github.com/tsuru/tsuru/api.nodeContainerList
 github.com/tsuru/tsuru/api.nodeHealingRead
 github.com/tsuru/tsuru/api.tokenList
+github.com/tsuru/tsuru/api.forceDeleteLock
 github.com/tsuru/tsuru/provision/docker.bsConfigGetHandler
 github.com/tsuru/tsuru/provision/docker.logsConfigGetHandler
 github.com/tsuru/tsuru/provision/docker.bsEnvSetHandler

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -1,7 +1,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT!
 // Please run 'go generate' to update this file.
 //
-// Copyright 2018 tsuru authors. All rights reserved.
+// Copyright 2019 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -13,7 +13,6 @@ var (
 	PermAppAdmin                         = PermissionRegistry.get("app.admin")                           // [global app team pool]
 	PermAppAdminQuota                    = PermissionRegistry.get("app.admin.quota")                     // [global app team pool]
 	PermAppAdminRoutes                   = PermissionRegistry.get("app.admin.routes")                    // [global app team pool]
-	PermAppAdminUnlock                   = PermissionRegistry.get("app.admin.unlock")                    // [global app team pool]
 	PermAppBuild                         = PermissionRegistry.get("app.build")                           // [global app team pool]
 	PermAppCreate                        = PermissionRegistry.get("app.create")                          // [global team]
 	PermAppDelete                        = PermissionRegistry.get("app.delete")                          // [global app team pool]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -67,7 +67,6 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"app.delete",
 	"app.run",
 	"app.run.shell",
-	"app.admin.unlock",
 	"app.admin.routes",
 	"app.admin.quota",
 	"app.build",

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -239,18 +239,6 @@ type App interface {
 	SetQuotaInUse(int) error
 }
 
-type AppLock interface {
-	json.Marshaler
-
-	GetLocked() bool
-
-	GetReason() string
-
-	GetOwner() string
-
-	GetAcquireDate() time.Time
-}
-
 // RollbackableDeployer is a provisioner that allows rolling back to a
 // previously deployed version.
 type RollbackableDeployer interface {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -319,10 +319,6 @@ func (a *FakeApp) UnsetEnvs(unsetEnvs bind.UnsetEnvArgs) error {
 	return nil
 }
 
-func (a *FakeApp) GetLock() provision.AppLock {
-	return nil
-}
-
 func (a *FakeApp) GetUnits() ([]bind.Unit, error) {
 	units := make([]bind.Unit, len(a.units))
 	for i := range a.units {

--- a/router/api/routeriface.go
+++ b/router/api/routeriface.go
@@ -1,7 +1,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT!
 // Please run 'go generate' to update this file.
 //
-// Copyright 2017 tsuru authors. All rights reserved.
+// Copyright 2019 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/router/rebuild/rebuild.go
+++ b/router/rebuild/rebuild.go
@@ -26,8 +26,6 @@ type RebuildApp interface {
 	GetRouters() []appTypes.AppRouter
 	GetHealthcheckData() (routerTypes.HealthcheckData, error)
 	RoutableAddresses() ([]url.URL, error)
-	InternalLock(string) (bool, error)
-	Unlock()
 }
 
 func RebuildRoutes(app RebuildApp, dry bool) (map[string]RebuildRoutesResult, error) {
@@ -50,6 +48,15 @@ func rebuildRoutes(app RebuildApp, dry, wait bool) (map[string]RebuildRoutesResu
 		}
 	}
 	return result, multi.ToError()
+}
+
+func resultHasChanges(result map[string]RebuildRoutesResult) bool {
+	for _, routerResult := range result {
+		if len(routerResult.Added) > 0 || len(routerResult.Removed) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func diffRoutes(old []*url.URL, new []url.URL) (toAdd []*url.URL, toRemove []*url.URL) {

--- a/types/app/error.go
+++ b/types/app/error.go
@@ -58,14 +58,6 @@ func (err ManyTeamsError) Error() string {
 	return "You belong to more than one team, choose one to be owner for this app."
 }
 
-type ErrAppNotLocked struct {
-	App string
-}
-
-func (e ErrAppNotLocked) Error() string {
-	return fmt.Sprintf("unable to lock app %q", e.App)
-}
-
 type PlanValidationError struct {
 	Field string
 }

--- a/types/app/lock.go
+++ b/types/app/lock.go
@@ -5,8 +5,6 @@
 package app
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -16,45 +14,4 @@ type AppLock struct {
 	Reason      string
 	Owner       string
 	AcquireDate time.Time
-}
-
-func (l *AppLock) String() string {
-	if !l.Locked {
-		return "Not locked"
-	}
-	return fmt.Sprintf("App locked by %s, running %s. Acquired in %s",
-		l.Owner,
-		l.Reason,
-		l.AcquireDate.Format(time.RFC3339),
-	)
-}
-
-func (l *AppLock) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Locked      bool   `json:"Locked"`
-		Reason      string `json:"Reason"`
-		Owner       string `json:"Owner"`
-		AcquireDate string `json:"AcquireDate"`
-	}{
-		Locked:      l.Locked,
-		Reason:      l.Reason,
-		Owner:       l.Owner,
-		AcquireDate: l.AcquireDate.Format(time.RFC3339),
-	})
-}
-
-func (l *AppLock) GetLocked() bool {
-	return l.Locked
-}
-
-func (l *AppLock) GetReason() string {
-	return l.Reason
-}
-
-func (l *AppLock) GetOwner() string {
-	return l.Owner
-}
-
-func (l *AppLock) GetAcquireDate() time.Time {
-	return l.AcquireDate
 }


### PR DESCRIPTION
All handlers with side-effects are already protected by event locks, however we were still using the legacy app lock for some internal processes and had to maintain the app lock for consistency. This PR replaces all uses of the legacy app lock in internal processes for internal events. With this change there's no need for the app lock and it was removed.