### PR TITLE
Stream logs directly from kubernetes api-server

### DIFF
--- a/api/logtracker_test.go
+++ b/api/logtracker_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/tsuru/tsuru/servicemanager"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	check "gopkg.in/check.v1"
 )
@@ -23,10 +22,7 @@ func (s *S) TestLogStreamTrackerAddRemove(c *check.C) {
 }
 
 func (s *S) TestLogStreamTrackerShutdown(c *check.C) {
-	l, err := servicemanager.AppLog.Watch(appTypes.ListLogArgs{
-		AppName: "myapp",
-	})
-	c.Assert(err, check.IsNil)
+	l := appTypes.NewMockLogWatcher()
 	logTracker.add(l)
 	logTracker.Shutdown(context.Background())
 	select {

--- a/api/server.go
+++ b/api/server.go
@@ -97,6 +97,10 @@ var onceServices sync.Once
 
 func setupServices() error {
 	var err error
+	servicemanager.App, err = app.AppService()
+	if err != nil {
+		return err
+	}
 	servicemanager.TeamToken, err = auth.TeamTokenService()
 	if err != nil {
 		return err

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -134,6 +134,8 @@ func (s *S) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	repository.Manager().CreateUser(s.user.Email)
 	s.setupMocks()
+	servicemanager.App, err = app.AppService()
+	c.Assert(err, check.IsNil)
 	servicemanager.AppLog, err = applog.AppLogService()
 	c.Assert(err, check.IsNil)
 	servicemanager.AppVersion, err = version.AppVersionService()

--- a/app/app.go
+++ b/app/app.go
@@ -172,9 +172,6 @@ func (app *App) CleanImage(img string) error {
 func (app *App) getProvisioner() (provision.Provisioner, error) {
 	var err error
 	if app.provisioner == nil {
-		if app.Pool == "" {
-			return provision.GetDefault()
-		}
 		app.provisioner, err = pool.GetProvisionerForPool(app.Pool)
 	}
 	return app.provisioner, err

--- a/app/service.go
+++ b/app/service.go
@@ -1,0 +1,19 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import (
+	appTypes "github.com/tsuru/tsuru/types/app"
+)
+
+type appService struct{}
+
+func (a *appService) GetByName(name string) (appTypes.App, error) {
+	return GetByName(name)
+}
+
+func AppService() (appTypes.AppService, error) {
+	return &appService{}, nil
+}

--- a/app/suite_test.go
+++ b/app/suite_test.go
@@ -181,6 +181,8 @@ func (s *S) SetUpTest(c *check.C) {
 	builder.Register("fake", s.builder)
 	builder.DefaultBuilder = "fake"
 	setupMocks(s)
+	servicemanager.App, err = AppService()
+	c.Assert(err, check.IsNil)
 	servicemanager.AppLog, err = applog.AppLogService()
 	c.Assert(err, check.IsNil)
 	servicemanager.AppVersion, err = version.AppVersionService()

--- a/applog/dispatcher.go
+++ b/applog/dispatcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/log"
 	appTypes "github.com/tsuru/tsuru/types/app"
@@ -29,71 +30,78 @@ var (
 
 	buckets = append([]float64{0.1, 0.5}, prometheus.ExponentialBuckets(1, 1.6, 15)...)
 
-	logsInQueue = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "tsuru_logs_queue_current",
-		Help: "The current number of log entries in dispatcher queue.",
+	logsInQueue = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "queue_current",
+		Help:      "The current number of log entries in dispatcher queue.",
 	})
 
-	logsInAppQueues = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tsuru_logs_app_queues_current",
-		Help: "The current number of log entries in app queues.",
+	logsInAppQueues = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "app_queues_current",
+		Help:      "The current number of log entries in app queues.",
 	}, []string{"app"})
 
-	logsQueueBlockedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "tsuru_logs_queue_blocked_seconds_total",
-		Help: "The total time spent blocked trying to add log to queue.",
+	logsQueueBlockedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "queue_blocked_seconds_total",
+		Help:      "The total time spent blocked trying to add log to queue.",
 	})
 
-	logsQueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "tsuru_logs_dispatcher_queue_size",
-		Help: "The max number of log entries in a dispatcher queue.",
+	logsQueueSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "dispatcher_queue_size",
+		Help:      "The max number of log entries in a dispatcher queue.",
 	})
 
-	logsEnqueued = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_enqueued_total",
-		Help: "The number of log entries enqueued for processing.",
+	logsEnqueued = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "enqueued_total",
+		Help:      "The number of log entries enqueued for processing.",
 	}, []string{"app"})
 
-	logsWritten = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_write_total",
-		Help: "The number of log entries written to mongo.",
+	logsWritten = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "write_total",
+		Help:      "The number of log entries written to mongo.",
 	}, []string{"app"})
 
-	logsDropped = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_dropped_total",
-		Help: "The number of log entries dropped due to full buffers.",
+	logsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "dropped_total",
+		Help:      "The number of log entries dropped due to full buffers.",
 	}, []string{"app"})
 
-	logsDroppedRateLimit = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_dropped_rate_limit_total",
-		Help: "The number of log entries dropped due to rate limit exceeded.",
+	logsDroppedRateLimit = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "dropped_rate_limit_total",
+		Help:      "The number of log entries dropped due to rate limit exceeded.",
 	}, []string{"app"})
 
-	logsMongoFullLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "tsuru_logs_mongo_full_duration_seconds",
-		Help:    "The latency distributions for log messages to be stored in database.",
-		Buckets: buckets,
+	logsMongoFullLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "mongo_full_duration_seconds",
+		Help:      "The latency distributions for log messages to be stored in database.",
+		Buckets:   buckets,
 	})
 
