### PR TITLE
iaas/dockermachine: init logs only once

### DIFF
--- a/iaas/dockermachine/dockermachine.go
+++ b/iaas/dockermachine/dockermachine.go
@@ -35,8 +35,6 @@ type DockerMachine struct {
 
 type DockerMachineConfig struct {
 	CaPath    string
-	OutWriter io.Writer
-	ErrWriter io.Writer
 	StorePath string
 	IsDebug   bool
 }
@@ -72,6 +70,20 @@ type Machine struct {
 	Host *host.Host
 }
 
+func InitLogging(outWriter, errorWriter io.Writer, isDebug bool) {
+	if outWriter != nil {
+		log.SetOutWriter(outWriter)
+	} else {
+		log.SetOutWriter(ioutil.Discard)
+	}
+	if errorWriter != nil {
+		log.SetOutWriter(errorWriter)
+	} else {
+		log.SetOutWriter(ioutil.Discard)
+	}
+	log.SetDebug(isDebug)
+}
+
 func NewDockerMachine(config DockerMachineConfig) (DockerMachineAPI, error) {
 	storePath := config.StorePath
 	temp := false
@@ -100,17 +112,6 @@ func NewDockerMachine(config DockerMachineConfig) (DockerMachineAPI, error) {
 			return nil, errors.Wrap(err, "failed to copy ca key file")
 		}
 	}
-	if config.OutWriter != nil {
-		log.SetOutWriter(config.OutWriter)
-	} else {
-		log.SetOutWriter(ioutil.Discard)
-	}
-	if config.ErrWriter != nil {
-		log.SetOutWriter(config.ErrWriter)
-	} else {
-		log.SetOutWriter(ioutil.Discard)
-	}
-	log.SetDebug(config.IsDebug)
 	client := libmachine.NewClient(storePath, certsPath)
 	client.IsDebug = config.IsDebug
 	if _, err := os.Stat(client.GetMachinesDir()); os.IsNotExist(err) {


### PR DESCRIPTION
The log packgage inside docker/machine is a singleton, by updating it each time a new machine is created/destroyed we were at risk of a race condition updating the log.

Race example:
```
==================
WARNING: DATA RACE
Write at 0x00c0000b41e0 by goroutine 88:
  github.com/docker/machine/libmachine/log.(*FmtMachineLogger).SetOutWriter()
      /Users/cezarsa/go/pkg/mod/github.com/cezarsa/machine@v0.7.1-0.20190219165632-cdcfd549f935/libmachine/log/fmt_machine_logger.go:31 +0x3a
  github.com/tsuru/tsuru/iaas/dockermachine.NewDockerMachine()
      /Users/cezarsa/go/pkg/mod/github.com/cezarsa/machine@v0.7.1-0.20190219165632-cdcfd549f935/libmachine/log/log.go:65 +0xcd0
  github.com/tsuru/tsuru/iaas/dockermachine.(*S).TestNewDockerMachineRaceCheck.func1()
      /Users/cezarsa/code/tsuru/iaas/dockermachine/dockermachine_test.go:35 +0x115

Previous write at 0x00c0000b41e0 by goroutine 87:
  github.com/docker/machine/libmachine/log.(*FmtMachineLogger).SetOutWriter()
      /Users/cezarsa/go/pkg/mod/github.com/cezarsa/machine@v0.7.1-0.20190219165632-cdcfd549f935/libmachine/log/fmt_machine_logger.go:31 +0x3a
  github.com/tsuru/tsuru/iaas/dockermachine.NewDockerMachine()
      /Users/cezarsa/go/pkg/mod/github.com/cezarsa/machine@v0.7.1-0.20190219165632-cdcfd549f935/libmachine/log/log.go:65 +0xcd0
  github.com/tsuru/tsuru/iaas/dockermachine.(*S).TestNewDockerMachineRaceCheck.func1()
      /Users/cezarsa/code/tsuru/iaas/dockermachine/dockermachine_test.go:35 +0x115

Goroutine 88 (running) created at:
  github.com/tsuru/tsuru/iaas/dockermachine.(*S).TestNewDockerMachineRaceCheck()
      /Users/cezarsa/code/tsuru/iaas/dockermachine/dockermachine_test.go:33 +0xb9
  runtime.call32()
      /usr/local/Cellar/go/1.13/libexec/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /usr/local/Cellar/go/1.13/libexec/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /Users/cezarsa/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20161208181325-20d25e280405/check.go:772 +0x9aa
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /Users/cezarsa/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20161208181325-20d25e280405/check.go:666 +0xc4

Goroutine 87 (running) created at:
  github.com/tsuru/tsuru/iaas/dockermachine.(*S).TestNewDockerMachineRaceCheck()
      /Users/cezarsa/code/tsuru/iaas/dockermachine/dockermachine_test.go:33 +0xb9
  runtime.call32()
      /usr/local/Cellar/go/1.13/libexec/src/runtime/asm_amd64.s:539 +0x3a
  reflect.Value.Call()
      /usr/local/Cellar/go/1.13/libexec/src/reflect/value.go:321 +0xd3
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /Users/cezarsa/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20161208181325-20d25e280405/check.go:772 +0x9aa
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /Users/cezarsa/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20161208181325-20d25e280405/check.go:666 +0xc4
==================
```