### PR TITLE
TestDeleteMachineErrorNoServer is failing

### DIFF
--- a/iaas/cloudstack/iaas_test.go
+++ b/iaas/cloudstack/iaas_test.go
@@ -362,7 +362,7 @@ func (s *cloudstackSuite) TestDeleteMachineErrorNoServer(c *check.C) {
 	c.Assert(err, check.IsNil)
 	machine := iaas.Machine{Id: "myMachineId"}
 	err = cs.DeleteMachine(&machine)
-	c.Assert(err, check.ErrorMatches, ".*no such host.*")
+	c.Assert(err, check.ErrorMatches, ".*Temporary failure in name resolution*")
 }
 
 func (s *cloudstackSuite) TestHealthCheck(c *check.C) {


### PR DESCRIPTION
Fixes : #2364 

Running make test failed inside TestDeleteMachineErrorNoServer method.

Looks like the returned error message has been modified