### PR TITLE
provision/kubernetes: fix race in leader election with reactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint: metalint
 	misc/check-contributors.sh
 
 metalint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.18.0
 	go install ./...
 	go test -i ./...
 	echo "$$(go list ./... | grep -v /vendor/)" | sed 's|github.com/tsuru/tsuru/|./|' | xargs -t -n 4 \

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 	golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59 // indirect
 	google.golang.org/api v0.7.0 // indirect
+	gopkg.in/ahmetb/go-linq.v3 v3.0.0-00010101000000-000000000000 // indirect
 	gopkg.in/amz.v3 v3.0.0-20161215130849-8c3190dff075
 	gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a // indirect
 	gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405
@@ -162,4 +163,6 @@ replace (
 	github.com/docker/docker => github.com/docker/engine v0.0.0-20190219214528-cbe11bdc6da8
 	github.com/docker/machine => github.com/cezarsa/machine v0.7.1-0.20190219165632-cdcfd549f935
 	github.com/rancher/kontainer-engine => github.com/cezarsa/kontainer-engine v0.0.4-dev.0.20190725184110-8b6c46d5dadd
+	github.com/samalba/dockerclient => github.com/cezarsa/dockerclient v0.0.0-20190924055524-af5052a88081
+	gopkg.in/ahmetb/go-linq.v3 => github.com/ahmetb/go-linq v3.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RobotsAndPencils/go-saml v0.0.0-20150922030833-aa127de49a01 h1:GmKJxiZbNy8VrLxN/UNwmQytQv7dYHQ/xOiGfjOf9Ig=
 github.com/RobotsAndPencils/go-saml v0.0.0-20150922030833-aa127de49a01/go.mod h1:3SAoF0F5EbcOuBD5WT9nYkbIJieBS84cUQXADbXeBsU=
+github.com/ahmetb/go-linq v3.0.0+incompatible h1:qQkjjOXKrKOTy83X8OpRmnKflXKQIL/mC/gMVVDMhOA=
+github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht7vnCfnGlEpak/DVg5cY=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmDlfhUrweEy1R1Fj1gu5iIM=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -39,6 +41,8 @@ github.com/bradfitz/go-smtpd v0.0.0-20130623174436-5b56f4f917c7 h1:1dPDAaaaEemTa
 github.com/bradfitz/go-smtpd v0.0.0-20130623174436-5b56f4f917c7/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/cenkalti/backoff v0.0.0-20160904140958-8edc80b07f38 h1:szLW82/T7mgZycdlzxu4qVwA9cNiaSNMWlhN0utNdjs=
 github.com/cenkalti/backoff v0.0.0-20160904140958-8edc80b07f38/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cezarsa/dockerclient v0.0.0-20190924055524-af5052a88081 h1:nERdkUtJ2vbNjbR59fPsKfwztXWaiJUQrJYmYXV7CTg=
+github.com/cezarsa/dockerclient v0.0.0-20190924055524-af5052a88081/go.mod h1:B3TZHoY3EjMaI/cEzZDGB2sRv7LVC/BdGvsRU43nllE=
 github.com/cezarsa/kontainer-engine v0.0.4-dev.0.20190725184110-8b6c46d5dadd h1:JmGR1BJeJ4A9jheroTytFgnMspjcHXypa+CdupofI7M=
 github.com/cezarsa/kontainer-engine v0.0.4-dev.0.20190725184110-8b6c46d5dadd/go.mod h1:iAOHGubAx5sEuLsyq/6XhZZOBplIP8n3UDl7pcSKUHQ=
 github.com/cezarsa/machine v0.7.1-0.20190219165632-cdcfd549f935 h1:5zCYEyUB91XDlstHctPrAoWkD7j+Wfb5FRTppDEZF8k=
@@ -298,8 +302,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/sajari/fuzzy v0.0.0-20141008071338-bbbcac964e38 h1:sCM/dygb6aUis1zTbLwPVHbq6IzPYlDpBnje41fCzM4=
 github.com/sajari/fuzzy v0.0.0-20141008071338-bbbcac964e38/go.mod h1:OjYR6KxoWOe9+dOlXeiCJd4dIbED4Oo8wpS89o0pwOo=
-github.com/samalba/dockerclient v0.0.0-20160531175551-a30362618471 h1:y8vpp0FfqRunnOezh5NVGD7SnqRHe0lptTp9/Oc2xL0=
-github.com/samalba/dockerclient v0.0.0-20160531175551-a30362618471/go.mod h1:yeYR4SlaRZJct6lwNRKR+qd0CocnxxWDE7Vh5dxsn/w=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -127,8 +127,6 @@ type StreamResult struct {
 }
 
 func (s *KubeMock) DefaultReactions(c *check.C) (*provisiontest.FakeApp, func(), func()) {
-	srv, wg := s.CreateDeployReadyServer(c)
-	s.MockfakeNodes(c, srv.URL)
 	a := provisiontest.NewFakeApp("myapp", "python", 0)
 	err := s.p.Provision(a)
 	c.Assert(err, check.IsNil)
@@ -139,6 +137,8 @@ func (s *KubeMock) DefaultReactions(c *check.C) (*provisiontest.FakeApp, func(),
 	s.client.PrependReactor("create", "pods", podReaction)
 	s.client.PrependReactor("create", "services", servReaction)
 	s.client.TsuruClientset.PrependReactor("create", "apps", s.AppReaction(a, c))
+	srv, wg := s.CreateDeployReadyServer(c)
+	s.MockfakeNodes(c, srv.URL)
 	return a, func() {
 			rollbackDeployment()
 			deployPodReady.Wait()
@@ -156,13 +156,13 @@ func (s *KubeMock) DefaultReactions(c *check.C) (*provisiontest.FakeApp, func(),
 }
 
 func (s *KubeMock) NoAppReactions(c *check.C) (func(), func()) {
-	srv, wg := s.CreateDeployReadyServer(c)
-	s.MockfakeNodes(c, srv.URL)
 	podReaction, podReady := s.buildPodReaction(c)
 	servReaction := s.ServiceWithPortReaction(c, nil)
 	rollbackDeployment := s.DeploymentReactions(c)
 	s.client.PrependReactor("create", "pods", podReaction)
 	s.client.PrependReactor("create", "services", servReaction)
+	srv, wg := s.CreateDeployReadyServer(c)
+	s.MockfakeNodes(c, srv.URL)
 	return func() {
 			rollbackDeployment()
 			podReady.Wait()

--- a/provision/labels.go
+++ b/provision/labels.go
@@ -490,3 +490,11 @@ func subMap(m map[string]string, keys ...string) map[string]string {
 	}
 	return result
 }
+
+func IsServiceLabelSet(prefix string) *LabelSet {
+	labels := map[string]string{
+		labelIsTsuru:   strconv.FormatBool(true),
+		labelIsService: strconv.FormatBool(true),
+	}
+	return &LabelSet{Labels: labels, Prefix: prefix}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -424,7 +424,7 @@ github.com/rancher/types/apis/project.cattle.io/v3
 github.com/rancher/types/image
 # github.com/sajari/fuzzy v0.0.0-20141008071338-bbbcac964e38
 github.com/sajari/fuzzy
-# github.com/samalba/dockerclient v0.0.0-20160531175551-a30362618471
+# github.com/samalba/dockerclient v0.0.0-20160531175551-a30362618471 => github.com/cezarsa/dockerclient v0.0.0-20190924055524-af5052a88081
 github.com/samalba/dockerclient
 # github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
@@ -749,11 +749,11 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/selection
+k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/httpstream/spdy
 k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/runtime
-k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/httpstream
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/util/json


### PR DESCRIPTION
This also changes the election process to ensure we wait until election has stopped when shutting down the provisioner and a consistent handling of resource versions.