-	logsMongoLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "tsuru_logs_mongo_duration_seconds",
-		Help:    "The latency distributions for log messages to be stored in database.",
-		Buckets: buckets,
+	logsMongoLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "mongo_duration_seconds",
+		Help:      "The latency distributions for log messages to be stored in database.",
+		Buckets:   buckets,
 	})
 )
-
-func init() {
-	prometheus.MustRegister(logsInQueue)
-	prometheus.MustRegister(logsInAppQueues)
-	prometheus.MustRegister(logsQueueSize)
-	prometheus.MustRegister(logsEnqueued)
-	prometheus.MustRegister(logsWritten)
-	prometheus.MustRegister(logsDropped)
-	prometheus.MustRegister(logsDroppedRateLimit)
-	prometheus.MustRegister(logsQueueBlockedTotal)
-	prometheus.MustRegister(logsMongoFullLatency)
-	prometheus.MustRegister(logsMongoLatency)
-}
 
 type logDispatcher struct {
 	mu             sync.RWMutex

--- a/applog/memory.go
+++ b/applog/memory.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/set"
 	appTypes "github.com/tsuru/tsuru/types/app"
@@ -22,42 +23,45 @@ const (
 	watchBufferSize         = 1000
 	watchWarningInterval    = 30 * time.Second
 	baseLogSize             = unsafe.Sizeof(appTypes.Applog{}) + unsafe.Sizeof(ringEntry{})
+	logMemorySubsytem       = "logs_memory"
 )
 
 var (
-	logsMemoryReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_memory_received_total",
-		Help: "The number of in memory log entries received for processing.",
+	logsMemoryReceived = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: logMemorySubsytem,
+		Name:      "received_total",
+		Help:      "The number of in memory log entries received for processing.",
 	}, []string{"app"})
 
-	logsMemoryEvicted = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_memory_evicted_total",
-		Help: "The number of in memory log entries removed due to full buffer.",
+	logsMemoryEvicted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: logMemorySubsytem,
+		Name:      "evicted_total",
+		Help:      "The number of in memory log entries removed due to full buffer.",
 	}, []string{"app"})
 
-	logsMemoryDroppedWatch = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "tsuru_logs_memory_watch_dropped_total",
-		Help: "The number of messages dropped in watchers due to a slow client.",
+	logsMemoryDroppedWatch = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: logMemorySubsytem,
+		Name:      "watch_dropped_total",
+		Help:      "The number of messages dropped in watchers due to a slow client.",
 	}, []string{"app"})
 
-	logsMemorySize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tsuru_logs_memory_size",
-		Help: "The size in bytes for in memory log entries of a given app.",
+	logsMemorySize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: logMemorySubsytem,
+		Name:      "size",
+		Help:      "The size in bytes for in memory log entries of a given app.",
 	}, []string{"app"})
 
-	logsMemoryLength = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tsuru_logs_memory_length",
-		Help: "The number of in memory log entries for a given app.",
+	logsMemoryLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNamespace,
+		Subsystem: logMemorySubsytem,
+		Name:      "length",
+		Help:      "The number of in memory log entries for a given app.",
 	}, []string{"app"})
 )
-
-func init() {
-	prometheus.MustRegister(logsMemoryReceived)
-	prometheus.MustRegister(logsMemoryEvicted)
-	prometheus.MustRegister(logsMemoryDroppedWatch)
-	prometheus.MustRegister(logsMemorySize)
-	prometheus.MustRegister(logsMemoryLength)
-}
 
 type memoryLogService struct {
 	bufferMap sync.Map

--- a/applog/provisioner_wrapper.go
+++ b/applog/provisioner_wrapper.go
@@ -152,7 +152,12 @@ func (m *multiWatcher) startConsume(subWatcher appTypes.LogWatcher) {
 				return
 			}
 
-			m.ch <- log
+			select {
+			case m.ch <- log:
+			case <-m.close:
+				return
+
+			}
 		case <-m.close:
 			return
 		}

