### PR TITLE
router/rebuild: Only save rebuild event on error

### DIFF
--- a/router/rebuild/rebuild.go
+++ b/router/rebuild/rebuild.go
@@ -60,17 +60,6 @@ func rebuildRoutes(app RebuildApp, dry, wait bool, w io.Writer) (map[string]Rebu
 	return result, multi.ToError()
 }
 
-func resultHasChanges(result map[string]RebuildRoutesResult) bool {
-	for _, routerResult := range result {
-		for _, prefixResult := range routerResult.PrefixResults {
-			if len(prefixResult.Added) > 0 || len(prefixResult.Removed) > 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func diffRoutes(old []*url.URL, new []*url.URL) (toAdd []*url.URL, toRemove []*url.URL) {
 	expectedMap := make(map[string]*url.URL)
 	for i, addr := range new {

--- a/router/rebuild/task.go
+++ b/router/rebuild/task.go
@@ -135,7 +135,7 @@ func runRoutesRebuildOnce(appName string, lock bool, w io.Writer) (err error) {
 		}
 
 		defer func() {
-			if err != nil || resultHasChanges(result) {
+			if err != nil {
 				evt.DoneCustomData(err, result)
 				return
 			}


### PR DESCRIPTION
Successful rebuild events are not really useful and create a lot of
noise in the events list.