### PR TITLE
provision/docker: Ignore errors during bind unit when adding units

### DIFF
--- a/provision/docker/actions.go
+++ b/provision/docker/actions.go
@@ -382,7 +382,7 @@ var bindAndHealthcheck = action.Action{
 			unit := c.AsUnit(args.app)
 			err := args.app.BindUnit(&unit)
 			if err != nil {
-				return err
+				log.Errorf("ignored error binding unit to service: %v", err)
 			}
 			toRollback <- c
 			if doHealthcheck && c.ProcessName == webProcessName {


### PR DESCRIPTION
The bindsyncer goroutine is already responsible for adding and removing incorrect unit binds. Ignoring bind errors was already the default behavior in the kubernetes provisioner, this ensures both provisioner behaves equaly regarding unit binds.