### PR TITLE
fix(auth/oauth2): validate token only using expiry time boundary

### DIFF
--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -200,19 +200,9 @@ func (s *OAuthScheme) Auth(header string) (auth.Token, error) {
 		}
 		return nil, err
 	}
-	config, err := s.loadConfig()
-	if err != nil {
-		return nil, err
+	if !token.Token.Valid() {
+		return token, auth.ErrInvalidToken
 	}
-	client := config.Client(context.Background(), &token.Token)
-	t0 := time.Now()
-	rsp, err := client.Get(s.InfoURL)
-	requestLatencies.Observe(time.Since(t0).Seconds())
-	if err != nil {
-		requestErrors.Inc()
-		return nil, err
-	}
-	defer rsp.Body.Close()
 	return token, nil
 }
 


### PR DESCRIPTION
This PR removes the need for validating the token against the authorization server. Now it's only verified locally by checking the expiry time boundary embed into oauth2 token.

NOTE: This PR also adds a new problem :roll_eyes: Even the user drops his session in the authorization server, his session in Tsuru API will not be deleted until the token expiration.

Closes #2355