### PR TITLE
provision/kubernetes: Remove '-base' suffix for base deployments

### DIFF
--- a/app/version/service.go
+++ b/app/version/service.go
@@ -113,3 +113,11 @@ func (s *appVersionService) AllAppVersions() ([]appTypes.AppVersions, error) {
 func (s *appVersionService) DeleteVersion(appName string, version int) error {
 	return s.storage.DeleteVersion(appName, version)
 }
+
+func (s *appVersionService) AppVersionFromInfo(app appTypes.App, info appTypes.AppVersionInfo) appTypes.AppVersion {
+	return &appVersionImpl{
+		app:         app,
+		storage:     s.storage,
+		versionInfo: &info,
+	}
+}

--- a/provision/kubernetes/helpers.go
+++ b/provision/kubernetes/helpers.go
@@ -514,22 +514,6 @@ func cleanupReplicas(client *ClusterClient, dep *appsv1.Deployment) error {
 	return cleanupPods(client, listOpts, dep)
 }
 
-func selectorForVersion(a provision.App, process string, version appTypes.AppVersion) (*provision.LabelSet, error) {
-	svcLabels, err := provision.ServiceLabels(provision.ServiceLabelsOpts{
-		App:     a,
-		Process: process,
-		Version: version.Version(),
-		ServiceLabelExtendedOpts: provision.ServiceLabelExtendedOpts{
-			Prefix:      tsuruLabelPrefix,
-			Provisioner: provisionerName,
-		},
-	})
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return svcLabels, nil
-}
-
 func baseVersionForApp(client *ClusterClient, a provision.App) (appTypes.AppVersion, error) {
 	deps, err := allDeploymentsForApp(client, a)
 	if err != nil {

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -58,13 +58,13 @@ func (s *S) TestDeploymentNameForAppBase(c *check.C) {
 	var tests = []struct {
 		name, process, expected string
 	}{
-		{"myapp", "p1", "myapp-p1-base"},
-		{"MYAPP", "p-1", "myapp-p-1-base"},
-		{"my-app_app", "P_1-1", "my-app-app-p-1-1-base"},
-		{"app-with-a-very-very-long-name", "p1", "app-with-a-very-very-long-name-p1-base"},
-		{"my-app", "process-with-a-very-very-long-name-12345678", "my-app-process-with-a-very-very-long-name-12345678-base"},
-		{"my-app", "process-with-a-very-very-long-name-12345678901234", "my-app-78668678080e31ecc876957b5f29e68738b41ea3d07145a5"},
-		{"app-with-a-very-very-long-name", "process-with-a-very-very-long-name", "app-with-a-very-very-long-name-197faf9d3223e28f0bec723c"},
+		{"myapp", "p1", "myapp-p1"},
+		{"MYAPP", "p-1", "myapp-p-1"},
+		{"my-app_app", "P_1-1", "my-app-app-p-1-1"},
+		{"app-with-a-very-very-long-name", "p1", "app-with-a-very-very-long-name-p1"},
+		{"my-app", "process-with-a-very-very-long-name-1234567890123", "my-app-process-with-a-very-very-long-name-1234567890123"},
+		{"my-app", "process-with-a-very-very-long-name-12345678901234", "my-app-0718ca0d56b1219fb50636a73252a47b977839e983558e08"},
+		{"app-with-a-very-very-long-name", "process-with-a-very-very-long-name", "app-with-a-very-very-long-name-a9101bf0964e84e3f4c4b2b0"},
 	}
 	for i, tt := range tests {
 		a := provisiontest.NewFakeApp(tt.name, "plat", 1)

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -525,6 +525,7 @@ func (s *S) TestCleanupReplicas(c *check.C) {
 			},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	rs, err := s.client.AppsV1().ReplicaSets(ns).Create(&appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "myapp-p1-xxx",

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -201,6 +201,7 @@ func (s *S) TestNodeUnits(c *check.C) {
 			Addresses: []url.URL{
 				{Scheme: "http", Host: ":30000"},
 			},
+			Routable: true,
 		},
 		{
 			ID:          "myapp-worker-pod-2-1",
@@ -214,6 +215,7 @@ func (s *S) TestNodeUnits(c *check.C) {
 			Addresses: []url.URL{
 				{Scheme: "http", Host: ":30000"},
 			},
+			Routable: true,
 		},
 	})
 }
@@ -304,6 +306,7 @@ func (s *S) TestNodeUnitsUsingPoolNamespaces(c *check.C) {
 			Status:      "started",
 			Address:     &url.URL{Scheme: "http", Host: ""},
 			Addresses:   []url.URL{},
+			Routable:    true,
 		},
 		{
 			ID:          "otherapp-1",
@@ -315,6 +318,7 @@ func (s *S) TestNodeUnitsUsingPoolNamespaces(c *check.C) {
 			Status:      "started",
 			Address:     &url.URL{Scheme: "http", Host: ""},
 			Addresses:   []url.URL{},
+			Routable:    true,
 		},
 	})
 }
@@ -373,6 +377,7 @@ func (s *S) TestNodeUnitsOnlyFromServices(c *check.C) {
 			Addresses: []url.URL{
 				{Scheme: "http", Host: ":30000"},
 			},
+			Routable: true,
 		},
 		{
 			ID:          "myapp-worker-pod-2-1",
@@ -386,6 +391,7 @@ func (s *S) TestNodeUnitsOnlyFromServices(c *check.C) {
 			Addresses: []url.URL{
 				{Scheme: "http", Host: ":30000"},
 			},
+			Routable: true,
 		},
 	})
 }

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -610,7 +610,7 @@ func (s *S) TestUnits(c *check.C) {
 	})
 	for i, u := range units {
 		splittedName := strings.Split(u.ID, "-")
-		c.Assert(splittedName, check.HasLen, 6)
+		c.Assert(splittedName, check.HasLen, 5)
 		c.Assert(splittedName[0], check.Equals, "myapp")
 		units[i].ID = ""
 		units[i].Name = ""
@@ -728,6 +728,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 				{Scheme: "http", Host: "192.168.99.1:30001"},
 				{Scheme: "http", Host: "192.168.99.1:30002"},
 			},
