### PR TITLE
app,router,provision: tcp only healthcheck for provisioners handling HC

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2393,8 +2393,19 @@ func (app *App) GetHealthcheckData() (routerTypes.HealthcheckData, error) {
 		return routerTypes.HealthcheckData{}, err
 	}
 	yamlData, err := image.GetImageTsuruYamlData(imageName)
-	if err != nil || yamlData.Healthcheck == nil {
+	if err != nil {
 		return routerTypes.HealthcheckData{}, err
+	}
+	prov, err := app.getProvisioner()
+	if err != nil {
+		return routerTypes.HealthcheckData{}, err
+	}
+	if hcProv, ok := prov.(provision.HCProvisioner); ok {
+		if hcProv.HandlesHC() {
+			return routerTypes.HealthcheckData{
+				TCPOnly: true,
+			}, nil
+		}
 	}
 	return yamlData.ToRouterHC(), nil
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -73,6 +73,7 @@ var (
 	_ provision.InitializableProvisioner = &kubernetesProvisioner{}
 	_ provision.RollbackableDeployer     = &kubernetesProvisioner{}
 	_ provision.InterAppProvisioner      = &kubernetesProvisioner{}
+	_ provision.HCProvisioner            = &kubernetesProvisioner{}
 	_ cluster.ClusteredProvisioner       = &kubernetesProvisioner{}
 	_ cluster.ClusterProvider            = &kubernetesProvisioner{}
 	// _ provision.OptionalLogsProvisioner  = &kubernetesProvisioner{}
@@ -1521,4 +1522,8 @@ func isDefaultPort(portsConfig []provTypes.TsuruYamlKubernetesProcessPortConfig)
 	return portsConfig[0].Protocol == defaultPort.Protocol &&
 		portsConfig[0].Port == defaultPort.Port &&
 		portsConfig[0].TargetPort == defaultPort.TargetPort
+}
+
+func (p *kubernetesProvisioner) HandlesHC() bool {
+	return true
 }

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -415,6 +415,13 @@ type UnitStatusProvisioner interface {
 	SetUnitStatus(Unit, Status) error
 }
 
+// HCProvisioner is a provisioner that may handle loadbalancing healthchecks.
+type HCProvisioner interface {
+	// HandlesHC returns true if the provisioner will handle healthchecking
+	// instead of the router.
+	HandlesHC() bool
+}
+
 type AddNodeOptions struct {
 	IaaSID     string
 	Address    string

--- a/router/galebv2/client/param_types.go
+++ b/router/galebv2/client/param_types.go
@@ -43,6 +43,7 @@ type BackendPoolHealthCheck struct {
 	HcPath           string `json:"hc_path,omitempty"`
 	HcBody           string `json:"hc_body,omitempty"`
 	HcHTTPStatusCode string `json:"hc_http_status_code,omitempty"`
+	HcTCPOnly        bool   `json:"hc_tcp_only,omitempty"`
 }
 
 type Pool struct {

--- a/router/galebv2/router.go
+++ b/router/galebv2/router.go
@@ -491,6 +491,12 @@ func (r *galebRouter) SetHealthcheck(name string, data routerTypes.HealthcheckDa
 	if err != nil {
 		return err
 	}
+	poolName := r.poolName(backendName)
+	if data.TCPOnly {
+		return r.client.UpdatePoolProperties(poolName, galebClient.BackendPoolHealthCheck{
+			HcTCPOnly: true,
+		})
+	}
 	if data.Path == "" {
 		data.Path = "/"
 	}
@@ -501,5 +507,5 @@ func (r *galebRouter) SetHealthcheck(name string, data routerTypes.HealthcheckDa
 	if data.Status != 0 {
 		poolHealthCheck.HcHTTPStatusCode = fmt.Sprintf("%d", data.Status)
 	}
-	return r.client.UpdatePoolProperties(r.poolName(backendName), poolHealthCheck)
+	return r.client.UpdatePoolProperties(poolName, poolHealthCheck)
 }

--- a/types/router/router.go
+++ b/types/router/router.go
@@ -5,7 +5,8 @@
 package router
 
 type HealthcheckData struct {
-	Path   string
-	Status int
-	Body   string
+	Path    string
+	Status  int
+	Body    string
+	TCPOnly bool
 }


### PR DESCRIPTION
This change is focused on the kubernetes provisioner, since healthcheck is handled by probes it makes sense to trust probes and only enable a simple tcp healthcheck on routers that support it.