### PR TITLE
Improve error messages on failed deploy

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/globalsign/mgo/bson"
+	pkgErrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tsuru/tsuru/api/context"
 	"github.com/tsuru/tsuru/app"
@@ -405,7 +406,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 			if e.Err == app.ErrAppAlreadyExists {
 				return &errors.HTTP{Code: http.StatusConflict, Message: e.Error()}
 			}
-			if _, ok := e.Err.(*quota.QuotaExceededError); ok {
+			if _, ok := pkgErrors.Cause(e.Err).(*quota.QuotaExceededError); ok {
 				return &errors.HTTP{
 					Code:    http.StatusForbidden,
 					Message: "Quota exceeded",

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -2173,7 +2173,7 @@ func (s *S) TestAddUnitsQuotaExceeded(c *check.C) {
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
-	c.Assert(recorder.Body.String(), check.Equals, `Quota exceeded. Available: 2, Requested: 3.`+"\n")
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*Quota exceeded. Available: 2, Requested: 3.*`)
 	c.Assert(eventtest.EventDesc{
 		Target:          appTarget("armorandsword"),
 		Owner:           s.token.GetUserName(),

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -617,7 +617,7 @@ func (s *DeploySuite) TestDeployWithoutPlatformFails(c *check.C) {
 	server := RunServer(true)
 	server.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusInternalServerError)
-	c.Assert(recorder.Body.String(), check.Matches, "(?s).*can't deploy app without platform, if it's not an image or rollback\n")
+	c.Assert(recorder.Body.String(), check.Matches, "(?s).*can't deploy app without platform, if it's not an image or rollback.*")
 }
 
 func (s *DeploySuite) TestDeployDockerImage(c *check.C) {

--- a/api/log_test.go
+++ b/api/log_test.go
@@ -80,9 +80,13 @@ loop:
 			logs1 []appTypes.Applog
 			logs2 []appTypes.Applog
 		)
-		logs1, err = a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, false, nil)
+		logs1, err = a1.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+			Limit: 3,
+		})
 		c.Assert(err, check.IsNil)
-		logs2, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, false, nil)
+		logs2, err = a2.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+			Limit: 2,
+		})
 		c.Assert(err, check.IsNil)
 		if len(logs1) == 3 && len(logs2) == 2 {
 			break
@@ -94,7 +98,9 @@ loop:
 		default:
 		}
 	}
-	logs, err := a1.LastLogs(servicemanager.AppLog, 3, appTypes.Applog{}, false, nil)
+	logs, err := a1.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 3,
+	})
 	c.Assert(err, check.IsNil)
 	sort.Sort(LogList(logs))
 	compareLogs(c, logs, []appTypes.Applog{
@@ -102,7 +108,9 @@ loop:
 		{Date: baseTime.Add(2 * time.Second), Message: "msg3", Source: "web", AppName: "myapp1", Unit: "unit3"},
 		{Date: baseTime.Add(4 * time.Second), Message: "msg5", Source: "worker", AppName: "myapp1", Unit: "unit3"},
 	})
-	logs, err = a2.LastLogs(servicemanager.AppLog, 2, appTypes.Applog{}, false, nil)
+	logs, err = a2.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 2,
+	})
 	c.Assert(err, check.IsNil)
 	sort.Sort(LogList(logs))
 	compareLogs(c, logs, []appTypes.Applog{
@@ -156,7 +164,9 @@ func (s *S) TestAddLogsHandlerConcurrent(c *check.C) {
 loop:
 	for {
 		var logs1 []appTypes.Applog
-		logs1, err = a1.LastLogs(servicemanager.AppLog, nConcurrency, appTypes.Applog{}, false, nil)
+		logs1, err = a1.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+			Limit: nConcurrency,
+		})
 		c.Assert(err, check.IsNil)
 		if len(logs1) == nConcurrency {
 			break
@@ -168,7 +178,9 @@ loop:
 		default:
 		}
 	}
-	logs, err := a1.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := a1.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	compareLogs(c, logs, []appTypes.Applog{
 		{Date: baseTime, Message: "msg1", Source: "web", AppName: "myapp1", Unit: "unit1"},

--- a/api/logtracker_test.go
+++ b/api/logtracker_test.go
@@ -23,7 +23,9 @@ func (s *S) TestLogStreamTrackerAddRemove(c *check.C) {
 }
 
 func (s *S) TestLogStreamTrackerShutdown(c *check.C) {
-	l, err := servicemanager.AppLog.Watch("myapp", "", "", nil)
+	l, err := servicemanager.AppLog.Watch(appTypes.ListLogArgs{
+		AppName: "myapp",
+	})
 	c.Assert(err, check.IsNil)
 	logTracker.add(l)
 	logTracker.Shutdown(context.Background())

--- a/app/app.go
+++ b/app/app.go
@@ -728,7 +728,7 @@ func (app *App) AddUnits(n uint, process string, w io.Writer) error {
 	rebuild.RoutesRebuildOrEnqueue(app.Name)
 	quotaErr := app.fixQuota()
 	if err != nil {
-		return err
+		return newErrorWithLog(err, app, "add units")
 	}
 	return quotaErr
 }
@@ -748,7 +748,7 @@ func (app *App) RemoveUnits(n uint, process string, w io.Writer) error {
 	rebuild.RoutesRebuildOrEnqueue(app.Name)
 	quotaErr := app.fixQuota()
 	if err != nil {
-		return err
+		return newErrorWithLog(err, app, "remove units")
 	}
 	return quotaErr
 }
@@ -1239,7 +1239,7 @@ func (app *App) Restart(process string, w io.Writer) error {
 	err = prov.Restart(app, process, w)
 	if err != nil {
 		log.Errorf("[restart] error on restart the app %s - %s", app.Name, err)
-		return err
+		return newErrorWithLog(err, app, "restart")
 	}
 	rebuild.RoutesRebuildOrEnqueue(app.Name)
 	return nil
@@ -1309,7 +1309,7 @@ func (app *App) Sleep(w io.Writer, process string, proxyURL *url.URL) error {
 		log.Errorf("[sleep] error on sleep the app %s - %s", app.Name, err)
 		log.Errorf("[sleep] rolling back the sleep %s", app.Name)
 		rebuild.RoutesRebuildOrEnqueue(app.Name)
-		return err
+		return newErrorWithLog(err, app, "sleep")
 	}
 	return nil
 }
@@ -1540,7 +1540,11 @@ func (app *App) restartIfUnits(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return prov.Restart(app, "", w)
+	err = prov.Restart(app, "", w)
+	if err != nil {
+		return newErrorWithLog(err, app, "restart")
+	}
+	return nil
 }
 
 // AddCName adds a CName to app. It updates the attribute,
@@ -1968,7 +1972,7 @@ func (app *App) Start(w io.Writer, process string) error {
 	err = prov.Start(app, process)
 	if err != nil {
 		log.Errorf("[start] error on start the app %s - %s", app.Name, err)
-		return err
+		return newErrorWithLog(err, app, "start")
 	}
 	rebuild.RoutesRebuildOrEnqueue(app.Name)
 	return err

--- a/app/app.go
+++ b/app/app.go
@@ -1657,7 +1657,7 @@ func (app *App) RemoveInstance(removeArgs bind.RemoveInstanceArgs) error {
 
 // LastLogs returns a list of the last `lines` log of the app, matching the
 // fields in the log instance received as an example.
-func (app *App) LastLogs(logService appTypes.AppLogService, lines int, filterLog appTypes.Applog, invertFilter bool, t authTypes.Token) ([]appTypes.Applog, error) {
+func (app *App) LastLogs(logService appTypes.AppLogService, args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return nil, err
@@ -1674,14 +1674,8 @@ func (app *App) LastLogs(logService appTypes.AppLogService, lines int, filterLog
 			return nil, errors.New(doc)
 		}
 	}
-	return logService.List(appTypes.ListLogArgs{
-		AppName:       app.Name,
-		InvertFilters: invertFilter,
-		Limit:         lines,
-		Source:        filterLog.Source,
-		Unit:          filterLog.Unit,
-		Token:         t,
-	})
+	args.AppName = app.Name
+	return logService.List(args)
 }
 
 type Filter struct {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2512,7 +2512,10 @@ func (s *S) TestLastLogs(c *check.C) {
 		time.Sleep(1e6) // let the time flow
 	}
 	servicemanager.AppLog.Add(app.Name, "app3 log from circus", "circus", "rdaneel")
-	logs, err := app.LastLogs(servicemanager.AppLog, 10, appTypes.Applog{Source: "tsuru"}, false, nil)
+	logs, err := app.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit:  10,
+		Source: "tsuru",
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 10)
 	for i := 5; i < 15; i++ {
@@ -2534,7 +2537,11 @@ func (s *S) TestLastLogsInvertFilters(c *check.C) {
 		time.Sleep(1e6) // let the time flow
 	}
 	servicemanager.AppLog.Add(app.Name, "app3 log from circus", "circus", "rdaneel")
-	logs, err := app.LastLogs(servicemanager.AppLog, 10, appTypes.Applog{Source: "tsuru"}, true, nil)
+	logs, err := app.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit:        10,
+		Source:       "tsuru",
+		InvertSource: true,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 1)
 	c.Check(logs[0].Message, check.Equals, "app3 log from circus")
@@ -2564,7 +2571,9 @@ func (s *S) TestLastLogsDisabled(c *check.C) {
 	}
 	err := s.conn.Apps().Insert(app)
 	c.Assert(err, check.IsNil)
-	_, err = app.LastLogs(servicemanager.AppLog, 10, appTypes.Applog{}, false, nil)
+	_, err = app.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 10,
+	})
 	c.Assert(err, check.ErrorMatches, "my doc msg")
 }
 
@@ -2863,7 +2872,9 @@ func (s *S) TestRun(c *check.C) {
 	var logs []appTypes.Applog
 	timeout := time.After(5 * time.Second)
 	for {
-		logs, err = app.LastLogs(servicemanager.AppLog, 10, appTypes.Applog{}, false, nil)
+		logs, err = app.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+			Limit: 10,
+		})
 		c.Assert(err, check.IsNil)
 		if len(logs) > 2 {
 			break

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -256,7 +256,7 @@ func (e *errorWithLog) Error() string {
 	if len(e.logs) > 0 {
 		logPart = fmt.Sprintf("\n---- Last %d log messages: ----\n%s", len(e.logs), e.formatLogLines())
 	}
-	return fmt.Sprintf("---- ERROR during deploy: ----\n%v%s", e.err, logPart)
+	return fmt.Sprintf("\n---- ERROR during deploy: ----\n%v\n%s", e.err, logPart)
 }
 
 // Deploy runs a deployment of an application. It will first try to run an

--- a/app/writer_test.go
+++ b/app/writer_test.go
@@ -52,7 +52,9 @@ func (s *WriterSuite) TestLogWriter(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, string(data))
 	c.Assert(logs[0].Source, check.Equals, "tsuru")
@@ -70,7 +72,9 @@ func (s *WriterSuite) TestLogWriterCustomSource(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, string(data))
 	c.Assert(logs[0].Source, check.Equals, "cool-test")
@@ -106,7 +110,9 @@ func (s *WriterSuite) TestLogWriterAsync(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs[0].Message, check.Equals, "ble")
 	c.Assert(logs[0].Source, check.Equals, "tsuru")
@@ -145,7 +151,9 @@ func (s *WriterSuite) TestLogWriterAsyncCopySlice(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 100, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 100,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 100)
 	for i := 0; i < 100; i++ {
@@ -192,7 +200,9 @@ func (s *WriterSuite) TestLogWriterAsyncWriteClosed(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 0)
 }
@@ -212,7 +222,9 @@ func (s *WriterSuite) TestLogWriterWriteClosed(c *check.C) {
 	instance := App{}
 	err = s.conn.Apps().Find(bson.M{"name": a.Name}).One(&instance)
 	c.Assert(err, check.IsNil)
-	logs, err := instance.LastLogs(servicemanager.AppLog, 1, appTypes.Applog{}, false, nil)
+	logs, err := instance.LastLogs(servicemanager.AppLog, appTypes.ListLogArgs{
+		Limit: 1,
+	})
 	c.Assert(err, check.IsNil)
 	c.Assert(logs, check.HasLen, 0)
 }

--- a/applog/aggregator.go
+++ b/applog/aggregator.go
@@ -22,7 +22,6 @@ import (
 	tsuruNet "github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/servicemanager"
 	appTypes "github.com/tsuru/tsuru/types/app"
-	"github.com/tsuru/tsuru/types/auth"
 )
 
 type aggregatorLogService struct {
@@ -92,14 +91,8 @@ func (s *aggregatorLogService) List(args appTypes.ListLogArgs) ([]appTypes.Applo
 	return allLogs, nil
 }
 
-func (s *aggregatorLogService) Watch(appName, source, unit string, t auth.Token) (appTypes.LogWatcher, error) {
-	args := appTypes.ListLogArgs{
-		AppName: appName,
-		Source:  source,
-		Unit:    unit,
-		Limit:   -1,
-		Token:   t,
-	}
+func (s *aggregatorLogService) Watch(args appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	args.Limit = -1
 	requests, err := buildInstanceRequests(args, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "[aggregator service]")
@@ -219,8 +212,10 @@ func buildInstanceRequests(args appTypes.ListLogArgs, follow bool) ([]*http.Requ
 		urlValues := url.Values{}
 		urlValues.Add("lines", strconv.Itoa(args.Limit))
 		urlValues.Add("source", args.Source)
-		urlValues.Add("unit", args.Unit)
-		urlValues.Add("invert-filters", strconv.FormatBool(args.InvertFilters))
+		for _, u := range args.Units {
+			urlValues.Add("unit", u)
+		}
+		urlValues.Add("invert-source", strconv.FormatBool(args.InvertSource))
 		if follow {
 			urlValues.Add("follow", "1")
 		}

--- a/applog/dispatcher_test.go
+++ b/applog/dispatcher_test.go
@@ -20,7 +20,9 @@ func (s *S) TestLogDispatcherSend(c *check.C) {
 	logsInQueue.Set(0)
 	svc, err := storageAppLogService()
 	c.Assert(err, check.IsNil)
-	listener, err := svc.Watch("myapp1", "", "", nil)
+	listener, err := svc.Watch(appTypes.ListLogArgs{
+		AppName: "myapp1",
+	})
 	c.Assert(err, check.IsNil)
 	defer listener.Close()
 	dispatcher := newlogDispatcher(2000000, svc.(*storageLogService).storage)
@@ -179,7 +181,9 @@ func (s *S) TestLogDispatcherSendRateLimit(c *check.C) {
 	defer config.Unset("log:app-log-rate-limit")
 	svc, err := storageAppLogService()
 	c.Assert(err, check.IsNil)
-	listener, err := svc.Watch("myapp1", "", "", nil)
+	listener, err := svc.Watch(appTypes.ListLogArgs{
+		AppName: "myapp1",
+	})
 	c.Assert(err, check.IsNil)
 	defer listener.Close()
 	dispatcher := newlogDispatcher(2000000, svc.(*storageLogService).storage)
@@ -210,7 +214,9 @@ func (s *S) TestLogDispatcherSendGlobalRateLimit(c *check.C) {
 	defer config.Unset("log:global-app-log-rate-limit")
 	svc, err := storageAppLogService()
 	c.Assert(err, check.IsNil)
-	listener, err := svc.Watch("myapp1", "", "", nil)
+	listener, err := svc.Watch(appTypes.ListLogArgs{
+		AppName: "myapp1",
+	})
 	c.Assert(err, check.IsNil)
 	defer listener.Close()
 	dispatcher := newlogDispatcher(2000000, svc.(*storageLogService).storage)

--- a/applog/storage.go
+++ b/applog/storage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tsuru/tsuru/api/shutdown"
 	"github.com/tsuru/tsuru/storage"
 	appTypes "github.com/tsuru/tsuru/types/app"
-	"github.com/tsuru/tsuru/types/auth"
 )
 
 type storageLogService struct {
@@ -73,8 +72,8 @@ func (s *storageLogService) List(filters appTypes.ListLogArgs) ([]appTypes.Applo
 	return s.storage.List(filters)
 }
 
-func (s *storageLogService) Watch(appName, source, unit string, t auth.Token) (appTypes.LogWatcher, error) {
-	return s.storage.Watch(appName, source, unit)
+func (s *storageLogService) Watch(filters appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	return s.storage.Watch(filters)
 }
 
 func (s *storageLogService) Shutdown(ctx context.Context) error {

--- a/auth/token.go
+++ b/auth/token.go
@@ -72,6 +72,10 @@ func BaseTokenPermission(t Token) ([]permission.Permission, error) {
 				Scheme:  permission.PermAppReadDeploy,
 				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
 			},
+			{
+				Scheme:  permission.PermAppReadLog,
+				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
+			},
 		}, nil
 	}
 	u, err := ConvertNewUser(t.User())

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -738,7 +738,7 @@ func createDeployTimeoutError(client *ClusterClient, a provision.App, processNam
 	badUnitsSet := make(map[string]struct{})
 	for _, m := range messages {
 		badUnitsSet[m.podName] = struct{}{}
-		msgsStr = append(msgsStr, fmt.Sprintf(" ---> %s\n", m.message))
+		msgsStr = append(msgsStr, fmt.Sprintf(" ---> %s", m.message))
 	}
 	var badUnits []string
 	for u := range badUnitsSet {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -685,7 +685,8 @@ func (e *Error) Error() string {
 }
 
 type ErrUnitStartup struct {
-	Err error
+	BadUnits []string
+	Err      error
 }
 
 func (e ErrUnitStartup) Error() string {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -697,6 +697,20 @@ func (e ErrUnitStartup) IsStartupError() bool {
 	return true
 }
 
+func (e ErrUnitStartup) Units() []string {
+	return e.BadUnits
+}
+
+func StartupBadUnits(err error) []string {
+	se, ok := errors.Cause(err).(interface {
+		Units() []string
+	})
+	if ok {
+		return se.Units()
+	}
+	return nil
+}
+
 func IsStartupError(err error) bool {
 	se, ok := errors.Cause(err).(interface {
 		IsStartupError() bool

--- a/types/app/log.go
+++ b/types/app/log.go
@@ -16,7 +16,7 @@ type AppLogService interface {
 	Enqueue(entry *Applog) error
 	Add(appName, message, source, unit string) error
 	List(args ListLogArgs) ([]Applog, error)
-	Watch(appName, source, unit string, t auth.Token) (LogWatcher, error)
+	Watch(args ListLogArgs) (LogWatcher, error)
 }
 
 type AppLogServiceInstance interface {
@@ -26,16 +26,16 @@ type AppLogServiceInstance interface {
 type AppLogStorage interface {
 	InsertApp(appName string, msgs ...*Applog) error
 	List(args ListLogArgs) ([]Applog, error)
-	Watch(appName, source, unit string) (LogWatcher, error)
+	Watch(args ListLogArgs) (LogWatcher, error)
 }
 
 type ListLogArgs struct {
-	AppName       string
-	Source        string
-	Unit          string
-	Limit         int
-	InvertFilters bool
-	Token         auth.Token
+	AppName      string
+	Source       string
+	Units        []string
+	Limit        int
+	InvertSource bool
+	Token        auth.Token
 }
 
 // Applog represents a log entry.


### PR DESCRIPTION
Error messages during deploy were improved removed unnecessary information and duplicated lines. Also the log lines shown are only relative to the failed units. Here are some examples of the output before and after the change.

### Failure scenarios mapped:

#### Scenario 1 - Wrong health check response

Before:
```
---- Updating units [web] ----
 ---> 0 of 1 new units created
 ---> 1 old units pending termination
  ---> myapp-web-848b95d8b6-j7ccj - Successfully assigned default/myapp-web-848b95d8b6-j7ccj to minikube [default-scheduler]
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
  ---> myapp-web-848b95d8b6-j7ccj - Container image "192.168.50.1:5000/tsuru/app-myapp:v4" already present on machine [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
 ---> Pod not ready in time: Pod myapp-web-848b95d8b6-j7ccj: invalid pod phase "Running" - last event: Readiness probe failed: HTTP probe failed with statuscode: 404

**** ROLLING BACK AFTER FAILURE ****
 ---> timeout waiting full rollout after 59.863102976s waiting for units: Pod myapp-web-848b95d8b6-j7ccj: invalid pod phase "Running" - last event: Readiness probe failed: HTTP probe failed with statuscode: 404 <---
---- ERROR during deploy: ----
timeout waiting full rollout after 59.863102976s waiting for units: Pod myapp-web-848b95d8b6-j7ccj: invalid pod phase "Running" - last event: Readiness probe failed: HTTP probe failed with statuscode: 404
---- Last 10 log messages: ----
    2019-09-27T14:47:49Z[tsuru][api]:  ---> waiting healthcheck on 1 created units
    2019-09-27T14:47:51Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:01Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:11Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:21Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:31Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:41Z[tsuru][api]:   ---> myapp-web-848b95d8b6-j7ccj - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
    2019-09-27T14:48:47Z[tsuru][api]:  ---> Pod not ready in time: Pod myapp-web-848b95d8b6-j7ccj: invalid pod phase "Running" - last event: Readiness probe failed: HTTP probe failed with statuscode: 404
    2019-09-27T14:48:47Z[tsuru][api]: **** ROLLING BACK AFTER FAILURE ****
    2019-09-27T14:48:47Z[tsuru][api]:  ---> timeout waiting full rollout after 59.863102976s waiting for units: Pod myapp-web-848b95d8b6-j7ccj: invalid pod phase "Running" - last event: Readiness probe failed: HTTP probe failed with statuscode: 404 <---
```

After:
```
---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-6869497ff4-zcf7p - Successfully assigned default/myapp-web-6869497ff4-zcf7p to minikube [default-scheduler]
  ---> myapp-web-6869497ff4-zcf7p - Container image "192.168.50.1:5000/tsuru/app-myapp:v28" already present on machine [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]
  ---> myapp-web-6869497ff4-zcf7p - Readiness probe failed: HTTP probe failed with statuscode: 404 [kubelet, minikube]

**** ROLLING BACK AFTER FAILURE ****

---- ERROR during deploy: ----
 ---> Pod "myapp-web-6869497ff4-zcf7p" not ready: containers with unready status: [myapp-web]
 ---> Pod "myapp-web-6869497ff4-zcf7p" failed health check, HTTP GET to /xyz on port 8888: Readiness probe failed: HTTP probe failed with statuscode: 404

---- Last 6 log messages: ----
    2019-10-02 14:52:06 -0300 [web][myapp-web-6869497ff4-zcf7p]: * Running on http://0.0.0.0:8888/ (Press CTRL+C to quit)
    2019-10-02 14:52:11 -0300 [web][myapp-web-6869497ff4-zcf7p]: 172.17.0.1 - - [02/Oct/2019 17:52:11] "GET /xyz HTTP/1.1" 404 -
    2019-10-02 14:52:21 -0300 [web][myapp-web-6869497ff4-zcf7p]: 172.17.0.1 - - [02/Oct/2019 17:52:21] "GET /xyz HTTP/1.1" 404 -
    2019-10-02 14:52:31 -0300 [web][myapp-web-6869497ff4-zcf7p]: 172.17.0.1 - - [02/Oct/2019 17:52:31] "GET /xyz HTTP/1.1" 404 -
    2019-10-02 14:52:41 -0300 [web][myapp-web-6869497ff4-zcf7p]: 172.17.0.1 - - [02/Oct/2019 17:52:41] "GET /xyz HTTP/1.1" 404 -
    2019-10-02 14:52:51 -0300 [web][myapp-web-6869497ff4-zcf7p]: 172.17.0.1 - - [02/Oct/2019 17:52:51] "GET /xyz HTTP/1.1" 404 -
```

#### Scenario 2 - Process started, but connections refused

Before:
```
---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-7df6c49bb6-wcjpz - Successfully assigned default/myapp-web-7df6c49bb6-wcjpz to minikube [default-scheduler]
  ---> myapp-web-7df6c49bb6-wcjpz - Container image "192.168.50.1:5000/tsuru/app-myapp:v5" already present on machine [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
 ---> Pod not ready in time: Pod myapp-web-7df6c49bb6-wcjpz: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused

**** ROLLING BACK AFTER FAILURE ****
 ---> timeout waiting full rollout after 59.824307872s waiting for units: Pod myapp-web-7df6c49bb6-wcjpz: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused <---
---- ERROR during deploy: ----
timeout waiting full rollout after 59.824307872s waiting for units: Pod myapp-web-7df6c49bb6-wcjpz: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused
---- Last 10 log messages: ----
    2019-09-27T14:55:27Z[tsuru][api]:  ---> waiting healthcheck on 1 created units
    2019-09-27T14:55:33Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:55:43Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:55:53Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:56:03Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:56:13Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:56:23Z[tsuru][api]:   ---> myapp-web-7df6c49bb6-wcjpz - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T14:56:25Z[tsuru][api]:  ---> Pod not ready in time: Pod myapp-web-7df6c49bb6-wcjpz: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused
    2019-09-27T14:56:25Z[tsuru][api]: **** ROLLING BACK AFTER FAILURE ****
    2019-09-27T14:56:25Z[tsuru][api]:  ---> timeout waiting full rollout after 59.824307872s waiting for units: Pod myapp-web-7df6c49bb6-wcjpz: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused <---
```

After:
```

---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-76c66d5dd4-8749z - Successfully assigned default/myapp-web-76c66d5dd4-8749z to minikube [default-scheduler]
  ---> myapp-web-76c66d5dd4-8749z - Container image "192.168.50.1:5000/tsuru/app-myapp:v29" already present on machine [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-76c66d5dd4-8749z - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]

**** ROLLING BACK AFTER FAILURE ****

---- ERROR during deploy: ----
 ---> Pod "myapp-web-76c66d5dd4-8749z" not ready: containers with unready status: [myapp-web]
 ---> Pod "myapp-web-76c66d5dd4-8749z" failed health check, HTTP GET to /xyz on port 8888: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused

---- Last 1 log messages: ----
    2019-10-02 14:58:20 -0300 [web][myapp-web-76c66d5dd4-8749z]: * Running on http://0.0.0.0:8889/ (Press CTRL+C to quit)
```

#### Scenario 3 - Process crashing after one second

Before:
```
---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-c9b8c6d6-8qgdb - Successfully assigned default/myapp-web-c9b8c6d6-8qgdb to minikube [default-scheduler]
  ---> myapp-web-c9b8c6d6-8qgdb - Container image "192.168.50.1:5000/tsuru/app-myapp:v6" already present on machine [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-c9b8c6d6-8qgdb - Container image "192.168.50.1:5000/tsuru/app-myapp:v6" already present on machine [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Container image "192.168.50.1:5000/tsuru/app-myapp:v6" already present on machine [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Container image "192.168.50.1:5000/tsuru/app-myapp:v6" already present on machine [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
 ---> Pod not ready in time: Pod myapp-web-c9b8c6d6-8qgdb: invalid pod phase "Running" - last event: Back-off restarting failed container

**** ROLLING BACK AFTER FAILURE ****
 ---> timeout waiting full rollout after 59.857221241s waiting for units: Pod myapp-web-c9b8c6d6-8qgdb: invalid pod phase "Running" - last event: Back-off restarting failed container <---
---- ERROR during deploy: ----
timeout waiting full rollout after 59.857221241s waiting for units: Pod myapp-web-c9b8c6d6-8qgdb: invalid pod phase "Running" - last event: Back-off restarting failed container
---- Last 10 log messages: ----
    2019-09-27T14:59:33Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
    2019-09-27T14:59:36Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T14:59:47Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T15:00:00Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Container image "192.168.50.1:5000/tsuru/app-myapp:v6" already present on machine [kubelet, minikube]
    2019-09-27T15:00:01Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Created container myapp-web [kubelet, minikube]
    2019-09-27T15:00:01Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Started container myapp-web [kubelet, minikube]
    2019-09-27T15:00:03Z[tsuru][api]:   ---> myapp-web-c9b8c6d6-8qgdb - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T15:00:14Z[tsuru][api]:  ---> Pod not ready in time: Pod myapp-web-c9b8c6d6-8qgdb: invalid pod phase "Running" - last event: Back-off restarting failed container
    2019-09-27T15:00:14Z[tsuru][api]: **** ROLLING BACK AFTER FAILURE ****
    2019-09-27T15:00:14Z[tsuru][api]:  ---> timeout waiting full rollout after 59.857221241s waiting for units: Pod myapp-web-c9b8c6d6-8qgdb: invalid pod phase "Running" - last event: Back-off restarting failed container <---
```

After:
```
---- Updating units [web] ----
 ---> 0 of 1 new units created
 ---> 1 old units pending termination
  ---> myapp-web-f8ff96d8d-pkvsp - Successfully assigned default/myapp-web-f8ff96d8d-pkvsp to minikube [default-scheduler]
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
  ---> myapp-web-f8ff96d8d-pkvsp - Container image "192.168.50.1:5000/tsuru/app-myapp:v30" already present on machine [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-f8ff96d8d-pkvsp - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Container image "192.168.50.1:5000/tsuru/app-myapp:v30" already present on machine [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Container image "192.168.50.1:5000/tsuru/app-myapp:v30" already present on machine [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Container image "192.168.50.1:5000/tsuru/app-myapp:v30" already present on machine [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f8ff96d8d-pkvsp - Back-off restarting failed container [kubelet, minikube]

**** ROLLING BACK AFTER FAILURE ****

---- ERROR during deploy: ----
 ---> Pod "myapp-web-f8ff96d8d-pkvsp" not ready: containers with unready status: [myapp-web]
 ---> Pod "myapp-web-f8ff96d8d-pkvsp" has crashed 3 times: Exited with status 1
 ---> Pod "myapp-web-f8ff96d8d-pkvsp" with warning: Back-off restarting failed container

---- Last 10 log messages: ----
    2019-10-02 15:00:59 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: a=1/0
    2019-10-02 15:00:59 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: ZeroDivisionError: division by zero
    2019-10-02 15:01:13 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: Traceback (most recent call last):
    2019-10-02 15:01:13 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: File "app.py", line 31, in <module>
    2019-10-02 15:01:13 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: a=1/0
    2019-10-02 15:01:13 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: ZeroDivisionError: division by zero
    2019-10-02 15:01:41 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: Traceback (most recent call last):
    2019-10-02 15:01:41 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: File "app.py", line 31, in <module>
    2019-10-02 15:01:41 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: a=1/0
    2019-10-02 15:01:41 -0300 [web][myapp-web-f8ff96d8d-pkvsp]: ZeroDivisionError: division by zero
```

#### Scenario 4 - Process unable to start (invalid command in Procfile)

Before:
```
---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-6f7dcc8587-v8lst - Successfully assigned default/myapp-web-6f7dcc8587-v8lst to minikube [default-scheduler]
  ---> myapp-web-6f7dcc8587-v8lst - Container image "192.168.50.1:5000/tsuru/app-myapp:v7" already present on machine [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Started container myapp-web [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-6f7dcc8587-v8lst - Container image "192.168.50.1:5000/tsuru/app-myapp:v7" already present on machine [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Container image "192.168.50.1:5000/tsuru/app-myapp:v7" already present on machine [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Container image "192.168.50.1:5000/tsuru/app-myapp:v7" already present on machine [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
 ---> Pod not ready in time: Pod myapp-web-6f7dcc8587-v8lst: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused

**** ROLLING BACK AFTER FAILURE ****
 ---> timeout waiting full rollout after 59.833326176s waiting for units: Pod myapp-web-6f7dcc8587-v8lst: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused <---
---- ERROR during deploy: ----
timeout waiting full rollout after 59.833326176s waiting for units: Pod myapp-web-6f7dcc8587-v8lst: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused
---- Last 10 log messages: ----
    2019-09-27T15:04:11Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T15:04:23Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Container image "192.168.50.1:5000/tsuru/app-myapp:v7" already present on machine [kubelet, minikube]
    2019-09-27T15:04:23Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Created container myapp-web [kubelet, minikube]
    2019-09-27T15:04:23Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Started container myapp-web [kubelet, minikube]
    2019-09-27T15:04:23Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused [kubelet, minikube]
    2019-09-27T15:04:24Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T15:04:36Z[tsuru][api]:   ---> myapp-web-6f7dcc8587-v8lst - Back-off restarting failed container [kubelet, minikube]
    2019-09-27T15:04:39Z[tsuru][api]:  ---> Pod not ready in time: Pod myapp-web-6f7dcc8587-v8lst: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused
    2019-09-27T15:04:39Z[tsuru][api]: **** ROLLING BACK AFTER FAILURE ****
    2019-09-27T15:04:39Z[tsuru][api]:  ---> timeout waiting full rollout after 59.833326176s waiting for units: Pod myapp-web-6f7dcc8587-v8lst: invalid pod phase "Running" - last event: Readiness probe failed: Get http://172.17.0.5:8888/xyz: dial tcp 172.17.0.5:8888: connect: connection refused <---
```

After:
```
---- Updating units [web] ----
 ---> 1 of 1 new units created
 ---> 0 of 1 new units ready
 ---> 1 old units pending termination
  ---> myapp-web-f4fddddfd-7lm9p - Successfully assigned default/myapp-web-f4fddddfd-7lm9p to minikube [default-scheduler]
  ---> myapp-web-f4fddddfd-7lm9p - Container image "192.168.50.1:5000/tsuru/app-myapp:v27" already present on machine [kubelet, minikube]
 ---> waiting healthcheck on 1 created units
  ---> myapp-web-f4fddddfd-7lm9p - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Container image "192.168.50.1:5000/tsuru/app-myapp:v27" already present on machine [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Container image "192.168.50.1:5000/tsuru/app-myapp:v27" already present on machine [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Container image "192.168.50.1:5000/tsuru/app-myapp:v27" already present on machine [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Created container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Started container myapp-web [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]
  ---> myapp-web-f4fddddfd-7lm9p - Back-off restarting failed container [kubelet, minikube]

**** ROLLING BACK AFTER FAILURE ****

---- ERROR during deploy: ----
 ---> Pod "myapp-web-f4fddddfd-7lm9p" not ready: containers with unready status: [myapp-web]
 ---> Pod "myapp-web-f4fddddfd-7lm9p" has crashed 3 times: Exited with status 127
 ---> Pod "myapp-web-f4fddddfd-7lm9p" with warning: Back-off restarting failed container

---- Last 2 log messages: ----
    2019-10-02 14:49:15 -0300 [web][myapp-web-f4fddddfd-7lm9p]: /bin/sh: 1: exec: xxxxxxxxxxxxxx: not found
    2019-10-02 14:49:42 -0300 [web][myapp-web-f4fddddfd-7lm9p]: /bin/sh: 1: exec: xxxxxxxxxxxxxx: not found
```