--- a/applog/provisioner_wrapper.go
+++ b/applog/provisioner_wrapper.go
@@ -1,0 +1,85 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package applog
+
+import (
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/pool"
+	"github.com/tsuru/tsuru/servicemanager"
+	appTypes "github.com/tsuru/tsuru/types/app"
+)
+
+var _ appTypes.AppLogService = &provisionerWrapper{}
+
+// provisionerWrapper is a layer designed to use provision native logging when is possible,
+// otherwise will use backwards compatibility with own tsuru log api.
+type provisionerWrapper struct {
+	logService appTypes.AppLogService
+}
+
+func newProvisionerWrapper(logService appTypes.AppLogService) appTypes.AppLogService {
+	return &provisionerWrapper{
+		logService: logService,
+	}
+}
+
+// Add is uncalled when the target pool uses own provisioner log stack
+func (k *provisionerWrapper) Add(appName, message, source, unit string) error {
+	return k.logService.Add(appName, message, source, unit)
+}
+
+// Enqueue is uncalled when the target pool uses own provisioner log stack
+func (k *provisionerWrapper) Enqueue(entry *appTypes.Applog) error {
+	return k.logService.Enqueue(entry)
+}
+
+func (k *provisionerWrapper) List(args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
+	a, err := servicemanager.App.GetByName(args.AppName)
+	if err != nil {
+		return nil, err
+	}
+	logsProvisioner, err := k.getLogsProvisioner(a)
+	if err == provision.ErrLogsUnavailable {
+		return k.logService.List(args)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	logs, err := logsProvisioner.ListLogs(a, args)
+	if err == provision.ErrLogsUnavailable {
+		return k.logService.List(args)
+	}
+	return logs, err
+}
+
+func (k *provisionerWrapper) Watch(args appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	a, err := servicemanager.App.GetByName(args.AppName)
+	if err != nil {
+		return nil, err
+	}
+	logsProvisioner, err := k.getLogsProvisioner(a)
+	if err == provision.ErrLogsUnavailable {
+		return k.logService.Watch(args)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return logsProvisioner.WatchLogs(a, args)
+}
+
+func (k *provisionerWrapper) getLogsProvisioner(a appTypes.App) (provision.LogsProvisioner, error) {
+	provisioner, err := pool.GetProvisionerForPool(a.GetPool())
+	if err != nil {
+		return nil, err
+	}
+
+	if logsProvisioner, ok := provisioner.(provision.LogsProvisioner); ok {
+		return logsProvisioner, nil
+	}
+
+	return nil, provision.ErrLogsUnavailable
+}

--- a/applog/provisioner_wrapper_test.go
+++ b/applog/provisioner_wrapper_test.go
@@ -25,6 +25,7 @@ type ProvisionerWrapperSuite struct {
 
 func (s *ProvisionerWrapperSuite) SetUpSuite(c *check.C) {
 	provisioner := provisiontest.NewFakeProvisioner()
+	provisioner.LogsEnabled = true
 	var err error
 	s.tsuruLogService, err = memoryAppLogService()
 	c.Check(err, check.IsNil)
@@ -62,7 +63,6 @@ func (s *ProvisionerWrapperSuite) Test_List(c *check.C) {
 }
 
 func (s *ProvisionerWrapperSuite) Test_Watch(c *check.C) {
-
 	watcher, err := s.provisionerWrapper.Watch(app.ListLogArgs{
 		AppName: "myapp",
 	})

--- a/applog/provisioner_wrapper_test.go
+++ b/applog/provisioner_wrapper_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package applog
+
+import (
+	"sort"
+	"time"
+
+	"github.com/tsuru/tsuru/provision"
+	"github.com/tsuru/tsuru/provision/provisiontest"
+	"github.com/tsuru/tsuru/servicemanager"
+	"github.com/tsuru/tsuru/types/app"
+	appTypes "github.com/tsuru/tsuru/types/app"
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&ProvisionerWrapperSuite{})
+
+type ProvisionerWrapperSuite struct {
+	tsuruLogService    appTypes.AppLogService
+	provisionerWrapper *provisionerWrapper
+}
+
+func (s *ProvisionerWrapperSuite) SetUpSuite(c *check.C) {
+	provisioner := provisiontest.NewFakeProvisioner()
+	var err error
+	s.tsuruLogService, err = memoryAppLogService()
+	c.Check(err, check.IsNil)
+
+	s.provisionerWrapper = &provisionerWrapper{
+		logService: s.tsuruLogService,
+		provisionerGetter: func(a appTypes.App) (provision.LogsProvisioner, error) {
+			return provisioner, nil
+		},
+	}
+	servicemanager.App = &app.MockAppService{
+		Apps: []app.App{
+			&app.MockApp{Name: "myapp", Pool: "mypool"},
+		},
+	}
+}
+
+func (s *ProvisionerWrapperSuite) Test_List(c *check.C) {
+	err := s.tsuruLogService.Enqueue(&app.Applog{
+		AppName: "myapp",
+		Message: "Fake message from tsuru logs",
+	})
+	c.Check(err, check.IsNil)
+
+	logs, err := s.provisionerWrapper.List(app.ListLogArgs{
+		AppName: "myapp",
+	})
+	sort.SliceStable(logs, func(i, j int) bool {
+		return logs[i].Message < logs[j].Message
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(logs, check.HasLen, 2)
+	c.Check(logs[0].Message, check.Equals, "Fake message from provisioner")
+	c.Check(logs[1].Message, check.Equals, "Fake message from tsuru logs")
+}
+
+func (s *ProvisionerWrapperSuite) Test_Watch(c *check.C) {
+
+	watcher, err := s.provisionerWrapper.Watch(app.ListLogArgs{
+		AppName: "myapp",
+	})
+	c.Assert(err, check.IsNil)
+
+	err = s.tsuruLogService.Enqueue(&app.Applog{
+		AppName: "myapp",
+		Message: "Fake message from tsuru logs",
+	})
+	c.Check(err, check.IsNil)
+
+	logs := []appTypes.Applog{}
+
+	ch := watcher.Chan()
+	timer := time.After(time.Second)
+loop:
+	for {
+		select {
+		case log, ok := <-ch:
+			if !ok {
+				break loop
+			}
+			logs = append(logs, log)
+			if len(logs) == 2 {
+				break loop
+			}
+		case <-timer:
+			break loop
+		}
+	}
+
+	sort.SliceStable(logs, func(i, j int) bool {
+		return logs[i].Message < logs[j].Message
+	})
+	c.Assert(logs, check.HasLen, 2)
+	c.Check(logs[0].Message, check.Equals, "Fake message from provisioner")
+	c.Check(logs[1].Message, check.Equals, "Fake message from tsuru logs")
+}
+
+func (s *ProvisionerWrapperSuite) Test_MultiWatcher(c *check.C) {
+	watcher1 := app.NewMockLogWatcher()
+	watcher2 := app.NewMockLogWatcher()
+	mw := newMultiWatcher(watcher1, watcher2)
+
+	now := time.Now()
+	watcher1.Enqueue(app.Applog{Message: "from watcher 1", Date: now})
+	watcher2.Enqueue(app.Applog{Message: "from watcher 2", Date: now.Add(time.Second)})
+	appLogs := []app.Applog{}
+
+	for {
+		appLog := <-mw.Chan()
+		appLogs = append(appLogs, appLog)
+		if len(appLogs) == 2 {
+			mw.Close()
+			break
+		}
+	}
+
+	sort.SliceStable(appLogs, func(i, j int) bool {
+		return appLogs[i].Date.Before(appLogs[j].Date)
+	})
+
+	c.Check(appLogs[0].Message, check.Equals, "from watcher 1")
+	c.Check(appLogs[1].Message, check.Equals, "from watcher 2")
+}

--- a/applog/service.go
+++ b/applog/service.go
@@ -10,6 +10,11 @@ import (
 	appTypes "github.com/tsuru/tsuru/types/app"
 )
 
+const (
+	promNamespace = "tsuru"
+	promSubsystem = "logs"
+)
+
 func AppLogService() (appTypes.AppLogService, error) {
 	appLogSvc, _ := config.GetString("log:app-log-service")
 	if appLogSvc == "" {
@@ -28,6 +33,5 @@ func AppLogService() (appTypes.AppLogService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return svc, nil
-
+	return newProvisionerWrapper(svc), nil
 }

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	tsuruv1clientset "github.com/tsuru/tsuru/provision/kubernetes/pkg/client/clientset/versioned"
 	"github.com/tsuru/tsuru/servicemanager"
+	appTypes "github.com/tsuru/tsuru/types/app"
 	provTypes "github.com/tsuru/tsuru/types/provision"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,9 @@ const (
 	maxUnavailableKey      = "max-unavailable"
 	singlePoolKey          = "single-pool"
 
+	enableLogsFromAPIServerKey = "enable-logs-from-apiserver"
+	defaultLogsFromAPIServer   = false
+
 	dialTimeout  = 30 * time.Second
 	tcpKeepAlive = 30 * time.Second
 )
@@ -61,6 +65,8 @@ var (
 		maxSurgeKey:            "Max surge for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 100%.",
 		maxUnavailableKey:      "Max unavailable for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 0.",
 		singlePoolKey:          "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
+
+		enableLogsFromAPIServerKey: "Enable tsuru to request application logs from kubernetes api-server, will be enabled by default in next tsuru major version",
 	}
 )
 
@@ -179,7 +185,7 @@ func (c *ClusterClient) SetTimeout(timeout time.Duration) error {
 	return nil
 }
 
-func (c *ClusterClient) AppNamespace(app provision.App) (string, error) {
+func (c *ClusterClient) AppNamespace(app appTypes.App) (string, error) {
 	if app == nil {
 		return c.Namespace(), nil
 	}
@@ -260,6 +266,15 @@ func (c *ClusterClient) OvercommitFactor(pool string) (int64, error) {
 	}
 	overcommit, err := strconv.Atoi(overcommitConf)
 	return int64(overcommit), err
+}
+
+func (c *ClusterClient) LogsFromAPIServerEnabled() bool {
+	if c.CustomData == nil {
+		return defaultLogsFromAPIServer
+	}
+
+	enabled, _ := strconv.ParseBool(c.CustomData[enableLogsFromAPIServerKey])
+	return enabled
 }
 
 func (c *ClusterClient) namespaceLabels(ns string) (map[string]string, error) {

--- a/provision/kubernetes/logs.go
+++ b/provision/kubernetes/logs.go
@@ -1,0 +1,318 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kubernetes
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tsuru/tsuru/provision"
+	appTypes "github.com/tsuru/tsuru/types/app"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	knet "k8s.io/apimachinery/pkg/util/net"
+)
+
+const (
+	logLineTimeSeparator = " "
+	logWatchBufferSize   = 1000
+)
+
+var (
+	watchNewPodsInterval = time.Second * 10
+	watchTimeout         = time.Hour
+)
+
+func (p *kubernetesProvisioner) ListLogs(app appTypes.App, args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
+	clusterClient, err := clusterForPool(app.GetPool())
+	if err != nil {
+		return nil, err
+	}
+	if !clusterClient.LogsFromAPIServerEnabled() {
+		return nil, provision.ErrLogsUnavailable
+	}
+	clusterController, err := getClusterController(p, clusterClient)
+	if err != nil {
+		return nil, err
+	}
+
+	ns, err := clusterClient.AppNamespace(app)
+	if err != nil {
+		return nil, err
+	}
+
+	podInformer, err := clusterController.getPodInformer()
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := podInformer.Lister().Pods(ns).List(listPodsSelectorForLog(args))
+	return listLogsFromPods(clusterClient, ns, pods, args)
+}
+
+func (p *kubernetesProvisioner) WatchLogs(app appTypes.App, args appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	clusterClient, err := clusterForPool(app.GetPool())
+	if err != nil {
+		return nil, err
+	}
+	if !clusterClient.LogsFromAPIServerEnabled() {
+		return nil, provision.ErrLogsUnavailable
+	}
+	clusterClient.SetTimeout(watchTimeout)
+
+	clusterController, err := getClusterController(p, clusterClient)
+	if err != nil {
+		return nil, err
+	}
+
+	ns, err := clusterClient.AppNamespace(app)
+	if err != nil {
+		return nil, err
+	}
+
+	podInformer, err := clusterController.getPodInformer()
+	if err != nil {
+		return nil, err
+	}
+
+	selector := listPodsSelectorForLog(args)
+	pods, err := podInformer.Lister().Pods(ns).List(selector)
+	if err != nil {
+		return nil, err
+	}
+	watchingPods := map[string]bool{}
+	ctx, done := context.WithCancel(context.Background())
+	watcher := &k8sLogsNotifier{
+		ctx:           ctx,
+		ch:            make(chan appTypes.Applog, logWatchBufferSize),
+		ns:            ns,
+		clusterClient: clusterClient,
+		done:          done,
+	}
+	for _, pod := range pods {
+		if pod.Status.Phase == apiv1.PodPending {
+			continue
+		}
+		watchingPods[pod.ObjectMeta.Name] = true
+		go watcher.watchPod(pod, false)
+	}
+
+	podListener := &podListener{
+		OnEvent: func(pod *apiv1.Pod) {
+			_, alreadyWatching := watchingPods[pod.ObjectMeta.Name]
+
+			if !alreadyWatching && pod.Status.Phase != apiv1.PodPending {
+				watchingPods[pod.ObjectMeta.Name] = true
+				go watcher.watchPod(pod, true)
+			}
+		},
+	}
+
+	clusterController.addPodListener(args.AppName, podListener)
+	go func() {
+		<-ctx.Done()
+		clusterController.removePodListener(args.AppName, podListener)
+	}()
+
+	return watcher, nil
+}
+
+func listLogsFromPods(clusterClient *ClusterClient, ns string, pods []*apiv1.Pod, args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
+	var wg sync.WaitGroup
+	wg.Add(len(pods))
+
+	errs := make([]error, len(pods))
+	logs := make([][]appTypes.Applog, len(pods))
+	tailLimit := tailLines(args.Limit)
+	if args.Limit == 0 {
+		tailLimit = tailLines(100)
+	}
+
+	for index, pod := range pods {
+		go func(index int, pod *apiv1.Pod) {
+			defer wg.Done()
+
+			request := clusterClient.CoreV1().Pods(ns).GetLogs(pod.ObjectMeta.Name, &apiv1.PodLogOptions{
+				TailLines:  tailLimit,
+				Timestamps: true,
+			})
+			stream, err := request.Stream()
+			if err != nil {
+				errs[index] = err
+				return
+			}
+
+			appName := pod.ObjectMeta.Labels["tsuru.io/app-name"]
+			appProcess := pod.ObjectMeta.Labels["tsuru.io/app-process"]
+
+			scanner := bufio.NewScanner(stream)
+			tsuruLogs := make([]appTypes.Applog, 0)
+			for scanner.Scan() {
+				line := scanner.Text()
+
+				if len(line) == 0 {
+					continue
+				}
+				tsuruLog := parsek8sLogLine(line)
+				tsuruLog.Unit = pod.ObjectMeta.Name
+				tsuruLog.AppName = appName
+				tsuruLog.Source = appProcess
+				tsuruLogs = append(tsuruLogs, tsuruLog)
+			}
+
+			if err := scanner.Err(); err != nil && !knet.IsProbableEOF(err) {
+				errs[index] = err
+			}
+
+			logs[index] = tsuruLogs
+		}(index, pod)
+	}
+
+	wg.Wait()
+
+	unifiedLog := []appTypes.Applog{}
+	for _, podLogs := range logs {
+		unifiedLog = append(unifiedLog, podLogs...)
+	}
+
+	sort.Slice(unifiedLog, func(i, j int) bool { return unifiedLog[i].Date.Before(unifiedLog[j].Date) })
+
+	for index, err := range errs {
+		if err == nil {
+			continue
+		}
+
+		pod := pods[index]
+		appName := pod.ObjectMeta.Labels["tsuru.io/app-name"]
+
+		unifiedLog = append(unifiedLog, errToLog(pod.ObjectMeta.Name, appName, err))
+	}
+
+	return unifiedLog, nil
+}
+
+func listPodsSelectorForLog(args appTypes.ListLogArgs) labels.Selector {
+	return labels.SelectorFromSet(labels.Set(map[string]string{
+		"tsuru.io/app-name": args.AppName,
+	}))
+}
+
+func parsek8sLogLine(line string) (appLog appTypes.Applog) {
+	parts := strings.SplitN(line, logLineTimeSeparator, 2)
+
+	if len(parts) < 2 {
+		appLog.Message = string(line)
+		return
+	}
+	appLog.Date, _ = parseRFC3339(parts[0])
+	appLog.Message = parts[1]
+
+	return
+}
+
+func parseRFC3339(s string) (time.Time, error) {
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func tailLines(i int) *int64 {
+	b := int64(i)
+	return &b
+}
+
+func errToLog(podName, appName string, err error) appTypes.Applog {
+	return appTypes.Applog{
+		Date:    time.Now().UTC(),
+		Message: fmt.Sprintf("Could not get logs from unit: %s, error: %s", podName, err.Error()),
+		Unit:    "apiserver",
+		AppName: appName,
+		Source:  "kubernetes",
+	}
+}
+
+func infoToLog(appName string, message string) appTypes.Applog {
+	return appTypes.Applog{
+		Date:    time.Now().UTC(),
+		Message: message,
+		Unit:    "apiserver",
+		AppName: appName,
+		Source:  "kubernetes",
+	}
+}
+
+type k8sLogsNotifier struct {
+	ctx  context.Context
+	ch   chan appTypes.Applog
+	ns   string
+	wg   sync.WaitGroup
+	once sync.Once
+	done context.CancelFunc
+
+	clusterClient *ClusterClient
+}
+
+func (k *k8sLogsNotifier) watchPod(pod *apiv1.Pod, notify bool) {
+	k.wg.Add(1)
+	defer k.wg.Done()
+	appName := pod.ObjectMeta.Labels["tsuru.io/app-name"]
+	appProcess := pod.ObjectMeta.Labels["tsuru.io/app-process"]
+
+	if notify {
+		k.ch <- infoToLog(appName, "Starting to watch new unit: "+pod.ObjectMeta.Name)
+	}
+
+	var tailLines int64
+	request := k.clusterClient.CoreV1().Pods(k.ns).GetLogs(pod.ObjectMeta.Name, &apiv1.PodLogOptions{
+		Follow:     true,
+		TailLines:  &tailLines,
+		Timestamps: true,
+	})
+	stream, err := request.Stream()
+	if err != nil {
+		k.ch <- errToLog(pod.ObjectMeta.Name, appName, err)
+		return
+	}
+
+	go func() {
+		// TODO: after update k8s library we can put context inside the request
+		<-k.ctx.Done()
+		stream.Close()
+	}()
+
+	scanner := bufio.NewScanner(stream)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		tsuruLog := parsek8sLogLine(line)
+		tsuruLog.Unit = pod.ObjectMeta.Name
+		tsuruLog.AppName = appName
+		tsuruLog.Source = appProcess
+
+		k.ch <- tsuruLog
+	}
+
+	if err := scanner.Err(); err != nil && !knet.IsProbableEOF(err) {
+		k.ch <- errToLog(pod.ObjectMeta.Name, appName, err)
+	}
+}
+
+func (k *k8sLogsNotifier) Chan() <-chan appTypes.Applog {
+	return k.ch
+}
+
+func (k *k8sLogsNotifier) Close() {
+	k.once.Do(func() {
+		k.done()
+		k.wg.Wait()
+		close(k.ch)
+	})
+}

--- a/provision/kubernetes/logs_test.go
+++ b/provision/kubernetes/logs_test.go
@@ -1,0 +1,131 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kubernetes
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tsuru/tsuru/event"
+	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/provision"
+	appTypes "github.com/tsuru/tsuru/types/app"
+	check "gopkg.in/check.v1"
+)
+
+func (s *S) Test_LogsProvisioner_parsek8sLogLine(c *check.C) {
+	logLine := "2020-06-18T18:47:01.885491991Z its a log line"
+	tsuruLog := parsek8sLogLine(logLine)
+
+	t, _ := time.Parse(time.RFC3339Nano, "2020-06-18T18:47:01.885491991Z")
+	c.Check(tsuruLog.Date, check.Equals, t)
+	c.Check(tsuruLog.Message, check.Equals, "its a log line")
+
+	logLine = "2020-06-18T18:47:02Z its a log line"
+	tsuruLog = parsek8sLogLine(logLine)
+
+	t, _ = time.Parse(time.RFC3339, "2020-06-18T18:47:02Z")
+	c.Check(tsuruLog.Date, check.Equals, t)
+	c.Check(tsuruLog.Message, check.Equals, "its a log line")
+}
+
+func (s *S) Test_LogsProvisioner_ListLogs(c *check.C) {
+	s.mock.LogHook = func(w io.Writer, r *http.Request) {
+		tailLines, _ := strconv.Atoi(r.URL.Query().Get("tailLines"))
+		for i := 1; i <= tailLines; i++ {
+			fmt.Fprintf(w, "2019-05-06T15:04:05Z its a message log: %d\n", i)
+		}
+	}
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	evt, err := event.New(&event.Opts{
+		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		Kind:    permission.PermAppDeploy,
+		Owner:   s.token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	customData := map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "run mycmd arg1",
+		},
+	}
+	version := newCommittedVersion(c, a, customData)
+	_, err = s.p.Deploy(provision.DeployArgs{App: a, Version: version, Event: evt})
+	c.Assert(err, check.IsNil)
+	wait()
+	logs, err := s.p.ListLogs(a, appTypes.ListLogArgs{
+		AppName: a.GetName(),
+		Limit:   10,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(logs, check.HasLen, 10)
+	c.Assert(logs[0].Date.IsZero(), check.Equals, false)
+	c.Assert(logs[0].Message, check.Equals, "its a message log: 1")
+	c.Assert(logs[0].Source, check.Equals, "web")
+	c.Assert(logs[0].AppName, check.Equals, a.GetName())
+	c.Assert(logs[0].Unit, check.Equals, "myapp-web-pod-1-1")
+}
+
+func (s *S) Test_LogsProvisioner_WatchLogs(c *check.C) {
+	s.mock.LogHook = func(w io.Writer, r *http.Request) {
+		i := 0
+		flusher := w.(http.Flusher)
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+				fmt.Fprintf(w, "2019-05-06T15:04:05Z its a message log: %d\n", i)
+				flusher.Flush()
+				time.Sleep(time.Second)
+				i++
+			}
+		}
+	}
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	evt, err := event.New(&event.Opts{
+		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		Kind:    permission.PermAppDeploy,
+		Owner:   s.token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	customData := map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "run mycmd arg1",
+		},
+	}
+	version := newCommittedVersion(c, a, customData)
+	_, err = s.p.Deploy(provision.DeployArgs{App: a, Version: version, Event: evt})
+	c.Assert(err, check.IsNil)
+	wait()
+	watcher, err := s.p.WatchLogs(a, appTypes.ListLogArgs{
+		AppName: a.GetName(),
+		Limit:   10,
+	})
+	c.Assert(err, check.IsNil)
+	logChan := watcher.Chan()
+
+	receivedLogs := []appTypes.Applog{}
+
+	for {
+		log, ok := <-logChan
+		if !ok {
+			break
+		}
+		receivedLogs = append(receivedLogs, log)
+
+		if len(receivedLogs) == 3 {
+			watcher.Close()
+		}
+	}
+
+	c.Check(receivedLogs, check.HasLen, 3)
+}

--- a/provision/kubernetes/monitor_test.go
+++ b/provision/kubernetes/monitor_test.go
@@ -93,3 +93,20 @@ func (s *S) TestNewRouterControllerSameInstance(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(c1, check.Equals, c2)
 }
+
+func (s *S) TestPodListeners(c *check.C) {
+	podListener1 := &podListener{}
+	podListener2 := &podListener{}
+
+	clusterController, err := getClusterController(s.p, s.clusterClient)
+	c.Assert(err, check.IsNil)
+	clusterController.addPodListener("my-app", podListener1)
+	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 1)
+	clusterController.addPodListener("my-app", podListener2)
+	clusterController.removePodListener("my-app", podListener1)
+	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 1)
+	_, contains := clusterController.podListeners["my-app"][podListener2]
+	c.Assert(contains, check.Equals, true)
+	clusterController.removePodListener("my-app", podListener2)
+	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 0)
+}

--- a/provision/kubernetes/monitor_test.go
+++ b/provision/kubernetes/monitor_test.go
@@ -94,19 +94,27 @@ func (s *S) TestNewRouterControllerSameInstance(c *check.C) {
 	c.Assert(c1, check.Equals, c2)
 }
 
+type podListenerImpl struct {
+}
+
+func (*podListenerImpl) OnPodEvent(pod *apiv1.Pod) {
+}
+
 func (s *S) TestPodListeners(c *check.C) {
-	podListener1 := &podListener{}
-	podListener2 := &podListener{}
+
+	podListener1 := &podListenerImpl{}
+	podListener2 := &podListenerImpl{}
 
 	clusterController, err := getClusterController(s.p, s.clusterClient)
 	c.Assert(err, check.IsNil)
-	clusterController.addPodListener("my-app", podListener1)
+	clusterController.addPodListener("my-app", "listerner1", podListener1)
 	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 1)
-	clusterController.addPodListener("my-app", podListener2)
-	clusterController.removePodListener("my-app", podListener1)
+	clusterController.addPodListener("my-app", "listerner2", podListener2)
+	clusterController.removePodListener("my-app", "listerner1")
 	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 1)
-	_, contains := clusterController.podListeners["my-app"][podListener2]
+
+	_, contains := clusterController.podListeners["my-app"]["listerner2"]
 	c.Assert(contains, check.Equals, true)
-	clusterController.removePodListener("my-app", podListener2)
+	clusterController.removePodListener("my-app", "listerner2")
 	c.Assert(clusterController.podListeners["my-app"], check.HasLen, 0)
 }

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -76,6 +76,7 @@ var (
 	_ provision.InterAppProvisioner      = &kubernetesProvisioner{}
 	_ provision.HCProvisioner            = &kubernetesProvisioner{}
 	_ provision.VersionsProvisioner      = &kubernetesProvisioner{}
+	_ provision.LogsProvisioner          = &kubernetesProvisioner{}
 	_ cluster.ClusteredProvisioner       = &kubernetesProvisioner{}
 	_ cluster.ClusterProvider            = &kubernetesProvisioner{}
 	// _ provision.OptionalLogsProvisioner  = &kubernetesProvisioner{}

--- a/provision/kubernetes/suite_test.go
+++ b/provision/kubernetes/suite_test.go
@@ -97,7 +97,9 @@ func (s *S) SetUpTest(c *check.C) {
 		Addresses:   []string{"https://clusteraddr"},
 		Default:     true,
 		Provisioner: provisionerName,
-		CustomData:  map[string]string{},
+		CustomData: map[string]string{
+			enableLogsFromAPIServerKey: "true",
+		},
 	}
 	s.clusterClient, err = NewClusterClient(clus)
 	c.Assert(err, check.IsNil)
@@ -193,6 +195,8 @@ func (s *S) SetUpTest(c *check.C) {
 		}
 		return ret, nil
 	}
+	servicemanager.App, err = app.AppService()
+	c.Assert(err, check.IsNil)
 	servicemanager.AppVersion, err = version.AppVersionService()
 	c.Assert(err, check.IsNil)
 }

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -446,6 +446,9 @@ func listPools(query bson.M) ([]Pool, error) {
 }
 
 func GetProvisionerForPool(name string) (provision.Provisioner, error) {
+	if name == "" {
+		return provision.GetDefault()
+	}
 	prov := poolCache.Get(name)
 	if prov != nil {
 		return prov, nil

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -37,6 +37,7 @@ var (
 	ErrEmptyApp      = errors.New("no units for this app")
 	ErrNodeNotFound  = errors.New("node not found")
 
+	ErrLogsUnavailable = errors.New("logs from provisioner are unavailable")
 	DefaultProvisioner = defaultDockerProvisioner
 )
 
@@ -374,6 +375,12 @@ type ExecOptions struct {
 
 type ExecutableProvisioner interface {
 	ExecuteCommand(opts ExecOptions) error
+}
+
+// LogsProvisioner is a provisioner that is self responsible for storage logs.
+type LogsProvisioner interface {
+	ListLogs(app appTypes.App, args appTypes.ListLogArgs) ([]appTypes.Applog, error)
+	WatchLogs(app appTypes.App, args appTypes.ListLogArgs) (appTypes.LogWatcher, error)
 }
 
 // SleepableProvisioner is a provisioner that allows putting applications to

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -366,6 +366,7 @@ type failure struct {
 // Fake implementation for provision.Provisioner.
 type FakeProvisioner struct {
 	Name           string
+	LogsEnabled    bool
 	outputs        chan []byte
 	failures       chan failure
 	apps           map[string]provisionedApp
@@ -1361,6 +1362,9 @@ func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App
 }
 
 func (p *FakeProvisioner) ListLogs(app appTypes.App, args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
+	if !p.LogsEnabled {
+		return nil, provision.ErrLogsUnavailable
+	}
 	return []appTypes.Applog{
 		{
 			Message: "Fake message from provisioner",
@@ -1369,6 +1373,9 @@ func (p *FakeProvisioner) ListLogs(app appTypes.App, args appTypes.ListLogArgs) 
 }
 
 func (p *FakeProvisioner) WatchLogs(app appTypes.App, args appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	if !p.LogsEnabled {
+		return nil, provision.ErrLogsUnavailable
+	}
 	watcher := appTypes.NewMockLogWatcher()
 	watcher.Enqueue(appTypes.Applog{Message: "Fake message from provisioner"})
 	return watcher, nil

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -39,6 +39,7 @@ var (
 	_ provision.InterAppProvisioner  = &FakeProvisioner{}
 	_ provision.UpdatableProvisioner = &FakeProvisioner{}
 	_ provision.Provisioner          = &FakeProvisioner{}
+	_ provision.LogsProvisioner      = &FakeProvisioner{}
 	_ provision.App                  = &FakeApp{}
 	_ bind.App                       = &FakeApp{}
 )
@@ -1357,6 +1358,20 @@ func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App
 		},
 	}, nil
 
+}
+
+func (p *FakeProvisioner) ListLogs(app appTypes.App, args appTypes.ListLogArgs) ([]appTypes.Applog, error) {
+	return []appTypes.Applog{
+		{
+			Message: "Fake message from provisioner",
+		},
+	}, nil
+}
+
+func (p *FakeProvisioner) WatchLogs(app appTypes.App, args appTypes.ListLogArgs) (appTypes.LogWatcher, error) {
+	watcher := appTypes.NewMockLogWatcher()
+	watcher.Enqueue(appTypes.Applog{Message: "Fake message from provisioner"})
+	return watcher, nil
 }
 
 func stringInArray(value string, array []string) bool {

--- a/service/suite_test.go
+++ b/service/suite_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app/version"
-	"github.com/tsuru/tsuru/applog"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
@@ -17,6 +16,7 @@ import (
 	"github.com/tsuru/tsuru/servicemanager"
 	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
+	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	serviceTypes "github.com/tsuru/tsuru/types/service"
 	check "gopkg.in/check.v1"
@@ -81,8 +81,7 @@ func (s *S) SetUpTest(c *check.C) {
 	s.mockService.ServiceBrokerCatalogCache.OnLoad = func(_ string) (*serviceTypes.BrokerCatalog, error) {
 		return nil, fmt.Errorf("not found")
 	}
-	servicemanager.AppLog, err = applog.AppLogService()
-	c.Assert(err, check.IsNil)
+	servicemanager.AppLog = &appTypes.MockAppLogService{}
 	servicemanager.AppVersion, err = version.AppVersionService()
 	c.Assert(err, check.IsNil)
 }

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	App                       app.AppService
 	AppCache                  cache.AppCacheService
 	Plan                      app.PlanService
 	Platform                  app.PlatformService

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -8,6 +8,16 @@ import (
 	"net/url"
 )
 
+type App interface {
+	GetName() string
+	GetPool() string
+	GetTeamOwner() string
+	GetPlatform() string
+	GetPlatformVersion() string
+	GetDeploys() uint
+	GetUpdatePlatform() bool
+}
+
 type AppRouter struct {
 	Name         string            `json:"name"`
 	Opts         map[string]string `json:"opts"`
@@ -22,4 +32,8 @@ type RoutableAddresses struct {
 	Prefix    string
 	Addresses []*url.URL
 	ExtraData map[string]string
+}
+
+type AppService interface {
+	GetByName(name string) (App, error)
 }

--- a/types/app/app_mock.go
+++ b/types/app/app_mock.go
@@ -37,3 +37,18 @@ func (a *MockApp) GetDeploys() uint {
 func (a *MockApp) GetUpdatePlatform() bool {
 	return a.UpdatePlatform
 }
+
+var _ AppService = &MockAppService{}
+
+type MockAppService struct {
+	Apps []App
+}
+
+func (m *MockAppService) GetByName(name string) (App, error) {
+	for _, app := range m.Apps {
+		if app.GetName() == name {
+			return app, nil
+		}
+	}
+	return nil, ErrAppNotFound
+}

--- a/types/app/log_mock.go
+++ b/types/app/log_mock.go
@@ -35,7 +35,11 @@ func (m *MockLogWatcher) Close() {
 	close(m.ch)
 }
 
-func NewMockLogWatcher() LogWatcher {
+func (m *MockLogWatcher) Enqueue(log Applog) {
+	m.ch <- log
+}
+
+func NewMockLogWatcher() *MockLogWatcher {
 	return &MockLogWatcher{
 		ch: make(chan Applog, 10),
 	}

--- a/types/app/log_mock.go
+++ b/types/app/log_mock.go
@@ -1,0 +1,42 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+var _ AppLogService = &MockAppLogService{}
+
+type MockAppLogService struct{}
+
+func (m *MockAppLogService) Enqueue(entry *Applog) error {
+	return nil
+}
+func (m *MockAppLogService) Add(appName, message, source, unit string) error {
+	return nil
+}
+
+func (m *MockAppLogService) List(args ListLogArgs) ([]Applog, error) {
+	return []Applog{}, nil
+}
+
+func (m *MockAppLogService) Watch(args ListLogArgs) (LogWatcher, error) {
+	return NewMockLogWatcher(), nil
+}
+
+type MockLogWatcher struct {
+	ch chan Applog
+}
+
+func (m *MockLogWatcher) Chan() <-chan Applog {
+	return m.ch
+}
+
+func (m *MockLogWatcher) Close() {
+	close(m.ch)
+}
+
+func NewMockLogWatcher() LogWatcher {
+	return &MockLogWatcher{
+		ch: make(chan Applog, 10),
+	}
+}

--- a/types/app/version.go
+++ b/types/app/version.go
@@ -26,15 +26,6 @@ func (i ErrInvalidVersion) Error() string {
 	return fmt.Sprintf("Invalid version: %s", i.Version)
 }
 
-type App interface {
-	GetName() string
-	GetTeamOwner() string
-	GetPlatform() string
-	GetPlatformVersion() string
-	GetDeploys() uint
-	GetUpdatePlatform() bool
-}
-
 type AppVersion interface {
 	Version() int
 	BuildImageName() string

--- a/types/app/version_mock.go
+++ b/types/app/version_mock.go
@@ -5,13 +5,17 @@
 package app
 
 type MockApp struct {
-	Name, TeamOwner, Platform, PlatformVersion string
-	Deploys                                    uint
-	UpdatePlatform                             bool
+	Name, TeamOwner, Platform, PlatformVersion, Pool string
+	Deploys                                          uint
+	UpdatePlatform                                   bool
 }
 
 func (a *MockApp) GetName() string {
 	return a.Name
+}
+
+func (a *MockApp) GetPool() string {
+	return a.Pool
 }
 
 func (a *MockApp) GetTeamOwner() string {


### PR DESCRIPTION
This MR is an architectural change using kubernetes provisioner, we intend to maintain Tsuru as a globally control-plane application, we are assigning the responsibility to store logs on kubelet engine, then allowing Tsuru to maintain many k8s clusters without bottleneck. 