### PR TITLE
Allow app update with no restart

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -471,6 +471,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 		RouterOpts:     ia.RouterOpts,
 	}
 	tags, _ := InputValues(r, "tag")
+	noRestart, _ := strconv.ParseBool(InputValue(r, "noRestart"))
 	updateData.Tags = append(updateData.Tags, tags...) // for compatibility
 	appName := r.URL.Query().Get(":appname")
 	a, err := getAppFromContext(appName, r)
@@ -491,6 +492,9 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 		wantedPerms = append(wantedPerms, permission.PermAppUpdatePlan)
 	}
 	if updateData.Pool != "" {
+		if noRestart {
+			return &errors.HTTP{Code: http.StatusBadRequest, Message: "You must restart the app when changing the pool."}
+		}
 		wantedPerms = append(wantedPerms, permission.PermAppUpdatePool)
 	}
 	if updateData.TeamOwner != "" {
@@ -546,7 +550,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	err = a.Update(app.UpdateAppArgs{
 		UpdateData:    updateData,
 		Writer:        evt,
-		ShouldRestart: false,
+		ShouldRestart: !noRestart,
 	})
 	if err == appTypes.ErrPlanNotFound {
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}

--- a/api/app.go
+++ b/api/app.go
@@ -543,7 +543,11 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	w.Header().Set("Content-Type", "application/x-json-stream")
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	evt.SetLogWriter(writer)
-	err = a.Update(updateData, evt)
+	err = a.Update(app.UpdateAppArgs{
+		UpdateData:    updateData,
+		Writer:        evt,
+		ShouldRestart: false,
+	})
 	if err == appTypes.ErrPlanNotFound {
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: err.Error()}
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -445,7 +445,7 @@ func (app *App) Update(args UpdateAppArgs) (err error) {
 			&provisionAppNewProvisioner,
 			&provisionAppAddUnits,
 			&destroyAppOldProvisioner)
-	} else if app.Plan != oldApp.Plan {
+	} else if app.Plan != oldApp.Plan && args.ShouldRestart {
 		actions = append(actions, &restartApp)
 	}
 	return action.NewPipeline(actions...).Execute(app, &oldApp, args.Writer)

--- a/app/app.go
+++ b/app/app.go
@@ -351,14 +351,20 @@ func (app *App) configureCreateRouters() error {
 	return nil
 }
 
+type UpdateAppArgs struct {
+	UpdateData    App
+	Writer        io.Writer
+	ShouldRestart bool
+}
+
 // Update changes informations of the application.
