### PR TITLE
io: prevent flushing and writing after on a closed writer

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -89,7 +89,7 @@ func (m *flushingWriterMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}()
 	if flusher, ok := w.(io.WriterFlusher); ok {
 		flushingWriter := &io.FlushingWriter{WriterFlusher: flusher}
-		defer flushingWriter.Flush()
+		defer flushingWriter.Close()
 		if m.latencyConfig != nil {
 			flushingWriter.MaxLatency = m.latencyConfig[r.URL.Query().Get(":mux-route-name")]
 		}

--- a/io/flushing_writer_test.go
+++ b/io/flushing_writer_test.go
@@ -174,7 +174,7 @@ func (s *S) TestFlushingWriterFlushAfterWrite(c *check.C) {
 		flusher, ok := w.(WriterFlusher)
 		c.Assert(ok, check.Equals, true)
 		fw := FlushingWriter{WriterFlusher: flusher}
-		defer fw.Flush()
+		defer fw.Close()
 		for i := 0; i < 100; i++ {
 			wg.Add(1)
 			go func() {
@@ -184,7 +184,10 @@ func (s *S) TestFlushingWriterFlushAfterWrite(c *check.C) {
 		}
 	}))
 	defer srv.Close()
-	_, err := http.Get(srv.URL)
+	rsp, err := http.Get(srv.URL)
+	c.Assert(err, check.IsNil)
+	defer rsp.Body.Close()
+	_, err = ioutil.ReadAll(rsp.Body)
 	c.Assert(err, check.IsNil)
 	wg.Wait()
 }


### PR DESCRIPTION
Writing to a http.ResponseWriter after the handler has returned is not allowed but the consequences are not too drastic, usually you only end up with unexpected data in the socket. Calling `Flush()` however is a different story, it can cause an ugly panic as demonstrated in the test added here:
```
$ go test
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x110056c]

goroutine 98 [running]:
bufio.(*Writer).Flush(0xc000196140, 0x0, 0x0)
	/usr/local/Cellar/go/1.13/libexec/src/bufio/bufio.go:593 +0x5c
net/http.(*response).Flush(0xc0001bc000)
	/usr/local/Cellar/go/1.13/libexec/src/net/http/server.go:1638 +0x35
github.com/tsuru/tsuru/io.(*FlushingWriter).Write(0xc00016e210, 0xc0000280de, 0x1, 0x1, 0x1, 0x0, 0x0)
	/Users/cezarsa/code/tsuru/io/flushing_writer.go:56 +0x204
github.com/tsuru/tsuru/io.(*S).TestFlushingWriterFlushAfterWrite.func1.1(0xc0000b52b0, 0xc00016e210)
	/Users/cezarsa/code/tsuru/io/flushing_writer_test.go:182 +0x94
created by github.com/tsuru/tsuru/io.(*S).TestFlushingWriterFlushAfterWrite.func1
	/Users/cezarsa/code/tsuru/io/flushing_writer_test.go:180 +0x1f1
```

Now the FlushingWriter do not allow further writes and flushes after being closed and we always call Close() before the handler has returned.