### PR TITLE
provision/kubernetes: add option to use entire cluster as a single pool

### DIFF
--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -41,6 +41,7 @@ const (
 	disableHeadlessKey     = "disable-headless"
 	maxSurgeKey            = "max-surge"
 	maxUnavailableKey      = "max-unavailable"
+	singlePoolKey          = "single-pool"
 
 	dialTimeout  = 30 * time.Second
 	tcpKeepAlive = 30 * time.Second
@@ -59,6 +60,7 @@ var (
 		disableHeadlessKey:     "Disable headless service creation for every app-process. This config may be prefixed with `<pool-name>:`.",
 		maxSurgeKey:            "Max surge for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 100%.",
 		maxUnavailableKey:      "Max unavailable for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 0.",
+		singlePoolKey:          "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
 	}
 )
 
@@ -316,6 +318,17 @@ func (c *ClusterClient) maxUnavailable(pool string) intstr.IntOrString {
 		return defaultUnvailable
 	}
 	return intstr.Parse(maxUnavailable)
+}
+
+func (c *ClusterClient) SinglePool(pool string) (bool, error) {
+	if c.CustomData == nil {
+		return false, nil
+	}
+	singlePool := c.configForContext(pool, singlePoolKey)
+	if singlePool == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(singlePool)
 }
 
 func (c *ClusterClient) configForContext(context, key string) string {

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -320,12 +320,12 @@ func (c *ClusterClient) maxUnavailable(pool string) intstr.IntOrString {
 	return intstr.Parse(maxUnavailable)
 }
 
-func (c *ClusterClient) SinglePool(pool string) (bool, error) {
+func (c *ClusterClient) SinglePool() (bool, error) {
 	if c.CustomData == nil {
 		return false, nil
 	}
-	singlePool := c.configForContext(pool, singlePoolKey)
-	if singlePool == "" {
+	singlePool, ok := c.CustomData[singlePoolKey]
+	if singlePool == "" || !ok {
 		return false, nil
 	}
 	return strconv.ParseBool(singlePool)

--- a/provision/kubernetes/cluster_test.go
+++ b/provision/kubernetes/cluster_test.go
@@ -219,6 +219,29 @@ func (s *S) TestClusterOvercommitFactor(c *check.C) {
 	c.Assert(ovf, check.Equals, int64(0))
 }
 
+func (s *S) TestClusterSinglePool(c *check.C) {
+	c1 := provTypes.Cluster{Addresses: []string{"addr1"}, CustomData: map[string]string{
+		"single-pool":           "",
+		"my-pool:single-pool":   "true",
+		"my-pool-2:single-pool": "0",
+		"invalid:single-pool":   "a",
+	}}
+	client, err := NewClusterClient(&c1)
+	c.Assert(err, check.IsNil)
+	ovf, err := client.SinglePool("my-pool")
+	c.Assert(err, check.IsNil)
+	c.Assert(ovf, check.Equals, true)
+	ovf, err = client.SinglePool("my-pool-2")
+	c.Assert(err, check.IsNil)
+	c.Assert(ovf, check.Equals, false)
+	ovf, err = client.SinglePool("global")
+	c.Assert(err, check.IsNil)
+	c.Assert(ovf, check.Equals, false)
+	ovf, err = client.SinglePool("invalid")
+	c.Assert(err, check.ErrorMatches, ".*invalid syntax.*")
+	c.Assert(ovf, check.Equals, false)
+}
+
 func (s *S) TestClustersForApps(c *check.C) {
 	c1 := provTypes.Cluster{
 		Name:        "c1",

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -551,7 +551,7 @@ func createAppDeployment(client *ClusterClient, depName string, oldDeployment *a
 	}
 	maxSurge := client.maxSurge(a.GetPool())
 	maxUnavailable := client.maxUnavailable(a.GetPool())
-	singlePool, err := client.SinglePool(a.GetPool())
+	singlePool, err := client.SinglePool()
 	if err != nil {
 		return nil, nil, nil, errors.WithMessage(err, "misconfigured cluster single pool value")
 	}
@@ -1596,7 +1596,7 @@ func newDeployAgentPod(client *ClusterClient, sourceImage string, app provision.
 		Pool:   app.GetPool(),
 		Prefix: tsuruLabelPrefix,
 	}).ToNodeByPoolSelector()
-	singlePool, err := client.SinglePool(app.GetPool())
+	singlePool, err := client.SinglePool()
 	if err != nil {
 		return apiv1.Pod{}, errors.WithMessage(err, "misconfigured cluster single pool value")
 	}
@@ -1681,7 +1681,7 @@ func newDeployAgentImageBuildPod(client *ClusterClient, sourceImage string, podN
 			},
 		},
 	}
-	singlePool, err := client.SinglePool("")
+	singlePool, err := client.SinglePool()
 	if err != nil {
 		return apiv1.Pod{}, errors.WithMessage(err, "misconfigured cluster single pool value")
 	}

--- a/provision/kubernetes/node.go
+++ b/provision/kubernetes/node.go
@@ -25,6 +25,9 @@ func (n *kubernetesNodeWrapper) IaaSID() string {
 }
 
 func (n *kubernetesNodeWrapper) Pool() string {
+	if ok, _ := n.cluster.SinglePool(); len(n.cluster.Pools) > 0 && ok {
+		return n.cluster.Pools[0]
+	}
 	return labelSetFromMeta(&n.node.ObjectMeta).NodePool()
 }
 

--- a/provision/kubernetes/node_test.go
+++ b/provision/kubernetes/node_test.go
@@ -63,6 +63,26 @@ func (s *S) TestNodePool(c *check.C) {
 			},
 		},
 	}
+	node.cluster = s.clusterClient
+	c.Assert(node.Pool(), check.Equals, "p1")
+}
+
+func (s *S) TestNodePoolSinglePool(c *check.C) {
+	s.clusterClient.CustomData["single-pool"] = "true"
+	s.clusterClient.Pools = []string{"p1"}
+	node := kubernetesNodeWrapper{
+		node: &apiv1.Node{
+			Status: apiv1.NodeStatus{
+				Addresses: []apiv1.NodeAddress{
+					{
+						Type:    apiv1.NodeInternalIP,
+						Address: "192.168.99.100",
+					},
+				},
+			},
+		},
+	}
+	node.cluster = s.clusterClient
 	c.Assert(node.Pool(), check.Equals, "p1")
 }
 

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -93,6 +93,13 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 			},
 		},
 	}
