### PR TITLE
provision/kubernetes: Improved errors and cancelation for image deploys

### DIFF
--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1186,7 +1186,7 @@ func (p *kubernetesProvisioner) ExecuteCommand(opts provision.ExecOptions) error
 		tty:      opts.Stdin != nil,
 	}
 	if len(opts.Units) == 0 {
-		return runIsolatedCmdPod(client, eOpts)
+		return runIsolatedCmdPod(context.TODO(), client, eOpts)
 	}
 	for _, u := range opts.Units {
 		eOpts.unit = u
@@ -1198,7 +1198,7 @@ func (p *kubernetesProvisioner) ExecuteCommand(opts provision.ExecOptions) error
 	return nil
 }
 
-func runIsolatedCmdPod(client *ClusterClient, opts execOpts) error {
+func runIsolatedCmdPod(ctx context.Context, client *ClusterClient, opts execOpts) error {
 	baseName := execCommandPodNameForApp(opts.app)
 	labels, err := provision.ServiceLabels(provision.ServiceLabelsOpts{
 		App: opts.app,
@@ -1222,7 +1222,7 @@ func runIsolatedCmdPod(client *ClusterClient, opts execOpts) error {
 	for _, envData := range appEnvs {
 		envs = append(envs, apiv1.EnvVar{Name: envData.Name, Value: envData.Value})
 	}
-	return runPod(runSinglePodArgs{
+	return runPod(ctx, runSinglePodArgs{
 		client:   client,
 		stdout:   opts.stdout,
 		stderr:   opts.stderr,

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -282,11 +282,17 @@ type NewImageInfo interface {
 	IsBuild() bool
 }
 
+type InspectData struct {
+	Image     docker.Image
+	TsuruYaml provTypes.TsuruYamlData
+	Procfile  string
+}
+
 type BuilderKubeClient interface {
 	BuildPod(App, *event.Event, io.Reader, string) (NewImageInfo, error)
 	BuildImage(name string, images []string, inputStream io.Reader, output io.Writer, ctx context.Context) error
-	ImageTagPushAndInspect(App, string, NewImageInfo) (*docker.Image, string, *provTypes.TsuruYamlData, error)
-	DownloadFromContainer(App, string) (io.ReadCloser, error)
+	ImageTagPushAndInspect(App, *event.Event, string, NewImageInfo) (InspectData, error)
+	DownloadFromContainer(App, *event.Event, string) (io.ReadCloser, error)
 }
 
 // BuilderDeploy is a provisioner that allows deploy builded image.


### PR DESCRIPTION
Now tsuru will show kubernetes events happening during image pull and inspect for image deploys. It will also show better error messages if the inspect pod failed to start. Event cancelation also propagates correctly to the deploy pod.