### PR TITLE
docs: add more information about planb configuration

### DIFF
--- a/docs/installing/planb-router.rst
+++ b/docs/installing/planb-router.rst
@@ -67,6 +67,12 @@ environment variable for configuring the binding address and the Redis
 endpoint, along with other settings, as `described in PlanB docs
 <https://github.com/tsuru/planb#start-up-flags>`_.
 
+Keep in mind that you will need to change the init file for service in
+``/etc/systemd/system/planb.service`` and add in the line where the 
+``ExecStart`` is located the loading of the environment variable.
+The line will have the following content: 
+``ExecStart=/usr/bin/planb $PLANB_OPTS``.
+
 After changing the file, you only need to start PlanB with:
 
 .. highlight:: bash


### PR DESCRIPTION
This PR adds more information about how to configure planb on systemd based hosts.

This update is necessary because FPM (used at `https://github.com/tsuru/planb/blob/master/misc/fpm_recipe.rb`) doesn't add as a parameter an environment variable.

Changing the FPM configuration doesn't have the expected result. When FPM script has your `pleaserun.input` altered to include `$PLANB_OPTS`, the result is escaped on systemd file.

```
pleaserun.input ["/usr/bin/planb", "$PLANB_OPTS"]
```

Generates at `/etc/systemd/system/planb.service`:
```
ExecStart=/usr/bin/planb "\$PLANB_OPTS"
```

Thus, as it is not possible to generate a `/etc /systemd/system/planb.service` file where`ExecStart` uses the `$PLANB_OPTS` environment variable, the documentation has been updated to inform that the user must make this change manually.

FPM has an issue with this behavior: https://github.com/jordansissel/pleaserun/issues/124