+	singlePool, err := client.SinglePool(pool)
+	if err != nil {
+		return err
+	}
+	if singlePool && pool != "" {
+		affinity = &apiv1.Affinity{}
+	}
 	if oldDs != nil && placementOnly {
 		if reflect.DeepEqual(oldDs.Spec.Template.Spec.Affinity, affinity) {
 			return nil

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -97,7 +97,10 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 	if err != nil {
 		return err
 	}
-	if singlePool && pool != "" {
+	if singlePool {
+		if pool == "" {
+			return nil
+		}
 		affinity = &apiv1.Affinity{}
 	}
 	if oldDs != nil && placementOnly {

--- a/provision/kubernetes/nodecontainer.go
+++ b/provision/kubernetes/nodecontainer.go
@@ -93,7 +93,7 @@ func (m *nodeContainerManager) deployNodeContainerForCluster(client *ClusterClie
 			},
 		},
 	}
-	singlePool, err := client.SinglePool(pool)
+	singlePool, err := client.SinglePool()
 	if err != nil {
 		return err
 	}

--- a/provision/kubernetes/nodecontainer_test.go
+++ b/provision/kubernetes/nodecontainer_test.go
@@ -326,26 +326,8 @@ func (s *S) TestManagerDeployNodeContainerOnSinglePool(c *check.C) {
 	err = m.DeployNodeContainer(&c1, "", servicecommon.PoolFilter{Exclude: []string{poolName}}, false)
 	c.Assert(err, check.IsNil)
 	daemon, err = s.client.AppsV1().DaemonSets(ns).Get("node-container-bs-all", metav1.GetOptions{})
-	expectedAffinity = &apiv1.Affinity{
-		NodeAffinity: &apiv1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
-				NodeSelectorTerms: []apiv1.NodeSelectorTerm{{
-					MatchExpressions: []apiv1.NodeSelectorRequirement{
-						{
-							Key:      "tsuru.io/pool",
-							Operator: apiv1.NodeSelectorOpExists,
-						},
-						{
-							Key:      "tsuru.io/pool",
-							Operator: apiv1.NodeSelectorOpNotIn,
-							Values:   []string{poolName},
-						},
-					},
-				}},
-			},
-		},
-	}
-	c.Assert(daemon.Spec.Template.Spec.Affinity, check.DeepEquals, expectedAffinity)
+	c.Assert(err, check.ErrorMatches, "daemonsets.apps \"node-container-bs-all\" not found")
+	c.Assert(daemon, check.IsNil)
 }
 
 func (s *S) TestManagerDeployNodeContainerIgnoreInvalidPools(c *check.C) {

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -201,6 +201,9 @@ func (p *kubernetesProvisioner) InitializeCluster(c *provTypes.Cluster) error {
 }
 
 func (p *kubernetesProvisioner) ValidateCluster(c *provTypes.Cluster) error {
+	if _, ok := c.CustomData[singlePoolKey]; ok && len(c.Pools) > 1 {
+		return errors.Errorf("only one pool is allowed to use entire cluster as single-pool. %d pools found", len(c.Pools))
+	}
 	return nil
 }
 

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -201,7 +201,7 @@ func (p *kubernetesProvisioner) InitializeCluster(c *provTypes.Cluster) error {
 }
 
 func (p *kubernetesProvisioner) ValidateCluster(c *provTypes.Cluster) error {
-	if _, ok := c.CustomData[singlePoolKey]; ok && len(c.Pools) > 1 {
+	if _, ok := c.CustomData[singlePoolKey]; ok && len(c.Pools) != 1 {
 		return errors.Errorf("only one pool is allowed to use entire cluster as single-pool. %d pools found", len(c.Pools))
 	}
 	return nil


### PR DESCRIPTION
This PR adds a new `single-pool` option to cluster that allows using the entire cluster as a single Tsuru pool