### PR TITLE
Ensure image versions are never reused and always incremented

### DIFF
--- a/api/build_test.go
+++ b/api/build_test.go
@@ -142,10 +142,10 @@ func (s *BuildSuite) SetUpTest(c *check.C) {
 }
 
 func (s *BuildSuite) TestBuildHandler(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
 		c.Assert(opts.ArchiveFile, check.NotNil)
 		c.Assert(opts.Tag, check.Equals, "mytag")
-		return "tsuruteam/app-otherapp:mytag", nil
+		return builder.MockImageInfo{FakeIsBuild: true, FakeBuildImageName: "tsuruteam/app-otherapp:mytag"}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",
@@ -195,9 +195,9 @@ func (s *BuildSuite) TestBuildHandler(c *check.C) {
 }
 
 func (s *BuildSuite) TestBuildArchiveURL(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
 		c.Assert(opts.ArchiveURL, check.Equals, "http://something.tar.gz")
-		return "tsuruteam/app-otherapp:mytag", nil
+		return builder.MockImageInfo{FakeIsBuild: true, FakeBuildImageName: "tsuruteam/app-otherapp:mytag"}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -145,10 +145,10 @@ func (s *DeploySuite) SetUpTest(c *check.C) {
 
 func (s *DeploySuite) TestDeployHandler(c *check.C) {
 	var builderCalled bool
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
 		builderCalled = true
 		c.Assert(opts.ArchiveURL, check.Equals, "http://something.tar.gz")
-		return "tsuruteam/app-otherapp:mytag", nil
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)
@@ -190,9 +190,9 @@ func (s *DeploySuite) TestDeployHandler(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployOriginDragAndDrop(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
 		c.Assert(opts.ArchiveFile, check.NotNil)
-		return "tsuruteam/app-otherapp:mytag", nil
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)
@@ -254,8 +254,8 @@ func (s *DeploySuite) TestDeployInvalidOrigin(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployOriginImage(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)
@@ -294,8 +294,8 @@ func (s *DeploySuite) TestDeployOriginImage(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployArchiveURL(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",
@@ -340,8 +340,8 @@ func (s *DeploySuite) TestDeployArchiveURL(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployUploadFile(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",
@@ -394,8 +394,8 @@ func (s *DeploySuite) TestDeployUploadFile(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployUploadLargeFile(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",
@@ -450,8 +450,8 @@ func (s *DeploySuite) TestDeployUploadLargeFile(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployWithCommit(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	token, err := nativeScheme.AppLogin(app.InternalAppName)
 	c.Assert(err, check.IsNil)
@@ -500,8 +500,8 @@ func (s *DeploySuite) TestDeployWithCommit(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{
 		Name:      "otherapp",
@@ -547,8 +547,8 @@ func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployWithMessage(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	token, err := nativeScheme.AppLogin(app.InternalAppName)
 	c.Assert(err, check.IsNil)
@@ -596,8 +596,8 @@ func (s *DeploySuite) TestDeployWithMessage(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployWithoutPlatformFails(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	token, err := nativeScheme.AppLogin(app.InternalAppName)
 	c.Assert(err, check.IsNil)
@@ -621,8 +621,8 @@ func (s *DeploySuite) TestDeployWithoutPlatformFails(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployDockerImage(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "myapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)
@@ -661,8 +661,8 @@ func (s *DeploySuite) TestDeployDockerImage(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployShouldIncrementDeployNumberOnApp(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)
@@ -736,8 +736,8 @@ func (s *DeploySuite) TestDeployShouldReturnForbiddenWhenTokenIsntFromTheApp(c *
 }
 
 func (s *DeploySuite) TestDeployWithTokenForInternalAppName(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "tsuruteam/app-otherapp:mytag", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	token, err := nativeScheme.AppLogin(app.InternalAppName)
 	c.Assert(err, check.IsNil)
@@ -1356,9 +1356,9 @@ func (s *DeploySuite) TestDiffDeployWhenUserDoesNotHaveAccessToApp(c *check.C) {
 }
 
 func (s *DeploySuite) TestDeployRebuildHandler(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
 		c.Assert(opts.Rebuild, check.Equals, true)
-		return "tsuruteam/app-otherapp:mytag", nil
+		return builder.MockImageInfo{FakeBuildImageName: "tsuruteam/app-otherapp:mytag", FakeIsBuild: true}, nil
 	}
 	a := app.App{Name: "otherapp", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(&a, s.user)

--- a/app/deploy_test.go
+++ b/app/deploy_test.go
@@ -258,8 +258,8 @@ func (s *S) TestGetDeployInvalidHex(c *check.C) {
 }
 
 func (s *S) TestBuildApp(c *check.C) {
-	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (string, error) {
-		return "registry.somewhere/" + s.team.Name + "/app-some-app:v1-builder", nil
+	s.builder.OnBuild = func(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *builder.BuildOpts) (provision.NewImageInfo, error) {
+		return builder.MockImageInfo{FakeIsBuild: true, FakeBuildImageName: "registry.somewhere/" + s.team.Name + "/app-some-app:v1-builder"}, nil
 	}
 	a := App{
 		Name:      "some-app",

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -33,7 +33,7 @@ type BuildOpts struct {
 
 // Builder is the basic interface of this package.
 type Builder interface {
-	Build(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *BuildOpts) (string, error)
+	Build(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *BuildOpts) (provision.NewImageInfo, error)
 }
 
 var builders = make(map[string]Builder)

--- a/builder/docker/actions.go
+++ b/builder/docker/actions.go
@@ -29,7 +29,7 @@ type runContainerActionsArgs struct {
 	commands      []string
 	writer        io.Writer
 	isDeploy      bool
-	buildingImage string
+	buildingImage provision.NewImageInfo
 	provisioner   provision.BuilderDeployDockerClient
 	client        provision.BuilderDockerClient
 	exposedPort   string
@@ -67,7 +67,7 @@ var createContainer = action.Action{
 				Type:          args.app.GetPlatform(),
 				Name:          contName,
 				Image:         args.imageID,
-				BuildingImage: args.buildingImage,
+				BuildingImage: args.buildingImage.BuildImageName(),
 				ExposedPort:   args.exposedPort,
 			},
 		}
@@ -231,7 +231,7 @@ var updateAppBuilderImage = action.Action{
 		if err := checkCanceled(args.event); err != nil {
 			return nil, err
 		}
-		err := image.AppendAppBuilderImageName(args.app.GetName(), args.buildingImage)
+		err := image.AppendAppBuilderImageName(args.app.GetName(), args.buildingImage.BuildImageName())
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to save image name")
 		}

--- a/builder/mock.go
+++ b/builder/mock.go
@@ -5,6 +5,7 @@
 package builder
 
 import (
+	"github.com/tsuru/tsuru/app/image"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/provision"
 	appTypes "github.com/tsuru/tsuru/types/app"
@@ -14,14 +15,14 @@ var _ Builder = &MockBuilder{}
 var _ PlatformBuilder = &MockBuilder{}
 
 type MockBuilder struct {
-	OnBuild          func(provision.BuilderDeploy, provision.App, *event.Event, *BuildOpts) (string, error)
+	OnBuild          func(provision.BuilderDeploy, provision.App, *event.Event, *BuildOpts) (provision.NewImageInfo, error)
 	OnPlatformBuild  func(appTypes.PlatformOptions) error
 	OnPlatformRemove func(string) error
 }
 
-func (b *MockBuilder) Build(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *BuildOpts) (string, error) {
+func (b *MockBuilder) Build(p provision.BuilderDeploy, app provision.App, evt *event.Event, opts *BuildOpts) (provision.NewImageInfo, error) {
 	if b.OnBuild == nil {
-		return "", nil
+		return image.NewImageInfo{}, nil
 	}
 	return b.OnBuild(p, app, evt, opts)
 }
@@ -38,4 +39,27 @@ func (b *MockBuilder) PlatformRemove(name string) error {
 		return nil
 	}
 	return b.OnPlatformRemove(name)
+}
+
+type MockImageInfo struct {
+	FakeBaseImageName  string
+	FakeBuildImageName string
+	FakeVersion        int
+	FakeIsBuild        bool
+}
+
+func (i MockImageInfo) BaseImageName() string {
+	return i.FakeBaseImageName
+}
+
+func (i MockImageInfo) BuildImageName() string {
+	return i.FakeBuildImageName
+}
+
+func (i MockImageInfo) Version() int {
+	return i.FakeVersion
+}
+
+func (i MockImageInfo) IsBuild() bool {
+	return i.FakeIsBuild
 }

--- a/provision/docker/actions_test.go
+++ b/provision/docker/actions_test.go
@@ -731,13 +731,13 @@ func (s *S) TestProvisionAddUnitsToHostForward(c *check.C) {
 	defer coll.RemoveAll(bson.M{"appname": app.GetName()})
 	imageID, err := image.AppNewImageName(app.GetName())
 	c.Assert(err, check.IsNil)
-	err = newFakeImage(p, imageID, nil)
+	err = newFakeImage(p, imageID.BaseImageName(), nil)
 	c.Assert(err, check.IsNil)
 	args := changeUnitsPipelineArgs{
 		app:         app,
 		toHost:      "localhost",
 		toAdd:       map[string]*containersToAdd{"web": {Quantity: 2}},
-		imageID:     imageID,
+		imageID:     imageID.BaseImageName(),
 		provisioner: p,
 	}
 	context := action.FWContext{Params: []interface{}{args}}
@@ -762,12 +762,12 @@ func (s *S) TestProvisionAddUnitsToHostForwardWithoutHost(c *check.C) {
 	defer coll.Close()
 	imageID, err := image.AppNewImageName(app.GetName())
 	c.Assert(err, check.IsNil)
-	err = newFakeImage(p, imageID, nil)
+	err = newFakeImage(p, imageID.BaseImageName(), nil)
 	c.Assert(err, check.IsNil)
 	args := changeUnitsPipelineArgs{
 		app:         app,
 		toAdd:       map[string]*containersToAdd{"web": {Quantity: 3}},
-		imageID:     imageID,
+		imageID:     imageID.BaseImageName(),
 		provisioner: p,
 	}
 	context := action.FWContext{Params: []interface{}{args}}
@@ -878,7 +878,7 @@ func (s *S) TestFollowLogsAndCommitForward(c *check.C) {
 	app := provisiontest.NewFakeApp("mightyapp", "python", 1)
 	nextImgName, err := image.AppNewImageName(app.GetName())
 	c.Assert(err, check.IsNil)
-	cont := container.Container{Container: types.Container{AppName: "mightyapp", ID: "myid123", BuildingImage: nextImgName}}
+	cont := container.Container{Container: types.Container{AppName: "mightyapp", ID: "myid123", BuildingImage: nextImgName.BaseImageName()}}
 	err = cont.Create(&container.CreateArgs{
 		App:      app,
 		ImageID:  "tsuru/python",
@@ -1271,12 +1271,12 @@ func (s *S) TestUpdateAppImageForward(c *check.C) {
 	app := provisiontest.NewFakeApp("mightyapp", "python", 1)
 	nextImgName, err := image.AppNewImageName(app.GetName())
 	c.Assert(err, check.IsNil)
-	err = image.AppendAppImageName(app.GetName(), nextImgName)
+	err = image.AppendAppImageName(app.GetName(), nextImgName.BaseImageName())
 	c.Assert(err, check.IsNil)
 	nextImgName, err = image.AppNewImageName(app.GetName())
 	c.Assert(err, check.IsNil)
 	registry.AddRepo(registrytest.Repository{Name: "tsuru/app-mightyapp", Tags: map[string]string{"v1": "abcdefg"}})
-	cont := container.Container{Container: types.Container{AppName: "mightyapp", ID: "myid123", BuildingImage: nextImgName}}
+	cont := container.Container{Container: types.Container{AppName: "mightyapp", ID: "myid123", BuildingImage: nextImgName.BaseImageName()}}
 	err = cont.Create(&container.CreateArgs{
 		App:      app,
 		ImageID:  "tsuru/python",
@@ -1295,7 +1295,7 @@ func (s *S) TestUpdateAppImageForward(c *check.C) {
 	}
 	err = s.p.Cluster().PullImage(pullOpts, dockercommon.RegistryAuthConfig(registry.Addr()))
 	c.Assert(err, check.IsNil)
-	args := changeUnitsPipelineArgs{app: app, writer: buf, provisioner: s.p, imageID: nextImgName}
+	args := changeUnitsPipelineArgs{app: app, writer: buf, provisioner: s.p, imageID: nextImgName.BaseImageName()}
 	context := action.FWContext{Params: []interface{}{args}, Previous: &cont}
 	_, err = updateAppImage.Forward(context)
 	c.Assert(err, check.IsNil)

--- a/provision/docker/provisioner.go
+++ b/provision/docker/provisioner.go
@@ -375,16 +375,16 @@ func (p *dockerProvisioner) Rollback(a provision.App, imageID string, evt *event
 	return imageID, p.deploy(a, imageID, evt)
 }
 
-func (p *dockerProvisioner) Deploy(app provision.App, buildImageID string, evt *event.Event) (string, error) {
-	if !strings.HasSuffix(buildImageID, "-builder") {
-		err := p.deploy(app, buildImageID, evt)
+func (p *dockerProvisioner) Deploy(app provision.App, img provision.NewImageInfo, evt *event.Event) (string, error) {
+	if !img.IsBuild() {
+		err := p.deploy(app, img.BaseImageName(), evt)
 		if err != nil {
 			return "", err
 		}
-		return buildImageID, nil
+		return img.BaseImageName(), nil
 	}
 	cmds := dockercommon.DeployCmds(app)
-	imageID, err := p.deployPipeline(app, buildImageID, cmds, evt)
+	imageID, err := p.deployPipeline(app, img, cmds, evt)
 	if err != nil {
 		return "", err
 	}

--- a/provision/kubernetes/builder_test.go
+++ b/provision/kubernetes/builder_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/builder"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/safe"
@@ -129,7 +130,7 @@ func (s *S) TestImageTagPushAndInspect(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	client := KubeClient{}
-	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", "tsuru/app-myapp:tag2")
+	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", builder.MockImageInfo{FakeBaseImageName: "tsuru/app-myapp:tag2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(img.ID, check.Equals, "1234")
 	c.Assert(procfileRaw, check.Equals, "web: make run")
@@ -161,7 +162,7 @@ func (s *S) TestImageTagPushAndInspectWithPoolNamespaces(c *check.C) {
 		return false, nil, nil
 	})
 	client := KubeClient{}
-	_, _, _, err = client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", "tsuru/app-myapp:tag2")
+	_, _, _, err = client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", builder.MockImageInfo{FakeBaseImageName: "tsuru/app-myapp:tag2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(atomic.LoadInt32(&counter), check.Equals, int32(1))
 }
@@ -211,7 +212,7 @@ cat >/dev/null && /bin/deploy-agent`)
 	})
 
 	client := KubeClient{}
-	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "registry.example.com/tsuru/app-myapp:tag1", "registry.example.com/tsuru/app-myapp:tag2")
+	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "registry.example.com/tsuru/app-myapp:tag1", builder.MockImageInfo{FakeBaseImageName: "registry.example.com/tsuru/app-myapp:tag2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(img.ID, check.Equals, "1234")
 	c.Assert(procfileRaw, check.Equals, "web: make run")
@@ -264,7 +265,7 @@ cat >/dev/null && /bin/deploy-agent`)
 	})
 
 	client := KubeClient{}
-	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "otherregistry.example.com/tsuru/app-myapp:tag1", "otherregistry.example.com/tsuru/app-myapp:tag2")
+	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "otherregistry.example.com/tsuru/app-myapp:tag1", builder.MockImageInfo{FakeBaseImageName: "otherregistry.example.com/tsuru/app-myapp:tag2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(img.ID, check.Equals, "1234")
 	c.Assert(procfileRaw, check.Equals, "web: make run")
@@ -284,7 +285,7 @@ func (s *S) TestImageTagPushAndInspectWithKubernetesConfig(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	client := KubeClient{}
-	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", "tsuru/app-myapp:tag2")
+	img, procfileRaw, yamlData, err := client.ImageTagPushAndInspect(a, "tsuru/app-myapp:tag1", builder.MockImageInfo{FakeBaseImageName: "tsuru/app-myapp:tag2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(img.ID, check.Equals, "1234")
 	c.Assert(procfileRaw, check.Equals, "web: make run")

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1600,6 +1600,7 @@ func (s *S) TestCreateBuildPodContainers(c *check.C) {
 		sourceImage:       "myimg",
 		destinationImages: []string{"destimg"},
 		inputFile:         "/home/application/archive.tar.gz",
+		podName:           "myapp-v1-build",
 	})
 	c.Assert(err, check.IsNil)
 	ns, err := s.client.AppNamespace(a)
@@ -1664,6 +1665,7 @@ func (s *S) TestCreateDeployPodContainers(c *check.C) {
 		sourceImage:       "myimg",
 		destinationImages: []string{"destimg"},
 		inputFile:         "/dev/null",
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.IsNil)
 	ns, err := s.client.AppNamespace(a)
@@ -1785,6 +1787,7 @@ func (s *S) TestCreateDeployPodContainersWithRegistryAuth(c *check.C) {
 		sourceImage:       "myimg",
 		destinationImages: []string{"registry.example.com/destimg"},
 		inputFile:         "/dev/null",
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.IsNil)
 	ns, err := s.client.AppNamespace(a)
@@ -1963,6 +1966,7 @@ func (s *S) TestCreateDeployPodProgress(c *check.C) {
 		inputFile:         "/dev/null",
 		attachInput:       strings.NewReader("."),
 		attachOutput:      buf,
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.IsNil)
 	<-podReactorDone
@@ -1995,6 +1999,7 @@ func (s *S) TestCreateDeployPodAttachFail(c *check.C) {
 		inputFile:         "/dev/null",
 		attachInput:       strings.NewReader("."),
 		attachOutput:      buf,
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.ErrorMatches, `error attaching to myapp-v1-deploy/committer-cont: container finished while attach is running`)
 	<-ch
@@ -2011,6 +2016,7 @@ func (s *S) TestCreateDeployPodContainersWithTag(c *check.C) {
 		sourceImage:       "myimg",
 		destinationImages: []string{"ip:destimg:v1"},
 		inputFile:         "/dev/null",
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.IsNil)
 	ns, err := s.client.AppNamespace(a)

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tsuru/tsuru/app/image"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/log"
 	tsuruNet "github.com/tsuru/tsuru/net"
@@ -70,22 +69,14 @@ func headlessServiceNameForApp(a provision.App, process string) string {
 	return fmt.Sprintf("%s-units", appProcessName(a, process))
 }
 
-func deployPodNameForApp(a provision.App) (string, error) {
-	version, err := image.AppCurrentImageVersion(a.GetName())
-	if err != nil {
-		return "", errors.WithMessage(err, "failed to retrieve app current image version")
-	}
+func deployPodNameForApp(a provision.App, newImg provision.NewImageInfo) string {
 	name := validKubeName(a.GetName())
-	return fmt.Sprintf("%s-%s-deploy", name, version), nil
+	return fmt.Sprintf("%s-v%d-deploy", name, newImg.Version())
 }
 
-func buildPodNameForApp(a provision.App) (string, error) {
-	version, err := image.AppCurrentImageVersion(a.GetName())
-	if err != nil {
-		return "", errors.WithMessage(err, "failed to retrieve app current image version")
-	}
+func buildPodNameForApp(a provision.App, newImg provision.NewImageInfo) string {
 	name := validKubeName(a.GetName())
-	return fmt.Sprintf("%s-%s-build", name, version), nil
+	return fmt.Sprintf("%s-v%d-build", name, newImg.Version())
 }
 
 func appLabelForApp(a provision.App, process string) string {

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/tsuru/tsuru/builder"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
 	"github.com/tsuru/tsuru/provision/provisiontest"
@@ -91,15 +92,16 @@ func (s *S) TestHeadlessServiceNameForApp(c *check.C) {
 func (s *S) TestDeployPodNameForApp(c *check.C) {
 	var tests = []struct {
 		name, expected string
+		version        int
 	}{
-		{"myapp", "myapp-v1-deploy"},
-		{"MYAPP", "myapp-v1-deploy"},
-		{"my-app_app", "my-app-app-v1-deploy"},
+		{"myapp", "myapp-v1-deploy", 1},
+		{"MYAPP", "myapp-v1-deploy", 1},
+		{"my-app_app", "my-app-app-v1-deploy", 1},
+		{"myapp", "myapp-v9-deploy", 9},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)
-		name, err := deployPodNameForApp(a)
-		c.Check(err, check.IsNil)
+		name := deployPodNameForApp(a, builder.MockImageInfo{FakeVersion: tt.version})
 		c.Check(name, check.Equals, tt.expected, check.Commentf("test %d", i))
 	}
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -928,6 +928,7 @@ func (s *S) TestRegisterUnitDeployUnit(c *check.C) {
 		app:               a,
 		sourceImage:       "myimg",
 		destinationImages: []string{"destimg"},
+		podName:           "myapp-v1-deploy",
 	})
 	c.Assert(err, check.IsNil)
 	meta, err := image.GetImageMetaData("destimg")
@@ -1108,7 +1109,9 @@ func (s *S) TestProvisionerDestroy(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	wait()
 	ns, err := s.client.AppNamespace(a)
@@ -1146,7 +1149,9 @@ func (s *S) TestProvisionerRoutableAddresses(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil)
 	wait()
 	addrs, err := s.p.RoutableAddresses(a)
@@ -1186,7 +1191,9 @@ func (s *S) TestProvisionerRoutableAddressesRouterAddressLocal(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil)
 	wait()
 	addrs, err := s.p.RoutableAddresses(a)
@@ -1216,7 +1223,9 @@ func (s *S) TestDeploy(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
@@ -1266,7 +1275,9 @@ func (s *S) TestDeployCreatesAppCR(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 }
 
@@ -1301,7 +1312,9 @@ func (s *S) TestDeployWithPoolNamespaces(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
@@ -1363,7 +1376,9 @@ func (s *S) TestInternalAddresses(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 
 	addrs, err := s.p.InternalAddresses(context.Background(), a)
@@ -1414,7 +1429,9 @@ func (s *S) TestInternalAddressesNoService(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	_, err = s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 
 	addrs, err := s.p.InternalAddresses(context.Background(), a)
@@ -1473,7 +1490,9 @@ func (s *S) TestDeployWithCustomConfig(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
@@ -1559,8 +1578,10 @@ func (s *S) TestDeployBuilderImageCancel(c *check.C) {
 		Cancelable:    true,
 	})
 	c.Assert(err, check.IsNil)
+	newImg, err := image.AppNewBuildImageName(a.GetName(), "", "")
+	c.Assert(err, check.IsNil)
 	go func(evt *event.Event) {
-		img, errDeploy := s.p.Deploy(a, "tsuru/app-myapp:v1-builder", evt)
+		img, errDeploy := s.p.Deploy(a, newImg, evt)
 		c.Check(errDeploy, check.ErrorMatches, `canceled after .*`)
 		c.Check(img, check.Equals, "")
 		deploy <- struct{}{}
@@ -1599,7 +1620,9 @@ func (s *S) TestRollback(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", deployEvt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, deployEvt)
 	c.Assert(err, check.IsNil)
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	customData = map[string]interface{}{
@@ -1609,7 +1632,9 @@ func (s *S) TestRollback(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v2", customData)
 	c.Assert(err, check.IsNil)
-	img, err = s.p.Deploy(a, "tsuru/app-myapp:v2", deployEvt)
+	newImg, err = image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err = s.p.Deploy(a, newImg, deployEvt)
 	c.Assert(err, check.IsNil)
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v2")
 	deployEvt.Done(err)
@@ -1683,7 +1708,9 @@ mkdir -p $(dirname /dev/null) && cat >/dev/null && tsuru_unit_agent   myapp depl
 		Allowed: event.Allowed(permission.PermAppDeploy),
 	})
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "registry.example.com/tsuru/app-myapp:v1-builder", evt)
+	newImg, err := image.AppNewBuildImageName(a.GetName(), "", "")
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "registry.example.com/tsuru/app-myapp:v1")
 }
@@ -2176,7 +2203,9 @@ func (s *S) TestProvisionerUpdateApp(c *check.C) {
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
@@ -2277,7 +2306,9 @@ func (s *S) TestProvisionerUpdateAppWithVolumeSameClusterAndNamespace(c *check.C
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()
@@ -2340,7 +2371,9 @@ func (s *S) TestProvisionerUpdateAppWithVolumeSameClusterOtherNamespace(c *check
 	}
 	err = image.SaveImageCustomData("tsuru/app-myapp:v1", customData)
 	c.Assert(err, check.IsNil)
-	img, err := s.p.Deploy(a, "tsuru/app-myapp:v1", evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	img, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(img, check.Equals, "tsuru/app-myapp:v1")
 	wait()

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -275,16 +275,23 @@ type ExecDockerClient interface {
 	InspectExec(execId string) (*docker.ExecInspect, error)
 }
 
+type NewImageInfo interface {
+	BaseImageName() string
+	BuildImageName() string
+	Version() int
+	IsBuild() bool
+}
+
 type BuilderKubeClient interface {
-	BuildPod(App, *event.Event, io.Reader, string) (string, error)
+	BuildPod(App, *event.Event, io.Reader, string) (NewImageInfo, error)
 	BuildImage(name string, images []string, inputStream io.Reader, output io.Writer, ctx context.Context) error
-	ImageTagPushAndInspect(App, string, string) (*docker.Image, string, *provTypes.TsuruYamlData, error)
+	ImageTagPushAndInspect(App, string, NewImageInfo) (*docker.Image, string, *provTypes.TsuruYamlData, error)
 	DownloadFromContainer(App, string) (io.ReadCloser, error)
 }
 
 // BuilderDeploy is a provisioner that allows deploy builded image.
 type BuilderDeploy interface {
-	Deploy(App, string, *event.Event) (string, error)
+	Deploy(App, NewImageInfo, *event.Event) (string, error)
 }
 
 type BuilderDeployDockerClient interface {

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -856,7 +856,7 @@ func (p *FakeProvisioner) Swap(app1, app2 provision.App, cnameOnly bool) error {
 	return routertest.FakeRouter.Swap(app1.GetName(), app2.GetName(), cnameOnly)
 }
 
-func (p *FakeProvisioner) Deploy(app provision.App, img string, evt *event.Event) (string, error) {
+func (p *FakeProvisioner) Deploy(app provision.App, img provision.NewImageInfo, evt *event.Event) (string, error) {
 	if err := p.getError("Deploy"); err != nil {
 		return "", err
 	}
@@ -866,7 +866,11 @@ func (p *FakeProvisioner) Deploy(app provision.App, img string, evt *event.Event
 	if !ok {
 		return "", errNotProvisioned
 	}
-	pApp.image = img
+	if img.IsBuild() {
+		pApp.image = img.BuildImageName()
+	} else {
+		pApp.image = img.BaseImageName()
+	}
 	evt.Write([]byte("Builder deploy called"))
 	p.apps[app.GetName()] = pApp
 	return fakeAppImage, nil

--- a/provision/swarm/provisioner_test.go
+++ b/provision/swarm/provisioner_test.go
@@ -1148,7 +1148,6 @@ func (s *S) TestDeploy(c *check.C) {
 		Allowed: event.Allowed(permission.PermAppDeploy),
 	})
 	c.Assert(err, check.IsNil)
-	builderImgID := "registry.tsuru.io/tsuru/app-myapp:v1-builder"
 	pullOpts := docker.PullImageOptions{
 		Repository: "tsuru/app-myapp",
 		Tag:        "v1-builder",
@@ -1157,7 +1156,9 @@ func (s *S) TestDeploy(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = cli.PullImage(pullOpts, docker.AuthConfiguration{})
 	c.Assert(err, check.IsNil)
-	imgID, err := s.p.Deploy(a, builderImgID, evt)
+	newImg, err := image.AppNewBuildImageName(a.GetName(), "", "")
+	c.Assert(err, check.IsNil)
+	imgID, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	c.Assert(<-attached, check.Equals, true)
 	c.Assert(tags, check.DeepEquals, []string{"v1", "latest"})
@@ -1206,14 +1207,15 @@ func (s *S) TestDeployImageID(c *check.C) {
 		Allowed: event.Allowed(permission.PermAppDeploy),
 	})
 	c.Assert(err, check.IsNil)
-	builderImgID := "registry.tsuru.io/tsuru/app-myapp:v1"
 	pullOpts := docker.PullImageOptions{
 		Repository: "tsuru/app-myapp",
 		Tag:        "v1",
 	}
 	err = cli.PullImage(pullOpts, docker.AuthConfiguration{})
 	c.Assert(err, check.IsNil)
-	deployedImg, err := s.p.Deploy(a, builderImgID, evt)
+	newImg, err := image.AppNewImageName(a.GetName())
+	c.Assert(err, check.IsNil)
+	deployedImg, err := s.p.Deploy(a, newImg, evt)
 	c.Assert(err, check.IsNil)
 	c.Assert(deployedImg, check.Equals, "registry.tsuru.io/tsuru/app-myapp:v1")
 	units, err := s.p.Units(a)


### PR DESCRIPTION
It was possible for a failed build to reuse the same version multiple
times for each failed attempt. This happened because the version counter
was only incremeneted *after* the build step and just before the deploy
step.

The changes introduced here ensure we always increment the version
counter in the database before any other action is taken, this
incremented version is then propagated to the provisioner.