### PR TITLE
Fixes last log lines shown after failed deploy

### DIFF
--- a/api/log_test.go
+++ b/api/log_test.go
@@ -80,9 +80,9 @@ loop:
 			logs1 []appTypes.Applog
 			logs2 []appTypes.Applog
 		)
-		logs1, err = a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, nil)
+		logs1, err = a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, false, nil)
 		c.Assert(err, check.IsNil)
-		logs2, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, nil)
+		logs2, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, false, nil)
 		c.Assert(err, check.IsNil)
 		if len(logs1) == 3 && len(logs2) == 2 {
 			break
@@ -94,7 +94,7 @@ loop:
 		default:
 		}
 	}
-	logs, err := a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, nil)
+	logs, err := a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	sort.Sort(LogList(logs))
 	compareLogs(c, logs, []appTypes.Applog{
@@ -102,7 +102,7 @@ loop:
 		{Date: baseTime.Add(2 * time.Second), Message: "msg3", Source: "web", AppName: "myapp1", Unit: "unit3"},
 		{Date: baseTime.Add(4 * time.Second), Message: "msg5", Source: "worker", AppName: "myapp1", Unit: "unit3"},
 	})
-	logs, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, nil)
+	logs, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	sort.Sort(LogList(logs))
 	compareLogs(c, logs, []appTypes.Applog{
@@ -156,7 +156,7 @@ func (s *S) TestAddLogsHandlerConcurrent(c *check.C) {
 loop:
 	for {
 		var logs1 []appTypes.Applog
-		logs1, err = a1.LastLogs(servicemanager.AppLog, nConcurrency, appTypes.Applog{}, nil)
+		logs1, err = a1.LastLogs(servicemanager.AppLog, nConcurrency, appTypes.Applog{}, false, nil)
 		c.Assert(err, check.IsNil)
 		if len(logs1) == nConcurrency {
 			break
@@ -168,7 +168,7 @@ loop:
 		default:
 		}
 	}
-	logs, err := a1.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := a1.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	compareLogs(c, logs, []appTypes.Applog{
 		{Date: baseTime, Message: "msg1", Source: "web", AppName: "myapp1", Unit: "unit1"},

--- a/app/app.go
+++ b/app/app.go
@@ -1657,11 +1657,7 @@ func (app *App) RemoveInstance(removeArgs bind.RemoveInstanceArgs) error {
 
 // LastLogs returns a list of the last `lines` log of the app, matching the
 // fields in the log instance received as an example.
-func (app *App) LastLogs(logService appTypes.AppLogService, lines int, filterLog appTypes.Applog, t authTypes.Token) ([]appTypes.Applog, error) {
-	return app.lastLogs(logService, lines, filterLog, false, t)
-}
-
-func (app *App) lastLogs(logService appTypes.AppLogService, lines int, filterLog appTypes.Applog, invertFilter bool, t authTypes.Token) ([]appTypes.Applog, error) {
+func (app *App) LastLogs(logService appTypes.AppLogService, lines int, filterLog appTypes.Applog, invertFilter bool, t authTypes.Token) ([]appTypes.Applog, error) {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return nil, err

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -286,7 +286,7 @@ func Deploy(opts DeployOptions) (string, error) {
 	if err != nil {
 		var logLines []appTypes.Applog
 		if provision.IsStartupError(err) {
-			logLines, _ = opts.App.lastLogs(servicemanager.AppLog, 10, appTypes.Applog{
+			logLines, _ = opts.App.LastLogs(servicemanager.AppLog, 10, appTypes.Applog{
 				Source: "tsuru",
 			}, true, opts.Token)
 		}

--- a/app/writer_test.go
+++ b/app/writer_test.go
@@ -52,7 +52,7 @@ func (s *WriterSuite) TestLogWriter(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, string(data))
 	c.Assert(logs[0].Source, check.Equals, "tsuru")
@@ -70,7 +70,7 @@ func (s *WriterSuite) TestLogWriterCustomSource(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, string(data))
 	c.Assert(logs[0].Source, check.Equals, "cool-test")
@@ -106,7 +106,7 @@ func (s *WriterSuite) TestLogWriterAsync(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, "ble")
 	c.Assert(logs[0].Source, check.Equals, "tsuru")
@@ -145,7 +145,7 @@ func (s *WriterSuite) TestLogWriterAsyncCopySlice(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 100, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 100, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 100)
 	for i := 0; i < 100; i++ {
@@ -192,7 +192,7 @@ func (s *WriterSuite) TestLogWriterAsyncWriteClosed(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 0)
 }
@@ -212,7 +212,7 @@ func (s *WriterSuite) TestLogWriterWriteClosed(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 0)
 }

--- a/applog/aggregator.go
+++ b/applog/aggregator.go
@@ -220,6 +220,7 @@ func buildInstanceRequests(args appTypes.ListLogArgs, follow bool) ([]*http.Requ
 		urlValues.Add("lines", strconv.Itoa(args.Limit))
 		urlValues.Add("source", args.Source)
 		urlValues.Add("unit", args.Unit)
+		urlValues.Add("invert-filters", strconv.FormatBool(args.InvertFilters))
 		if follow {
 			urlValues.Add("follow", "1")
 		}

--- a/applog/service_test.go
+++ b/applog/service_test.go
@@ -164,6 +164,20 @@ func (s *ServiceSuite) Test_LogService_ListUnitFilter(c *check.C) {
 	}
 }
 
+func (s *ServiceSuite) Test_LogService_ListFilterInvert(c *check.C) {
+	for i := 0; i < 15; i++ {
+		s.svc.Add("app3", strconv.Itoa(i), "tsuru", "rdaneel")
+		time.Sleep(1e6) // let the time flow
+	}
+	s.svc.Add("app3", "app3 log from circus", "circus", "rdaneel")
+	s.svc.Add("app3", "app3 log from tsuru", "tsuru", "seldon")
+	logs, err := s.svc.List(appTypes.ListLogArgs{Limit: 10, AppName: "app3", Source: "tsuru", InvertFilters: true})
+	c.Assert(err, check.IsNil)
+	c.Assert(logs, check.HasLen, 1)
+	c.Check(logs[0].Message, check.Equals, "app3 log from circus")
+	c.Check(logs[0].Source, check.Equals, "circus")
+}
+
 func (s *ServiceSuite) Test_LogService_ListEmpty(c *check.C) {
 	logs, err := s.svc.List(appTypes.ListLogArgs{Limit: 10, AppName: "myapp", Source: "tsuru"})
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
The invert filters flag in log listing was being ignores in aggregate log service. This caused the logs messages shown to always repeat the deploy log instead of showing application specific log messages.