### PR TITLE
Fixes to controller lifecycle and informer filters

### DIFF
--- a/builder/kubernetes/suite_test.go
+++ b/builder/kubernetes/suite_test.go
@@ -36,6 +36,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/informers/internalinterfaces"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -158,7 +159,7 @@ func (s *S) SetUpTest(c *check.C) {
 	s.b = &kubernetesBuilder{}
 	s.p = kubeProv.GetProvisioner()
 	s.factory = informers.NewSharedInformerFactory(s.client, time.Minute)
-	kubeProv.InformerFactory = func(client *kubeProv.ClusterClient) (informers.SharedInformerFactory, error) {
+	kubeProv.InformerFactory = func(client *kubeProv.ClusterClient, tweak internalinterfaces.TweakListOptionsFunc) (informers.SharedInformerFactory, error) {
 		return s.factory, nil
 	}
 	s.mock = kubeTesting.NewKubeMock(s.client, s.p, s.factory)

--- a/provision/cluster/cluster.go
+++ b/provision/cluster/cluster.go
@@ -143,7 +143,7 @@ func (s *clusterService) Delete(c provTypes.Cluster) error {
 	if err != nil {
 		return err
 	}
-	if createProv, ok := prov.(ClusterProvider); ok && len(c.CreateData) > 0 {
+	if createProv, ok := prov.(ClusterProvider); ok {
 		err = createProv.DeleteCluster(context.Background(), &c)
 		if err != nil {
 			return err
@@ -190,7 +190,7 @@ func (s *clusterService) initCluster(c provTypes.Cluster, isNewCluster bool) err
 	if err != nil {
 		return err
 	}
-	if createProv, ok := prov.(ClusterProvider); ok && len(c.CreateData) > 0 {
+	if createProv, ok := prov.(ClusterProvider); ok {
 		if isNewCluster {
 			err = createProv.CreateCluster(context.Background(), &c)
 		} else {

--- a/provision/cluster/cluster_test.go
+++ b/provision/cluster/cluster_test.go
@@ -578,67 +578,6 @@ func (s *S) TestClusterServiceDeleteProvisionCluster(c *check.C) {
 	c.Assert(inst.callLog, check.DeepEquals, [][]string{{"DeleteCluster", "c1"}})
 }
 
-func (s *S) TestClusterServiceCreateProvisionClusterNoCreateData(c *check.C) {
-	inst := provisionClusterProv{FakeProvisioner: provisiontest.ProvisionerInstance}
-	provision.Register("fake-cluster", func() (provision.Provisioner, error) {
-		return &inst, nil
-	})
-	defer provision.Unregister("fake-cluster")
-	myCluster := provTypes.Cluster{
-		Name:        "c1",
-		Addresses:   []string{},
-		Provisioner: "fake-cluster",
-		Default:     true,
-	}
-	upsertCall := false
-	cs := &clusterService{
-		storage: &provTypes.MockClusterStorage{
-			OnUpsert: func(clust provTypes.Cluster) error {
-				upsertCall = true
-				c.Assert(clust.Name, check.Equals, myCluster.Name)
-				c.Assert(clust.Provisioner, check.Equals, myCluster.Provisioner)
-				return nil
-			},
-		},
-	}
-	err := cs.Create(myCluster)
-	c.Assert(err, check.IsNil)
-	c.Assert(upsertCall, check.Equals, true)
-	c.Assert(inst.callLog, check.IsNil)
-}
-
-func (s *S) TestClusterServiceDeleteProvisionClusterNoCreateData(c *check.C) {
-	inst := provisionClusterProv{FakeProvisioner: provisiontest.ProvisionerInstance}
-	provision.Register("fake-cluster", func() (provision.Provisioner, error) {
-		return &inst, nil
-	})
-	defer provision.Unregister("fake-cluster")
-	myCluster := provTypes.Cluster{
-		Name:        "c1",
-		Addresses:   []string{},
-		Provisioner: "fake-cluster",
-		Default:     true,
-	}
-	deleteCall := false
-	cs := &clusterService{
-		storage: &provTypes.MockClusterStorage{
-			OnDelete: func(clust provTypes.Cluster) error {
-				deleteCall = true
-				c.Assert(clust.Name, check.Equals, myCluster.Name)
-				return nil
-			},
-			OnFindByName: func(name string) (*provTypes.Cluster, error) {
-				c.Assert(deleteCall, check.Equals, false)
-				return &myCluster, nil
-			},
-		},
-	}
-	err := cs.Delete(provTypes.Cluster{Name: "c1"})
-	c.Assert(err, check.IsNil)
-	c.Assert(deleteCall, check.Equals, true)
-	c.Assert(inst.callLog, check.IsNil)
-}
-
 func (s *S) TestClusterServiceCreateProvisionClusterError(c *check.C) {
 	inst := provisionClusterProv{
 		FakeProvisioner: provisiontest.ProvisionerInstance,

--- a/provision/kubernetes/monitor.go
+++ b/provision/kubernetes/monitor.go
@@ -86,12 +86,16 @@ func getClusterController(p *kubernetesProvisioner, cluster *ClusterClient) (*cl
 }
 
 func stopClusterController(p *kubernetesProvisioner, cluster *ClusterClient) {
+	stopClusterControllerByName(p, cluster.Name)
+}
+
+func stopClusterControllerByName(p *kubernetesProvisioner, clusterName string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if c, ok := p.clusterControllers[cluster.Name]; ok {
+	if c, ok := p.clusterControllers[clusterName]; ok {
 		c.stop()
 	}
-	delete(p.clusterControllers, cluster.Name)
+	delete(p.clusterControllers, clusterName)
 }
 
 func (c *clusterController) stop() {
@@ -313,6 +317,10 @@ func (c *clusterController) initLeaderElection(ctx context.Context) error {
 	recorder := broadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{
 		Component: leaderElectionName,
 	})
+	// err = ensureNamespace(c.cluster, c.cluster.Namespace())
+	// if err != nil {
+	// 	return err
+	// }
 	lock, err := resourcelock.New(
 		resourcelock.EndpointsResourceLock,
 		c.cluster.Namespace(),

--- a/provision/kubernetes/monitor.go
+++ b/provision/kubernetes/monitor.go
@@ -317,10 +317,10 @@ func (c *clusterController) initLeaderElection(ctx context.Context) error {
 	recorder := broadcaster.NewRecorder(scheme.Scheme, apiv1.EventSource{
 		Component: leaderElectionName,
 	})
-	// err = ensureNamespace(c.cluster, c.cluster.Namespace())
-	// if err != nil {
-	// 	return err
-	// }
+	err = ensureNamespace(c.cluster, c.cluster.Namespace())
+	if err != nil {
+		return err
+	}
 	lock, err := resourcelock.New(
 		resourcelock.EndpointsResourceLock,
 		c.cluster.Namespace(),

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -212,15 +212,25 @@ func (p *kubernetesProvisioner) ClusterHelp() provTypes.ClusterHelpInfo {
 }
 
 func (p *kubernetesProvisioner) CreateCluster(ctx context.Context, c *provTypes.Cluster) error {
-	return provider.CreateCluster(ctx, c.Name, c.CreateData, c.Writer)
+	if len(c.CreateData) > 0 {
+		return provider.CreateCluster(ctx, c.Name, c.CreateData, c.Writer)
+	}
+	return nil
 }
 
 func (p *kubernetesProvisioner) UpdateCluster(ctx context.Context, c *provTypes.Cluster) error {
-	return provider.UpdateCluster(ctx, c.Name, c.CreateData, c.Writer)
+	if len(c.CreateData) > 0 {
+		return provider.UpdateCluster(ctx, c.Name, c.CreateData, c.Writer)
+	}
+	return nil
 }
 
 func (p *kubernetesProvisioner) DeleteCluster(ctx context.Context, c *provTypes.Cluster) error {
-	return provider.DeleteCluster(ctx, c.Name, c.CreateData, c.Writer)
+	stopClusterControllerByName(p, c.Name)
+	if len(c.CreateData) > 0 {
+		return provider.DeleteCluster(ctx, c.Name, c.CreateData, c.Writer)
+	}
+	return nil
 }
 
 func (p *kubernetesProvisioner) GetName() string {

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -35,6 +35,7 @@ import (
 	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/informers/internalinterfaces"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -123,7 +124,7 @@ func (s *S) SetUpTest(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	s.factory = informers.NewSharedInformerFactory(s.client, 1)
-	InformerFactory = func(client *ClusterClient) (informers.SharedInformerFactory, error) {
+	InformerFactory = func(client *ClusterClient, tweak internalinterfaces.TweakListOptionsFunc) (informers.SharedInformerFactory, error) {
 		return s.factory, nil
 	}
 	s.p = &kubernetesProvisioner{


### PR DESCRIPTION
Only apply label filters to pod informer not the other informers. Also ensure the controller is stopped when a cluster is removed.