### PR TITLE
Support changing the exponential delay settings between consecutives rebuild routes taks

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1346,6 +1346,30 @@ IaaS. As an example, having the configuration below would allow you to call
 
 .. _config_throttling:
 
+Event rebuild routes configuration
+----------------------------------
+
+event:rebuild-routes-task:base-delay
+++++++++++++++++++++++++++++++++++++
+
+Duration in nanoseconds (supports human friendly amounts as well, such as ``1s``). Used to
+compute the exponential backoff time between failures in a row. Defaults to 5 milliseconds.
+
+event:rebuild-routes-task:max-delay
++++++++++++++++++++++++++++++++++++
+
+Duration in nanoseconds (supports human friendly amounts as well, such as ``1s``).
+Used as the maximum backoff time. Defaults to 1000 seconds.
+
+.. highlight:: yaml
+
+::
+
+    event:
+        rebuild-routes-task:
+            base-delay: 5ms
+            max-delay:  1000s
+
 Event throttling configuration
 ------------------------------
 


### PR DESCRIPTION
This PR supports to change the exponential backoff settings between rebuild routes tasks according to the values declared on Tsuru config file.

An example of Tsuru config to this PR can be seen below.

```yaml
% cat tsuru.conf
event:
  rebuild-routes-task:
    base-delay: 1s
    max-delay: 30min
```

The backoff time calculated as:

```
backoff = min( base-delay * 2 ^ failures, max-delay )
```