-func (app *App) Update(updateData App, w io.Writer) (err error) {
-	description := updateData.Description
-	planName := updateData.Plan.Name
-	poolName := updateData.Pool
-	teamOwner := updateData.TeamOwner
-	platform := updateData.Platform
-	tags := processTags(updateData.Tags)
+func (app *App) Update(args UpdateAppArgs) (err error) {
+	description := args.UpdateData.Description
+	planName := args.UpdateData.Plan.Name
+	poolName := args.UpdateData.Pool
+	teamOwner := args.UpdateData.TeamOwner
+	platform := args.UpdateData.Platform
+	tags := processTags(args.UpdateData.Tags)
 	oldApp := *app
 
 	if description != "" {
@@ -414,7 +420,7 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 		app.Platform = p
 		app.PlatformVersion = v
 	}
-	if updateData.UpdatePlatform {
+	if args.UpdateData.UpdatePlatform {
 		app.UpdatePlatform = true
 	}
 	err = app.validate()
@@ -442,7 +448,7 @@ func (app *App) Update(updateData App, w io.Writer) (err error) {
 	} else if app.Plan != oldApp.Plan {
 		actions = append(actions, &restartApp)
 	}
-	return action.NewPipeline(actions...).Execute(app, &oldApp, w)
+	return action.NewPipeline(actions...).Execute(app, &oldApp, args.Writer)
 }
 
 func validateVolumes(app *App) error {

--- a/app/app.go
+++ b/app/app.go
@@ -447,6 +447,8 @@ func (app *App) Update(args UpdateAppArgs) (err error) {
 			&destroyAppOldProvisioner)
 	} else if app.Plan != oldApp.Plan && args.ShouldRestart {
 		actions = append(actions, &restartApp)
+	} else if app.Pool != oldApp.Pool {
+		actions = append(actions, &restartApp)
 	}
 	return action.NewPipeline(actions...).Execute(app, &oldApp, args.Writer)
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4565,6 +4565,7 @@ func (s *S) TestUpdatePool(c *check.C) {
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(dbApp.Pool, check.Equals, "test2")
+	c.Assert(s.provisioner.Restarts(dbApp, ""), check.Equals, 1)
 }
 
 func (s *S) TestUpdatePoolOtherProv(c *check.C) {
@@ -4626,6 +4627,7 @@ func (s *S) TestUpdatePoolNotExists(c *check.C) {
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
 	c.Assert(dbApp.Pool, check.Equals, "test")
+	c.Assert(s.provisioner.Restarts(dbApp, ""), check.Equals, 0)
 }
 
 func (s *S) TestUpdatePoolWithBindedVolumeDifferentProvisioners(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4466,7 +4466,7 @@ func (s *S) TestUpdateAppWithInvalidName(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	updateData := App{Name: app.Name, Description: "bleble"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4478,7 +4478,7 @@ func (s *S) TestUpdateDescription(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "example", Description: "bleble"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4490,7 +4490,7 @@ func (s *S) TestUpdateAppPlatform(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "example", Platform: "heimerdinger"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4503,7 +4503,7 @@ func (s *S) TestUpdateAppPlatformWithVersion(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "example", Platform: "python:v3"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4525,7 +4525,7 @@ func (s *S) TestUpdateTeamOwner(c *check.C) {
 		return &authTypes.Team{Name: teamName}, nil
 	}
 	updateData := App{Name: "example", TeamOwner: teamName}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4537,7 +4537,7 @@ func (s *S) TestUpdateTeamOwnerNotExists(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "example", TeamOwner: "newowner"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "team not found")
 	dbApp, err := GetByName(app.Name)
@@ -4560,7 +4560,7 @@ func (s *S) TestUpdatePool(c *check.C) {
 	err = CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "test", Pool: "test2"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4597,7 +4597,7 @@ func (s *S) TestUpdatePoolOtherProv(c *check.C) {
 	c.Assert(p1.Provisioned(&app), check.Equals, true)
 	c.Assert(p2.Provisioned(&app), check.Equals, false)
 	updateData := App{Name: "test", Pool: "test2"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4621,7 +4621,7 @@ func (s *S) TestUpdatePoolNotExists(c *check.C) {
 	err = CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "test", Pool: "test2"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.Equals, pool.ErrPoolNotFound)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4666,7 +4666,7 @@ func (s *S) TestUpdatePoolWithBindedVolumeDifferentProvisioners(c *check.C) {
 	c.Assert(p1.Provisioned(&app), check.Equals, true)
 	c.Assert(p2.Provisioned(&app), check.Equals, false)
 	updateData := App{Name: "test", Pool: "test2"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.ErrorMatches, "can't change the provisioner of an app with binded volumes")
 }
 
@@ -4701,7 +4701,7 @@ func (s *S) TestUpdatePoolWithBindedVolumeSameProvisioner(c *check.C) {
 	c.Assert(p1.GetUnits(&app), check.HasLen, 1)
 	c.Assert(p1.Provisioned(&app), check.Equals, true)
 	updateData := App{Name: "test", Pool: "test2"}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 }
 
@@ -4721,7 +4721,7 @@ func (s *S) TestUpdatePlan(c *check.C) {
 	c.Assert(routertest.FakeRouter.HasBackend(a.Name), check.Equals, true)
 	c.Assert(routertest.HCRouter.HasBackend(a.Name), check.Equals, false)
 	updateData := App{Name: "my-test-app", Plan: appTypes.Plan{Name: "something"}}
-	err = a.Update(updateData, new(bytes.Buffer))
+	err = a.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -4749,7 +4749,7 @@ func (s *S) TestUpdatePlanWithConstraint(c *check.C) {
 	err = CreateApp(&a, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "my-test-app", Plan: appTypes.Plan{Name: "something"}}
-	err = a.Update(updateData, new(bytes.Buffer))
+	err = a.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.ErrorMatches, `App plan "something" is not allowed on pool "pool1"`)
 }
 
@@ -4768,7 +4768,7 @@ func (s *S) TestUpdatePlanNoRouteChange(c *check.C) {
 	s.provisioner.AddUnits(&a, 3, "web", nil)
 	c.Assert(routertest.FakeRouter.HasBackend(a.Name), check.Equals, true)
 	updateData := App{Name: "my-test-app", Plan: appTypes.Plan{Name: "something"}}
-	err = a.Update(updateData, new(bytes.Buffer))
+	err = a.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -4798,7 +4798,7 @@ func (s *S) TestUpdatePlanNotFound(c *check.C) {
 		return nil, appTypes.ErrPlanNotFound
 	}
 	updateData := App{Name: "my-test-app", Plan: appTypes.Plan{Name: "some-unknown-plan"}}
-	err := app.Update(updateData, new(bytes.Buffer))
+	err := app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.Equals, appTypes.ErrPlanNotFound)
 }
 
@@ -4826,7 +4826,7 @@ func (s *S) TestUpdatePlanRestartFailure(c *check.C) {
 	c.Assert(routertest.HCRouter.HasBackend(a.Name), check.Equals, false)
 	s.provisioner.PrepareFailure("Restart", fmt.Errorf("cannot restart app, I'm sorry"))
 	updateData := App{Name: "my-test-app", Routers: []appTypes.AppRouter{{Name: "fake-hc"}}, Plan: appTypes.Plan{Name: "something"}}
-	err = a.Update(updateData, new(bytes.Buffer))
+	err = a.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.NotNil)
 	dbApp, err := GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -4856,7 +4856,7 @@ func (s *S) TestUpdateIgnoresEmptyAndDuplicatedTags(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Tags: []string{"tag2 ", "  tag3  ", "", " tag3", "  "}}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4868,7 +4868,7 @@ func (s *S) TestUpdatePlatform(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{UpdatePlatform: true}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4880,7 +4880,7 @@ func (s *S) TestUpdateWithEmptyTagsRemovesAllTags(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Description: "ble", Tags: []string{}}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4892,7 +4892,7 @@ func (s *S) TestUpdateWithoutTagsKeepsOriginalTags(c *check.C) {
 	err := CreateApp(&app, s.user)
 	c.Assert(err, check.IsNil)
 	updateData := App{Description: "ble", Tags: nil}
-	err = app.Update(updateData, new(bytes.Buffer))
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(app.Name)
 	c.Assert(err, check.IsNil)
@@ -4923,7 +4923,7 @@ func (s *S) TestUpdateDescriptionPoolPlan(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.provisioner.AddUnits(&a, 3, "web", nil)
 	updateData := App{Name: "my-test-app", Plan: appTypes.Plan{Name: "something"}, Description: "bleble", Pool: "test2"}
-	err = a.Update(updateData, new(bytes.Buffer))
+	err = a.Update(UpdateAppArgs{UpdateData: updateData, Writer: new(bytes.Buffer)})
 	c.Assert(err, check.IsNil)
 	dbApp, err := GetByName(a.Name)
 	c.Assert(err, check.IsNil)
@@ -5216,7 +5216,7 @@ func (s *S) TestUpdateAppUpdatableProvisioner(c *check.C) {
 	err = app.AddUnits(1, "web", nil)
 	c.Assert(err, check.IsNil)
 	updateData := App{Name: "test", Description: "updated description"}
-	err = app.Update(updateData, nil)
+	err = app.Update(UpdateAppArgs{UpdateData: updateData, Writer: nil})
 	c.Assert(err, check.IsNil)
 	units, err := app.Units()
 	c.Assert(err, check.IsNil)
@@ -5265,7 +5265,7 @@ func (s *S) TestUpdateAppPoolWithInvalidConstraint(c *check.C) {
 		},
 		Blacklist: true,
 	})
-	err = app.Update(App{Pool: optsPool2.Name}, nil)
+	err = app.Update(UpdateAppArgs{UpdateData: App{Pool: optsPool2.Name}, Writer: nil})
 	c.Assert(err, check.NotNil)
 }
 


### PR DESCRIPTION
Now, if a user updates the app pool we must force its restart. That way, we make sure all units will be in the new pool. 

Also, the API now accepts the flag `noRestart` on the app update route, so the user can change the app plan without restarting it. The API returns a bad request error if a user tries to perform a pool update with the `noRestart` option.