### PR TITLE
Fix pool list for users on multiple teams

### DIFF
--- a/api/pool_test.go
+++ b/api/pool_test.go
@@ -416,6 +416,9 @@ func (s *S) TestPoolListHandler(c *check.C) {
 	token := userWithPermission(c, permission.Permission{
 		Scheme:  permission.PermAppCreate,
 		Context: permission.Context(permTypes.CtxTeam, teamName),
+	}, permission.Permission{
+		Scheme:  permission.PermAppCreate,
+		Context: permission.Context(permTypes.CtxTeam, "foo_team"),
 	})
 	p := pool.Pool{Name: "pool1"}
 	opts := pool.AddPoolOptions{Name: p.Name}

--- a/provision/pool/constraint.go
+++ b/provision/pool/constraint.go
@@ -174,8 +174,8 @@ func getPoolsSatisfyConstraints(exactCheck bool, field poolConstraintType, value
 		return nil, err
 	}
 	var satisfying []Pool
-loop:
 	for _, p := range pools {
+		checked := false
 		constraints, err := getConstraintsForPool(p.Name, field)
 		if err != nil {
 			return nil, err
@@ -186,13 +186,16 @@ loop:
 		}
 		for _, v := range values {
 			if exactCheck && !c.checkExact(v) {
-				continue loop
+				continue
 			}
 			if !exactCheck && !c.check(v) {
-				continue loop
+				continue
 			}
+			checked = true
 		}
-		satisfying = append(satisfying, p)
+		if checked || len(values) == 0 {
+			satisfying = append(satisfying, p)
+		}
 	}
 	return satisfying, nil
 }


### PR DESCRIPTION
This PR fixes a condition on pool constraint which compares multiple teams against pool constraints and skip at first false evaluation for a team instead trying remaining teams comparison on a list.