### PR TITLE
integration: add option to disable pool for kubernetes masters

### DIFF
--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -390,6 +391,9 @@ func poolAdd() ExecFlow {
 				}
 				return true
 			})
+			if noPoolOnKubeMasters, _ := strconv.ParseBool(env.Get("no_pool_on_kube_masters")); noPoolOnKubeMasters {
+				nodeIPs = nil
+			}
 			c.Assert(ok, check.Equals, true, check.Commentf("nodes not ready after 2 minutes: %v - all nodes: %v", res, T("node-list").Run(env)))
 			for _, ip := range nodeIPs {
 				res = T("node-update", ip, "pool="+poolName).Run(env)


### PR DESCRIPTION
Add option to disable master hosts acting as a tsuru pool. Some components on integration test, eg hostcert node-container, lead to an odd behavior on some scenarios, like when API server runs on masters. When docker is restart on those nodes by hostcert and kubernetes API runs on same hosts it may cause next test on flow to fail.