### PR TITLE
auth/oauth: Make types private and always read urls from config

### DIFF
--- a/auth/oauth/token.go
+++ b/auth/oauth/token.go
@@ -17,37 +17,39 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type Token struct {
+var _ authTypes.Token = &tokenWrapper{}
+
+type tokenWrapper struct {
 	oauth2.Token
 	UserEmail string `json:"email"`
 }
 
-func (t *Token) GetValue() string {
+func (t *tokenWrapper) GetValue() string {
 	return t.AccessToken
 }
 
-func (t *Token) User() (*authTypes.User, error) {
+func (t *tokenWrapper) User() (*authTypes.User, error) {
 	return auth.ConvertOldUser(auth.GetUserByEmail(t.UserEmail))
 }
 
-func (t *Token) IsAppToken() bool {
+func (t *tokenWrapper) IsAppToken() bool {
 	return false
 }
 
-func (t *Token) GetUserName() string {
+func (t *tokenWrapper) GetUserName() string {
 	return t.UserEmail
 }
 
-func (t *Token) GetAppName() string {
+func (t *tokenWrapper) GetAppName() string {
 	return ""
 }
 
-func (t *Token) Permissions() ([]permission.Permission, error) {
+func (t *tokenWrapper) Permissions() ([]permission.Permission, error) {
 	return auth.BaseTokenPermission(t)
 }
 
-func getToken(header string) (*Token, error) {
-	var t Token
+func getToken(header string) (*tokenWrapper, error) {
+	var t tokenWrapper
 	token, err := auth.ParseToken(header)
 	if err != nil {
 		return nil, err
@@ -77,7 +79,7 @@ func deleteAllTokens(email string) error {
 	return err
 }
 
-func (t *Token) save() error {
+func (t *tokenWrapper) save() error {
 	coll := collection()
 	defer coll.Close()
 	return coll.Insert(t)

--- a/auth/oauth/token_test.go
+++ b/auth/oauth/token_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func (s *S) TestGetToken(c *check.C) {
-	existing := Token{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
+	existing := tokenWrapper{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
 	err := existing.save()
 	c.Assert(err, check.IsNil)
-	var result []Token
+	var result []tokenWrapper
 	coll := collection()
 	defer coll.Close()
 	coll.Find(nil).All(&result)
@@ -43,12 +43,12 @@ func (s *S) TestGetTokenInvalid(c *check.C) {
 }
 
 func (s *S) TestSave(c *check.C) {
-	existing := Token{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
+	existing := tokenWrapper{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
 	err := existing.save()
 	c.Assert(err, check.IsNil)
 	coll := collection()
 	defer coll.Close()
-	var tokens []Token
+	var tokens []tokenWrapper
 	err = coll.Find(nil).All(&tokens)
 	c.Assert(err, check.IsNil)
 	c.Assert(tokens, check.HasLen, 1)
@@ -56,14 +56,14 @@ func (s *S) TestSave(c *check.C) {
 }
 
 func (s *S) TestDelete(c *check.C) {
-	existing := Token{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
+	existing := tokenWrapper{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
 	err := existing.save()
 	c.Assert(err, check.IsNil)
 	err = deleteToken("myvalidtoken")
 	c.Assert(err, check.IsNil)
 	coll := collection()
 	defer coll.Close()
-	var tokens []Token
+	var tokens []tokenWrapper
 	err = coll.Find(nil).All(&tokens)
 	c.Assert(err, check.IsNil)
 	c.Assert(tokens, check.HasLen, 0)


### PR DESCRIPTION
By always reading the config we can change oauth configs without restarting tsuru.