+			Routable: true,
 		},
 		{
 			ID:          "myapp-2",
@@ -742,6 +743,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 				{Scheme: "http", Host: "192.168.99.2:30001"},
 				{Scheme: "http", Host: "192.168.99.2:30002"},
 			},
+			Routable: true,
 		},
 		{
 			ID:          "otherapp-1",
@@ -756,6 +758,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 				{Scheme: "http", Host: "192.168.99.1:30001"},
 				{Scheme: "http", Host: "192.168.99.1:30002"},
 			},
+			Routable: true,
 		},
 		{
 			ID:          "otherapp-2",
@@ -770,6 +773,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 				{Scheme: "http", Host: "192.168.99.2:30001"},
 				{Scheme: "http", Host: "192.168.99.2:30002"},
 			},
+			Routable: true,
 		},
 	})
 }
@@ -1440,7 +1444,7 @@ func (s *S) TestDeploy(c *check.C) {
 	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
-	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web-base")
+	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web")
 	containers := deps.Items[0].Spec.Template.Spec.Containers
 	c.Assert(containers, check.HasLen, 1)
 	c.Assert(containers[0].Command[len(containers[0].Command)-3:], check.DeepEquals, []string{
@@ -1457,8 +1461,8 @@ func (s *S) TestDeploy(c *check.C) {
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
 		NamespaceName:      "default",
 		ServiceAccountName: "app-myapp",
-		Deployments:        map[string][]string{"web": {"myapp-web-base"}},
-		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-v1", "myapp-web-units"}},
+		Deployments:        map[string][]string{"web": {"myapp-web"}},
+		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-units", "myapp-web-v1"}},
 	})
 }
 
@@ -1525,8 +1529,8 @@ func (s *S) TestDeployWithPoolNamespaces(c *check.C) {
 	c.Assert(appList.Items[0].Spec, check.DeepEquals, tsuruv1.AppSpec{
 		NamespaceName:      "tsuru-test-default",
 		ServiceAccountName: "app-myapp",
-		Deployments:        map[string][]string{"web": {"myapp-web-base"}},
-		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-v1", "myapp-web-units"}},
+		Deployments:        map[string][]string{"web": {"myapp-web"}},
+		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-units", "myapp-web-v1"}},
 	})
 }
 
@@ -1690,7 +1694,7 @@ func (s *S) TestDeployWithCustomConfig(c *check.C) {
 	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
-	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web-base")
+	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web")
 	containers := deps.Items[0].Spec.Template.Spec.Containers
 	c.Assert(containers, check.HasLen, 1)
 	c.Assert(containers[0].Command[len(containers[0].Command)-3:], check.DeepEquals, []string{
@@ -1707,8 +1711,8 @@ func (s *S) TestDeployWithCustomConfig(c *check.C) {
 	expected := tsuruv1.AppSpec{
 		NamespaceName:      "default",
 		ServiceAccountName: "app-myapp",
-		Deployments:        map[string][]string{"web": {"myapp-web-base"}},
-		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-v1", "myapp-web-units"}},
+		Deployments:        map[string][]string{"web": {"myapp-web"}},
+		Services:           map[string][]string{"web": {"myapp-web", "myapp-web-units", "myapp-web-v1"}},
 		Configs: &provTypes.TsuruYamlKubernetesConfig{
 			Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 				"pod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -1838,7 +1842,7 @@ func (s *S) TestDeployRollback(c *check.C) {
 	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)
-	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web-base")
+	c.Assert(deps.Items[0].Name, check.Equals, "myapp-web")
 	containers := deps.Items[0].Spec.Template.Spec.Containers
 	c.Assert(containers, check.HasLen, 1)
 	c.Assert(containers[0].Command[len(containers[0].Command)-3:], check.DeepEquals, []string{
@@ -2010,19 +2014,19 @@ func (s *S) TestExecuteCommandWithStdin(c *check.C) {
 		Width:  99,
 		Height: 42,
 		Term:   "xterm",
-		Units:  []string{"myapp-web-base-pod-1-1"},
+		Units:  []string{"myapp-web-pod-1-1"},
 		Cmds:   []string{"mycmd", "arg1"},
 	})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	rollback()
-	c.Assert(s.mock.Stream["myapp-web-base"].Stdin, check.Equals, "echo test")
+	c.Assert(s.mock.Stream["myapp-web"].Stdin, check.Equals, "echo test")
 	var sz remotecommand.TerminalSize
-	err = json.Unmarshal([]byte(s.mock.Stream["myapp-web-base"].Resize), &sz)
+	err = json.Unmarshal([]byte(s.mock.Stream["myapp-web"].Resize), &sz)
 	c.Assert(err, check.IsNil)
 	c.Assert(sz, check.DeepEquals, remotecommand.TerminalSize{Width: 99, Height: 42})
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls, check.HasLen, 1)
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-base-pod-1-1/exec")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Query()["command"], check.DeepEquals, []string{"/usr/bin/env", "TERM=xterm", "mycmd", "arg1"})
+	c.Assert(s.mock.Stream["myapp-web"].Urls, check.HasLen, 1)
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-pod-1-1/exec")
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Query()["command"], check.DeepEquals, []string{"/usr/bin/env", "TERM=xterm", "mycmd", "arg1"})
 }
 
 func (s *S) TestExecuteCommandWithStdinNoSize(c *check.C) {
@@ -2044,15 +2048,15 @@ func (s *S) TestExecuteCommandWithStdinNoSize(c *check.C) {
 		Stdout: conn,
 		Stderr: conn,
 		Term:   "xterm",
-		Units:  []string{"myapp-web-base-pod-1-1"},
+		Units:  []string{"myapp-web-pod-1-1"},
 		Cmds:   []string{"mycmd", "arg1"},
 	})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	rollback()
-	c.Assert(s.mock.Stream["myapp-web-base"].Stdin, check.Equals, "echo test")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls, check.HasLen, 1)
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-base-pod-1-1/exec")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Query()["command"], check.DeepEquals, []string{"/usr/bin/env", "TERM=xterm", "mycmd", "arg1"})
+	c.Assert(s.mock.Stream["myapp-web"].Stdin, check.Equals, "echo test")
+	c.Assert(s.mock.Stream["myapp-web"].Urls, check.HasLen, 1)
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-pod-1-1/exec")
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Query()["command"], check.DeepEquals, []string{"/usr/bin/env", "TERM=xterm", "mycmd", "arg1"})
 }
 
 func (s *S) TestExecuteCommandWithStdinNoUnits(c *check.C) {
@@ -2127,18 +2131,18 @@ func (s *S) TestExecuteCommand(c *check.C) {
 		App:    a,
 		Stdout: stdout,
 		Stderr: stderr,
-		Units:  []string{"myapp-web-base-pod-1-1", "myapp-web-base-pod-2-2"},
+		Units:  []string{"myapp-web-pod-1-1", "myapp-web-pod-2-2"},
 		Cmds:   []string{"mycmd", "arg1", "arg2"},
 	})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	rollback()
 	c.Assert(stdout.String(), check.Equals, "stdout datastdout data")
 	c.Assert(stderr.String(), check.Equals, "stderr datastderr data")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls, check.HasLen, 2)
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-base-pod-1-1/exec")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[1].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-base-pod-2-2/exec")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[1].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
+	c.Assert(s.mock.Stream["myapp-web"].Urls, check.HasLen, 2)
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-pod-1-1/exec")
+	c.Assert(s.mock.Stream["myapp-web"].Urls[1].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-pod-2-2/exec")
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
+	c.Assert(s.mock.Stream["myapp-web"].Urls[1].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
 }
 
 func (s *S) TestExecuteCommandSingleUnit(c *check.C) {
@@ -2157,16 +2161,16 @@ func (s *S) TestExecuteCommandSingleUnit(c *check.C) {
 		App:    a,
 		Stdout: stdout,
 		Stderr: stderr,
-		Units:  []string{"myapp-web-base-pod-1-1"},
+		Units:  []string{"myapp-web-pod-1-1"},
 		Cmds:   []string{"mycmd", "arg1", "arg2"},
 	})
 	c.Assert(err, check.IsNil, check.Commentf("%+v", err))
 	rollback()
 	c.Assert(stdout.String(), check.Equals, "stdout data")
 	c.Assert(stderr.String(), check.Equals, "stderr data")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls, check.HasLen, 1)
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-base-pod-1-1/exec")
-	c.Assert(s.mock.Stream["myapp-web-base"].Urls[0].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
+	c.Assert(s.mock.Stream["myapp-web"].Urls, check.HasLen, 1)
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Path, check.DeepEquals, "/api/v1/namespaces/default/pods/myapp-web-pod-1-1/exec")
+	c.Assert(s.mock.Stream["myapp-web"].Urls[0].Query()["command"], check.DeepEquals, []string{"mycmd", "arg1", "arg2"})
 }
 
 func (s *S) TestExecuteCommandNoUnits(c *check.C) {

--- a/types/app/version.go
+++ b/types/app/version.go
@@ -95,6 +95,7 @@ type AppVersionService interface {
 	NewAppVersion(args NewVersionArgs) (AppVersion, error)
 	DeleteVersions(appName string) error
 	DeleteVersion(appName string, version int) error
+	AppVersionFromInfo(App, AppVersionInfo) AppVersion
 }
 
 type AppVersionStorage interface {


### PR DESCRIPTION
With this change we go back to using `<app>-<process>` name for regular deployments and will ensure that regular rollouts will be used even after upgrading tsuru api.