### PR TITLE
provision/kubernetes: Use labels in pod template to find version 

### DIFF
--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -98,11 +98,9 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		"tsuru.io/app-process-replicas": "1",
 		"tsuru.io/app-platform":         "",
 		"tsuru.io/app-pool":             "test-default",
-		"tsuru.io/app-version":          "1",
 		"tsuru.io/provisioner":          "kubernetes",
 		"tsuru.io/builder":              "",
 		"app":                           "myapp-p1",
-		"version":                       "v1",
 	}
 	podLabels := make(map[string]string)
 	for k, v := range depLabels {
@@ -111,6 +109,8 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 		}
 		podLabels[k] = v
 	}
+	podLabels["tsuru.io/app-version"] = "1"
+	podLabels["version"] = "v1"
 	annotations := map[string]string{
 		"tsuru.io/router-type": "fake",
 		"tsuru.io/router-name": "fake",
@@ -1750,11 +1750,9 @@ func (s *S) TestServiceManagerDeployServiceWithPreserveVersions(c *check.C) {
 		"tsuru.io/app-process-replicas":    "1",
 		"tsuru.io/app-platform":            "",
 		"tsuru.io/app-pool":                "test-default",
-		"tsuru.io/app-version":             "2",
 		"tsuru.io/provisioner":             "kubernetes",
 		"tsuru.io/builder":                 "",
 		"app":                              "myapp-p1",
-		"version":                          "v2",
 	}
 	podLabels := make(map[string]string)
 	for k, v := range depLabels {
@@ -1763,6 +1761,8 @@ func (s *S) TestServiceManagerDeployServiceWithPreserveVersions(c *check.C) {
 		}
 		podLabels[k] = v
 	}
+	podLabels["tsuru.io/app-version"] = "2"
+	podLabels["version"] = "v2"
 	annotations := map[string]string{
 		"tsuru.io/router-type": "fake",
 		"tsuru.io/router-name": "fake",
@@ -1952,8 +1952,8 @@ func (s *S) TestServiceManagerDeployServiceWithLegacyDeploy(c *check.C) {
 
 	expectedDep := legacyDep.DeepCopy()
 	expectedDep.Labels["tsuru.io/restarts"] = "1"
-	expectedDep.Labels["tsuru.io/app-version"] = "1"
 	expectedDep.Labels["tsuru.io/is-routable"] = "true"
+	delete(expectedDep.Labels, "version")
 	expectedDep.Spec.Template.ObjectMeta.Labels["tsuru.io/restarts"] = "1"
 	expectedDep.Spec.Template.ObjectMeta.Labels["tsuru.io/app-version"] = "1"
 	expectedDep.Spec.Template.ObjectMeta.Labels["tsuru.io/is-routable"] = "true"
@@ -2030,8 +2030,8 @@ func (s *S) TestServiceManagerDeployServiceWithLegacyDeployAndNewVersion(c *chec
 	c.Assert(err, check.IsNil)
 
 	expectedDepBase := legacyDep.DeepCopy()
-	expectedDepBase.Labels["tsuru.io/app-version"] = "1"
 	expectedDepBase.Labels["tsuru.io/is-routable"] = "true"
+	delete(expectedDepBase.Labels, "version")
 	expectedDepBase.Spec.Template.ObjectMeta.Labels["tsuru.io/app-version"] = "1"
 	expectedDepBase.Spec.Template.ObjectMeta.Labels["tsuru.io/is-routable"] = "true"
 	expectedDepBase.Spec.Template.Spec.Containers[0].Env = []apiv1.EnvVar{
@@ -2045,9 +2045,8 @@ func (s *S) TestServiceManagerDeployServiceWithLegacyDeployAndNewVersion(c *chec
 
 	expectedDepV2 := legacyDep.DeepCopy()
 	expectedDepV2.Name = "myapp-p1-v2"
-	expectedDepV2.Labels["version"] = "v2"
-	expectedDepV2.Labels["tsuru.io/app-version"] = "2"
 	expectedDepV2.Labels["tsuru.io/is-isolated-run-version"] = "false"
+	delete(expectedDepV2.Labels, "version")
 	delete(expectedDepV2.Labels, "tsuru.io/is-routable")
 	delete(expectedDepV2.Labels, "tsuru.io/is-isolated-run")
 	expectedDepV2.Spec.Selector.MatchLabels["tsuru.io/app-version"] = "2"

--- a/provision/kubernetes/helpers_test.go
+++ b/provision/kubernetes/helpers_test.go
@@ -460,6 +460,11 @@ func (s *S) TestCleanupDeployment(c *check.C) {
 			Labels:    expectedLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: expectedLabels,
+				},
+			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"tsuru.io/app-name":        "myapp",

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1717,7 +1717,7 @@ func toggleRoutableDeployment(client *ClusterClient, version int, dep *appsv1.De
 	ls.ToggleIsRoutable(isRoutable)
 	ls.SetVersion(version)
 	dep.Spec.Paused = true
-	dep.ObjectMeta.Labels = ls.ToLabels()
+	dep.ObjectMeta.Labels = ls.WithoutVersion().ToLabels()
 	dep.Spec.Template.ObjectMeta.Labels = ls.WithoutAppReplicas().ToLabels()
 	_, err = client.AppsV1().Deployments(dep.Namespace).Update(dep)
 	if err != nil {

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1441,6 +1441,7 @@ func (s *S) TestDeploy(c *check.C) {
 	wait()
 	ns, err := s.client.AppNamespace(a)
 	c.Assert(err, check.IsNil)
+
 	deps, err := s.client.AppsV1().Deployments(ns).List(metav1.ListOptions{})
 	c.Assert(err, check.IsNil)
 	c.Assert(deps.Items, check.HasLen, 1)


### PR DESCRIPTION
The rollback operation on deployments only restores data in dep.Spec.Template. This change allows the rollback operation to restore the correct version labels atomically.