### PR TITLE
provision/docker: add pids limit config option

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1135,6 +1135,11 @@ docker:sharedfs:app-isolation
 
 If true, the ``hostdir`` will have subdirectories for each app. All apps will still have access to a shared mount point, however they will be in completely isolated subdirectories.
 
+docker:pids-limit
++++++++++++++++++
+
+Maximum number of pids in a single container. Defaults to unlimited.
+
 .. _iaas_configuration:
 
 IaaS configuration

--- a/provision/docker/container/container.go
+++ b/provision/docker/container/container.go
@@ -492,6 +492,12 @@ func (c *Container) hostConfig(app provision.App, isDeploy bool) (*docker.HostCo
 			hostConfig.Binds = append(hostConfig.Binds, fmt.Sprintf("%s:%s:rw", sharedBasedir, sharedMount))
 		}
 	}
+
+	pidsLimit, _ := config.GetInt("docker:pids-limit")
+	if pidsLimit > 0 {
+		hostConfig.PidsLimit = int64(pidsLimit)
+	}
+
 	return &hostConfig, nil
 }
 

--- a/provision/docker/containers.go
+++ b/provision/docker/containers.go
@@ -13,6 +13,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
+	"github.com/tsuru/config"
 	"github.com/tsuru/docker-cluster/cluster"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/app"
@@ -369,6 +370,10 @@ func (p *dockerProvisioner) runCommandInContainer(image string, app provision.Ap
 		HostConfig: &docker.HostConfig{
 			AutoRemove: true,
 		},
+	}
+	pidsLimit, _ := config.GetInt("docker:pids-limit")
+	if pidsLimit > 0 {
+		createOptions.HostConfig.PidsLimit = int64(pidsLimit)
 	}
 	cluster := p.Cluster()
 	schedOpts := &container.SchedulerOpts{


### PR DESCRIPTION
This limit can help preventing a bad container from affecting the host with excessive forks like in a shell bomb.