### PR TITLE
Fixes for IaaS destroy

### DIFF
--- a/api/iaas.go
+++ b/api/iaas.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/globalsign/mgo"
 	"github.com/tsuru/tsuru/auth"
@@ -64,6 +65,7 @@ func machineDestroy(w http.ResponseWriter, r *http.Request, token auth.Token) (e
 	if machineID == "" {
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: "machine id is required"}
 	}
+	force, _ := strconv.ParseBool(r.URL.Query().Get("force"))
 	m, err := iaas.FindMachineById(machineID)
 	if err != nil {
 		if err == iaas.ErrMachineNotFound {
@@ -87,7 +89,9 @@ func machineDestroy(w http.ResponseWriter, r *http.Request, token auth.Token) (e
 		return err
 	}
 	defer func() { evt.Done(err) }()
-	return m.Destroy()
+	return m.Destroy(iaas.DestroyParams{
+		Force: force,
+	})
 }
 
 // title: machine template list

--- a/healer/healer_node.go
+++ b/healer/healer_node.go
@@ -144,7 +144,7 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 		Disable: true,
 	})
 	if err != nil {
-		machine.Destroy()
+		machine.Destroy(iaas.DestroyParams{})
 		return nil, errors.Wrapf(err, "Can't auto-heal after %d failures for node %s: error unregistering old node", failures, failingHost)
 	}
 	newAddr := machine.FormatNodeAddress()
@@ -169,7 +169,7 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 			healthNode.ResetFailures()
 		}
 		node.Provisioner().UpdateNode(provision.UpdateNodeOptions{Address: failingAddr, Enable: true})
-		machine.Destroy()
+		machine.Destroy(iaas.DestroyParams{})
 		return nil, errors.Wrapf(err, "Can't auto-heal after %d failures for node %s: error registering new node", failures, failingHost)
 	}
 	nodeSpec := provision.NodeToSpec(node)
@@ -189,7 +189,7 @@ func (h *NodeHealer) healNode(node provision.Node) (*provision.NodeSpec, error) 
 	}
 	failingMachine, err := iaas.FindMachineById(node.IaaSID())
 	if err == nil {
-		err = failingMachine.Destroy()
+		err = failingMachine.Destroy(iaas.DestroyParams{})
 		if err != nil {
 			multiErr.Add(errors.Wrapf(err, "Unable to destroy machine %s from IaaS", failingHost))
 		}

--- a/iaas/suite_test.go
+++ b/iaas/suite_test.go
@@ -40,11 +40,15 @@ func (s *S) TearDownSuite(c *check.C) {
 }
 
 type TestIaaS struct {
-	cmds []string
+	cmds      []string
+	deleteErr error
 }
 
 func (i *TestIaaS) DeleteMachine(m *Machine) error {
 	i.cmds = append(i.cmds, "delete")
+	if i.deleteErr != nil {
+		return i.deleteErr
+	}
 	m.Status = "destroyed"
 	return nil
 }

--- a/provision/docker/healer/suite_test.go
+++ b/provision/docker/healer/suite_test.go
@@ -53,7 +53,7 @@ func (s *S) SetUpTest(c *check.C) {
 	iaas.ResetAll()
 	machines, _ := iaas.ListMachines()
 	for _, m := range machines {
-		m.Destroy()
+		m.Destroy(iaas.DestroyParams{})
 	}
 	os.Setenv("TSURU_TARGET", "http://localhost")
 	servicemock.SetMockService(&servicemock.MockService{})

--- a/provision/node/node.go
+++ b/provision/node/node.go
@@ -130,7 +130,7 @@ func removeNodeWithNode(node provision.Node, opts provision.RemoveNodeOptions, r
 		var m iaas.Machine
 		m, err = iaas.FindMachineByIdOrAddress(node.IaaSID(), net.URLToHost(opts.Address))
 		if err == nil {
-			err = m.Destroy()
+			err = m.Destroy(iaas.DestroyParams{})
 		}
 		if err != nil && err != iaas.ErrMachineNotFound {
 			multi.Add(errors.Wrapf(err, "unable to destroy machine in iaas"))


### PR DESCRIPTION
Twor major changes in this PR.

On the dockermachine IaaS implementation we now convert panics on `Close()` to regular errors, these panics are currently out of our control and may happen after an error in `DeleteMachine` calls.
Also on dockermachine implementation we convert cloudstack plugin information related to networks from a single string to a string slice due to changes in the plugin implementation.

The second major change is for the base IaaS implementation. We no longer ignore errors on destroy and instead return the error by default. A `force` flag was introduced to the iaas and to the related handler to allow us to ignore such errors and proceed with the removal from our internal storage.

