### PR TITLE
Returns server version on: /info route

### DIFF
--- a/api/info.go
+++ b/api/info.go
@@ -7,6 +7,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/tsuru/tsuru/auth"
 )
 
 // title: api info
@@ -15,7 +17,7 @@ import (
 // produce: application/json
 // responses:
 //   200: OK
-func info(w http.ResponseWriter, r *http.Request) error {
+func info(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	data := map[string]string{}
 	data["version"] = Version
 	w.Header().Set("Content-Type", "application/json")

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -16,6 +16,7 @@ import (
 func (s *S) TestInfo(c *check.C) {
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest("GET", "/info", nil)
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	c.Assert(err, check.IsNil)
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)

--- a/api/server.go
+++ b/api/server.go
@@ -187,7 +187,7 @@ func RunServer(dry bool) http.Handler {
 	if disableIndex, _ := config.GetBool("disable-index-page"); !disableIndex {
 		m.Add("1.0", "Get", "/", Handler(index))
 	}
-	m.Add("1.0", "Get", "/info", Handler(info))
+	m.Add("1.0", "Get", "/info", AuthorizationRequiredHandler(info))
 
 	m.Add("1.0", "Get", "/services/instances", AuthorizationRequiredHandler(serviceInstances))
 	m.Add("1.0", "Get", "/services/{service}/instances/{instance}", AuthorizationRequiredHandler(serviceInstance))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -622,7 +622,7 @@ func versionString(manager *Manager) string {
 
 func apiVersionString(client *Client) (string, error) {
 	if client == nil {
-		return "", fmt.Errorf("Null Client Exception")
+		return "", fmt.Errorf("client cannot be nil")
 	}
 
 	url, err := GetURL("/info")
@@ -635,13 +635,10 @@ func apiVersionString(client *Client) (string, error) {
 		return "", err
 	}
 
-	serverVersionPrefix := "Server version: "
 	resp, err := client.Do(req)
 	if err != nil {
-		if isUnauthorized(err) {
-			return fmt.Sprintf("%s Can't retrieve server version, user %v", serverVersionPrefix, err), nil
-		}
-		return "", err
+		// if we return the error, stdout won't flush until the prompt
+		return fmt.Sprintf("Unable to retrieve server version: %v", err), nil
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -655,7 +652,7 @@ func apiVersionString(client *Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s%s\n", serverVersionPrefix, version["version"]), nil
+	return fmt.Sprintf("Server version: %s\n", version["version"]), nil
 }
 
 func (c *version) Run(context *Context, client *Client) error {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -642,7 +642,6 @@ func apiVersionString(client *Client) (string, error) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
 	if err != nil {
 		return "", err
 	}
@@ -652,7 +651,9 @@ func apiVersionString(client *Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Server version: %s\n", version["version"]), nil
+
+	resp.Body.Close()
+	return fmt.Sprintf("Server version: %s.\n", version["version"]), nil
 }
 
 func (c *version) Run(context *Context, client *Client) error {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -617,12 +617,12 @@ func versionString(manager *Manager) string {
 	if GitHash != "" {
 		suffix = fmt.Sprintf(" hash %s\n", GitHash)
 	}
-	return fmt.Sprintf("%s version %s.%s", manager.name, manager.version, suffix)
+	return fmt.Sprintf("Client version: %s.%s", manager.version, suffix)
 }
 
 func apiVersionString(client *Client) (string, error) {
 	if client == nil {
-		return "API Server not found", nil
+		return "Server not found", nil
 	}
 	url, err := GetURL("/info")
 	if err != nil {
@@ -652,7 +652,7 @@ func apiVersionString(client *Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("API Server version %s\n", version["version"]), nil
+	return fmt.Sprintf("Server version: %s\n", version["version"]), nil
 }
 
 func (c *version) Run(context *Context, client *Client) error {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1200,7 +1200,6 @@ func (s *S) TestVersionWithAPI(c *check.C) {
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Send response to be tested
 		rw.Write([]byte(`{"version":"1.7.4"}`))
 	}))
 	defer ts.Close()
@@ -1224,7 +1223,6 @@ func (s *S) TestVersionWithoutEnvVar(c *check.C) {
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Send response to be tested
 		rw.Write([]byte(`{"version":"1.7.4"}`))
 	}))
 	defer ts.Close()
@@ -1241,7 +1239,6 @@ func (s *S) TestVersionAPIInvalidURL(c *check.C) {
 	mngr := NewManager("tsuru", "5.0", "", &stdout, &stderr, os.Stdin, nil)
 	var exiter recordingExiter
 	mngr.e = &exiter
-	c.Assert(exiter.value(), check.Equals, 0)
 	command := version{manager: mngr}
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 
@@ -1251,6 +1248,7 @@ func (s *S) TestVersionAPIInvalidURL(c *check.C) {
 	os.Setenv("TSURU_TARGET", URL)
 	defer os.Unsetenv("TSURU_TARGET")
 	err := command.Run(&context, client)
+	c.Assert(exiter.value(), check.Equals, 0)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr.stdout.(*bytes.Buffer).String(),
 		check.Equals, "Client version: 5.0.\nUnable to retrieve server version: Failed to connect to tsuru server (notvalid.test), it's probably down.")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1203,6 +1203,7 @@ func (s *S) TestVersionWithAPI(c *check.C) {
 		// Send response to be tested
 		rw.Write([]byte(`{"version":"1.7.4"}`))
 	}))
+	defer ts.Close()
 
 	client := NewClient(&http.Client{}, &context, mngr)
 
@@ -1226,6 +1227,7 @@ func (s *S) TestVersionWithoutEnvVar(c *check.C) {
 		// Send response to be tested
 		rw.Write([]byte(`{"version":"1.7.4"}`))
 	}))
+	defer ts.Close()
 
 	client := NewClient(ts.Client(), &context, mngr)
 	err := command.Run(&context, client)
@@ -1239,18 +1241,14 @@ func (s *S) TestVersionAPIInvalidURL(c *check.C) {
 	mngr := NewManager("tsuru", "5.0", "", &stdout, &stderr, os.Stdin, nil)
 	var exiter recordingExiter
 	mngr.e = &exiter
+	c.Assert(exiter.value(), check.Equals, 0)
 	command := version{manager: mngr}
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// Send response to be tested
-		rw.Write([]byte(`{"version":"1.7.4"}`))
-	}))
-
 	client := NewClient(&http.Client{}, &context, mngr)
 
-	ts.URL = "notvalid.test"
-	os.Setenv("TSURU_TARGET", ts.URL)
+	URL := "notvalid.test"
+	os.Setenv("TSURU_TARGET", URL)
 	defer os.Unsetenv("TSURU_TARGET")
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1211,7 +1211,7 @@ func (s *S) TestVersionWithAPI(c *check.C) {
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr.stdout.(*bytes.Buffer).String(),
-		check.Equals, "Client version: 5.0.\nServer version: 1.7.4\n")
+		check.Equals, "Client version: 5.0.\nServer version: 1.7.4.\n")
 }
 
 func (s *S) TestVersionWithoutEnvVar(c *check.C) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -617,8 +617,8 @@ func (s *S) TestVersion(c *check.C) {
 	command := version{manager: mngr}
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 	err := command.Run(&context, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(mngr.stdout.(*bytes.Buffer).String(), check.Equals, "Client version: 5.0.\nServer not found")
+	c.Assert(err, check.ErrorMatches, "Null Client Exception")
+	c.Assert(mngr.stdout.(*bytes.Buffer).String(), check.Equals, "Client version: 5.0.\n")
 }
 
 func (s *S) TestDashDashVersion(c *check.C) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -132,7 +132,7 @@ func (s *S) TestImplicitTopicsHelp(c *check.C) {
 	command := help{manager: globalManager}
 	err := command.Run(&context, nil)
 	c.Assert(err, check.IsNil)
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 The following commands are available in the "foo" topic:
 
@@ -359,7 +359,7 @@ func (s *S) TestRunCommandThatDoesNotExist(c *check.C) {
 }
 
 func (s *S) TestHelp(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb command [args]
 
@@ -378,7 +378,7 @@ Use glb help <commandname> to get more information about a command.
 }
 
 func (s *S) TestHelpWithTopics(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb command [args]
 
@@ -404,7 +404,7 @@ Use glb help <topicname> to get more information about a topic.
 }
 
 func (s *S) TestHelpFromTopic(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Targets
 
@@ -436,7 +436,7 @@ func (s *S) TestHelpReturnErrorIfTheGivenCommandDoesNotExist(c *check.C) {
 }
 
 func (s *S) TestRunWithoutArgsShouldRunHelp(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb command [args]
 
@@ -451,7 +451,7 @@ Use glb help <commandname> to get more information about a command.
 }
 
 func (s *S) TestDashDashHelp(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb command [args]
 
@@ -466,7 +466,7 @@ Use glb help <commandname> to get more information about a command.
 }
 
 func (s *S) TestRunCommandWithDashHelp(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb foo
 
@@ -479,7 +479,7 @@ Foo do anything or nothing.
 }
 
 func (s *S) TestRunCommandWithDashH(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb foo
 
@@ -492,7 +492,7 @@ Foo do anything or nothing.
 }
 
 func (s *S) TestHelpShouldReturnHelpForACmd(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb foo
 
@@ -505,7 +505,7 @@ Foo do anything or nothing.
 }
 
 func (s *S) TestDashDashHelpShouldReturnHelpForACmd(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb foo
 
@@ -532,7 +532,7 @@ func (s *S) TestDuplicateHFlag(c *check.C) {
 }
 
 func (s *S) TestHelpFlaggedCommand(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb with-flags
 
@@ -550,7 +550,7 @@ Flags:
 }
 
 func (s *S) TestHelpFlaggedMultilineCommand(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: glb with-flags
 
@@ -569,7 +569,7 @@ Flags:
 }
 
 func (s *S) TestHelpDeprecatedCmd(c *check.C) {
-	expectedStdout := `glb version 1.0.
+	expectedStdout := `Client version: 1.0.
 
 Usage: glb foo
 
@@ -594,7 +594,7 @@ Foo do anything or nothing.
 func (s *S) TestHelpDeprecatedCmdWritesWarningFirst(c *check.C) {
 	expected := `WARNING: "bar" is deprecated. Showing help for "foo" instead.
 
-glb version 1.0.
+Client version: 1.0.
 
 Usage: glb foo
 
@@ -618,11 +618,11 @@ func (s *S) TestVersion(c *check.C) {
 	context := Context{[]string{}, mngr.stdout, mngr.stderr, mngr.stdin}
 	err := command.Run(&context, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(mngr.stdout.(*bytes.Buffer).String(), check.Equals, "tsuru version 5.0.\nAPI Server not found")
+	c.Assert(mngr.stdout.(*bytes.Buffer).String(), check.Equals, "Client version: 5.0.\nServer not found")
 }
 
 func (s *S) TestDashDashVersion(c *check.C) {
-	expected := "glb version 1.0.\n"
+	expected := "Client version: 1.0.\n"
 	globalManager.Run([]string{"--version"})
 	c.Assert(globalManager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
 }
@@ -654,7 +654,7 @@ func (cmd *ArgCmd) Run(ctx *Context, client *Client) error {
 }
 
 func (s *S) TestRunWrongArgsNumberShouldRunsHelpAndReturnStatus1(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 ERROR: wrong number of arguments.
 
@@ -672,7 +672,7 @@ Maximum # of arguments: 2
 }
 
 func (s *S) TestRunWithTooManyArguments(c *check.C) {
-	expected := `glb version 1.0.
+	expected := `Client version: 1.0.
 
 ERROR: wrong number of arguments.
 
@@ -690,7 +690,7 @@ Maximum # of arguments: 2
 }
 
 func (s *S) TestHelpShouldReturnUsageWithTheCommandName(c *check.C) {
-	expected := `tsuru version 1.0.
+	expected := `Client version: 1.0.
 
 Usage: tsuru foo
 
@@ -1211,7 +1211,7 @@ func (s *S) TestVersionWithAPI(c *check.C) {
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr.stdout.(*bytes.Buffer).String(),
-		check.Equals, "tsuru version 5.0.\nAPI Server version 1.7.4\n")
+		check.Equals, "Client version: 5.0.\nServer version: 1.7.4\n")
 }
 
 func (s *S) TestVersionWithoutEnvVar(c *check.C) {


### PR DESCRIPTION
Closes Issue #2257
tsuru --version now shows Server version as well as Client version. If it can't establish a connection to the server, it raises an error showing that the server is probably down.