### PR TITLE
Read groups from oauth provider and allow roles to groups

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -162,6 +162,10 @@ func setupServices() error {
 		return err
 	}
 	servicemanager.AppVersion, err = version.AppVersionService()
+	if err != nil {
+		return err
+	}
+	servicemanager.AuthGroup, err = auth.GroupService()
 	return err
 }
 
@@ -383,6 +387,8 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.0", "Get", "/permissions", AuthorizationRequiredHandler(listPermissions))
 	m.Add("1.6", "Post", "/roles/{name}/token", AuthorizationRequiredHandler(assignRoleToToken))
 	m.Add("1.6", "Delete", "/roles/{name}/token/{token_id}", AuthorizationRequiredHandler(dissociateRoleFromToken))
+	m.Add("1.9", "Post", "/roles/{name}/group", AuthorizationRequiredHandler(assignRoleToGroup))
+	m.Add("1.9", "Delete", "/roles/{name}/group/{group_name}", AuthorizationRequiredHandler(dissociateRoleFromGroup))
 
 	m.Add("1.0", "Get", "/debug/goroutines", AuthorizationRequiredHandler(dumpGoroutines))
 	m.Add("1.0", "Get", "/debug/pprof/", AuthorizationRequiredHandler(indexHandler))

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -140,6 +140,8 @@ func (s *S) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	servicemanager.AppVersion, err = version.AppVersionService()
 	c.Assert(err, check.IsNil)
+	servicemanager.AuthGroup, err = auth.GroupService()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *S) setupMocks() {

--- a/auth/group.go
+++ b/auth/group.go
@@ -1,0 +1,57 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/permission"
+	"github.com/tsuru/tsuru/storage"
+	authTypes "github.com/tsuru/tsuru/types/auth"
+)
+
+var (
+	_ authTypes.GroupService = &groupService{}
+
+	errGroupNameEmpty = errors.New("group name cannot be empty")
+)
+
+func GroupService() (authTypes.GroupService, error) {
+	dbDriver, err := storage.GetCurrentDbDriver()
+	if err != nil {
+		dbDriver, err = storage.GetDefaultDbDriver()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &groupService{
+		storage: dbDriver.AuthGroupStorage,
+	}, nil
+}
+
+type groupService struct {
+	storage authTypes.GroupStorage
+}
+
+func (s *groupService) List(filter []string) ([]authTypes.Group, error) {
+	return s.storage.List(filter)
+}
+
+func (s *groupService) AddRole(name, roleName, contextValue string) error {
+	if name == "" {
+		return errGroupNameEmpty
+	}
+	_, err := permission.FindRole(roleName)
+	if err != nil {
+		return err
+	}
+	return s.storage.AddRole(name, roleName, contextValue)
+}
+
+func (s *groupService) RemoveRole(name, roleName, contextValue string) error {
+	if name == "" {
+		return errGroupNameEmpty
+	}
+	return s.storage.RemoveRole(name, roleName, contextValue)
+}

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -132,7 +132,16 @@ func (s *S) TestOAuthParse(c *check.C) {
 	parser := &oAuthScheme{}
 	email, err := parser.parse(rsp)
 	c.Assert(err, check.IsNil)
-	c.Assert(email, check.Equals, "x@x.com")
+	c.Assert(email, check.DeepEquals, userData{Email: "x@x.com"})
+}
+
+func (s *S) TestOAuthParseWithGroups(c *check.C) {
+	b := ioutil.NopCloser(bytes.NewBufferString(`{"email":"x@x.com", "groups": ["g1", "g2"]}`))
+	rsp := &http.Response{Body: b, StatusCode: http.StatusOK}
+	parser := &oAuthScheme{}
+	email, err := parser.parse(rsp)
+	c.Assert(err, check.IsNil)
+	c.Assert(email, check.DeepEquals, userData{Email: "x@x.com", Groups: []string{"g1", "g2"}})
 }
 
 func (s *S) TestOAuthParseInvalid(c *check.C) {

--- a/auth/suite_test.go
+++ b/auth/suite_test.go
@@ -51,6 +51,8 @@ func (s *S) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 	servicemanager.Team, err = TeamService()
 	c.Assert(err, check.IsNil)
+	servicemanager.AuthGroup, err = GroupService()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *S) TearDownSuite(c *check.C) {

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/tsuru/tsuru/auth/oauth"
 	"github.com/tsuru/tsuru/cmd"
 	"github.com/tsuru/tsuru/permission"
+	_ "github.com/tsuru/tsuru/storage/mongodb"
 	permTypes "github.com/tsuru/tsuru/types/permission"
 )
 

--- a/cmd/tsurud/token_test.go
+++ b/cmd/tsurud/token_test.go
@@ -60,7 +60,8 @@ func (s *S) TestCreateRootUserCmdRun(c *check.C) {
 	}
 	manager := cmd.NewManager("glb", "", "", &stdout, &stderr, os.Stdin, nil)
 	client := cmd.NewClient(&http.Client{}, nil, manager)
-	command := createRootUserCmd{}
+	command := &tsurudCommand{Command: createRootUserCmd{}}
+	command.Flags().Parse(true, []string{"--config", "testdata/tsuru.conf"})
 	err := command.Run(&context, client)
 	c.Assert(err, check.IsNil)
 	c.Assert(stdout.String(), check.Equals, "Password: \nConfirm: \nRoot user successfully created.\n")

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -2683,6 +2683,69 @@ paths:
         - nodecontainer
       security:
         - Bearer: []
+  /1.9/roles/{role_name}/group:
+    post:
+      operationId: AssignRoleToGroup
+      description: Assigns a role to a group.
+      consumes:
+        - application/json
+      parameters:
+        - name: role_name
+          required: true
+          in: path
+          type: string
+        - name: token
+          required: true
+          in: body
+          schema:
+            $ref: "#/definitions/AssignGroupArgs"
+      responses:
+        "200":
+          description: Role assigned.
+        "401":
+          description: Unauthorized.
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        "404":
+          description: Role not found
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+      tags:
+        - auth
+      security:
+        - Bearer: []
+  /1.6/roles/{role_name}/group/{group_name}:
+    delete:
+      operationId: DissociateRoleFromGroup
+      description: Dissociates a role from a group.
+      parameters:
+        - name: role_name
+          required: true
+          in: path
+          type: string
+        - name: group_name
+          required: true
+          in: path
+          type: string
+        - name: context
+          required: true
+          in: query
+          type: string
+      responses:
+        "200":
+          description: Role dissociated.
+        "401":
+          description: Unauthorized.
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        "404":
+          description: Role not found
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+      tags:
+        - auth
+      security:
+        - Bearer: []
 definitions:
   DynamicRouter:
     description: Dynamic router
@@ -3539,6 +3602,14 @@ definitions:
     type: object
     properties:
       token_id:
+        type: string
+      context:
+        type: string
+  AssignGroupArgs:
+    description: Assign role to group arguments.
+    type: object
+    properties:
+      group_name:
         type: string
       context:
         type: string

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
+	"github.com/tsuru/tsuru/log"
 	permTypes "github.com/tsuru/tsuru/types/permission"
 )
 
@@ -180,6 +181,7 @@ func ContextsForPermission(token Token, scheme *PermissionScheme, ctxTypes ...pe
 func Check(token Token, scheme *PermissionScheme, contexts ...permTypes.PermissionContext) bool {
 	perms, err := token.Permissions()
 	if err != nil {
+		log.Errorf("unable to read token permissions: %v", err)
 		return false
 	}
 	return CheckFromPermList(perms, scheme, contexts...)

--- a/provision/docker/handlers_test.go
+++ b/provision/docker/handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tsuru/docker-cluster/cluster"
 	"github.com/tsuru/tsuru/api"
 	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/app/version"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
@@ -34,6 +35,7 @@ import (
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	"github.com/tsuru/tsuru/queue"
+	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	permTypes "github.com/tsuru/tsuru/types/permission"
 	"golang.org/x/crypto/bcrypt"
@@ -102,6 +104,10 @@ func (s *HandlersSuite) SetUpTest(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permTypes.PermissionContext{CtxType: permTypes.CtxGlobal},
 	})
+	servicemanager.AppVersion, err = version.AppVersionService()
+	c.Assert(err, check.IsNil)
+	servicemanager.AuthGroup, err = auth.GroupService()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *HandlersSuite) TearDownTest(c *check.C) {

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -31,6 +31,7 @@ type MockService struct {
 	ServiceBrokerCatalogCache *service.MockServiceBrokerCatalogCacheService
 	InstanceTracker           tracker.InstanceService
 	DynamicRouter             *router.MockDynamicRouterService
+	AuthGroup                 auth.GroupService
 }
 
 // SetMockService return a new MockService and set as a servicemanager
@@ -47,6 +48,7 @@ func SetMockService(m *MockService) {
 	m.ServiceBrokerCatalogCache = &service.MockServiceBrokerCatalogCacheService{}
 	m.InstanceTracker = &tracker.MockInstanceService{}
 	m.DynamicRouter = &router.MockDynamicRouterService{}
+	m.AuthGroup = &auth.MockGroupService{}
 	servicemanager.AppCache = m.Cache
 	servicemanager.Plan = m.Plan
 	servicemanager.Platform = m.Platform
@@ -59,6 +61,7 @@ func SetMockService(m *MockService) {
 	servicemanager.ServiceBrokerCatalogCache = m.ServiceBrokerCatalogCache
 	servicemanager.InstanceTracker = m.InstanceTracker
 	servicemanager.DynamicRouter = m.DynamicRouter
+	servicemanager.AuthGroup = m.AuthGroup
 }
 
 func (m *MockService) ResetCache() {

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -35,4 +35,5 @@ var (
 	InstanceTracker           tracker.InstanceService
 	AppVersion                app.AppVersionService
 	DynamicRouter             router.DynamicRouterService
+	AuthGroup                 auth.GroupService
 )

--- a/set/set.go
+++ b/set/set.go
@@ -61,6 +61,13 @@ func (s Set) Sorted() []string {
 	return result
 }
 
+func (s Set) Equal(other Set) bool {
+	if len(s) != len(other) {
+		return false
+	}
+	return len(s.Intersection(other)) == len(s)
+}
+
 func FromValues(l ...string) Set {
 	return FromSlice(l)
 }

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -38,6 +38,7 @@ type DbDriver struct {
 	InstanceTrackerStorage           tracker.InstanceStorage
 	AppVersionStorage                app.AppVersionStorage
 	DynamicRouterStorage             router.DynamicRouterStorage
+	AuthGroupStorage                 auth.GroupStorage
 }
 
 var (

--- a/storage/mongodb/auth_group.go
+++ b/storage/mongodb/auth_group.go
@@ -1,0 +1,93 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/pkg/errors"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storage"
+	"github.com/tsuru/tsuru/types/auth"
+)
+
+const (
+	authGroupCollection = "auth_groups"
+)
+
+var errAuthGroupNameEmpty = errors.New("group name cannot be empty")
+
+type authGroupStorage struct{}
+
+func (s *authGroupStorage) collection() (*storage.Collection, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	coll := conn.Collection(authGroupCollection)
+	err = coll.EnsureIndex(mgo.Index{
+		Key:    []string{"name"},
+		Unique: true,
+	})
+	return coll, err
+}
+
+func (s *authGroupStorage) List(filter []string) ([]auth.Group, error) {
+	coll, err := s.collection()
+	if err != nil {
+		return nil, err
+	}
+	defer coll.Close()
+	bsonFilter := bson.M{}
+	if filter != nil {
+		bsonFilter["name"] = bson.M{"$in": filter}
+	}
+	var groups []auth.Group
+	err = coll.Find(bsonFilter).All(&groups)
+	return groups, err
+}
+
+func (s *authGroupStorage) AddRole(name, roleName, contextValue string) error {
+	if name == "" {
+		return errAuthGroupNameEmpty
+	}
+	coll, err := s.collection()
+	if err != nil {
+		return err
+	}
+	defer coll.Close()
+	_, err = coll.Upsert(bson.M{"name": name}, bson.M{
+		"$addToSet": bson.M{
+			"roles": roleToBson(auth.RoleInstance{Name: roleName, ContextValue: contextValue}),
+		},
+	})
+	return err
+}
+
+func (s *authGroupStorage) RemoveRole(name, roleName, contextValue string) error {
+	if name == "" {
+		return errAuthGroupNameEmpty
+	}
+	coll, err := s.collection()
+	if err != nil {
+		return err
+	}
+	defer coll.Close()
+	_, err = coll.Upsert(bson.M{"name": name}, bson.M{
+		"$pullAll": bson.M{
+			"roles": []bson.D{roleToBson(auth.RoleInstance{Name: roleName, ContextValue: contextValue})},
+		},
+	})
+	return err
+}
+
+func roleToBson(ri auth.RoleInstance) bson.D {
+	// Order matters in $addToSet, that's why bson.D is used instead
+	// of bson.M.
+	return bson.D([]bson.DocElem{
+		{Name: "name", Value: ri.Name},
+		{Name: "contextvalue", Value: ri.ContextValue},
+	})
+}

--- a/storage/mongodb/auth_group_test.go
+++ b/storage/mongodb/auth_group_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.AuthGroupSuite{
+	AuthGroupStorage: &authGroupStorage{},
+	SuiteHooks:       &mongodbBaseTest{},
+})

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -26,6 +26,7 @@ func init() {
 		InstanceTrackerStorage:           &instanceTrackerStorage{},
 		AppVersionStorage:                &appVersionStorage{},
 		DynamicRouterStorage:             &dynamicRouterStorage{},
+		AuthGroupStorage:                 &authGroupStorage{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/storagetest/auth_group_suite.go
+++ b/storage/storagetest/auth_group_suite.go
@@ -1,0 +1,97 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"github.com/tsuru/tsuru/types/auth"
+	check "gopkg.in/check.v1"
+)
+
+type AuthGroupSuite struct {
+	SuiteHooks
+	AuthGroupStorage auth.GroupStorage
+}
+
+func (s *AuthGroupSuite) TestAddRole(c *check.C) {
+	err := s.AuthGroupStorage.AddRole("g1", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	err = s.AuthGroupStorage.AddRole("g1", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	groups, err := s.AuthGroupStorage.List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.DeepEquals, []auth.Group{
+		{
+			Name: "g1",
+			Roles: []auth.RoleInstance{
+				{
+					Name:         "r1",
+					ContextValue: "v1",
+				},
+			},
+		},
+	})
+
+	err = s.AuthGroupStorage.AddRole("g1", "r2", "v1")
+	c.Assert(err, check.IsNil)
+	groups, err = s.AuthGroupStorage.List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.DeepEquals, []auth.Group{
+		{
+			Name: "g1",
+			Roles: []auth.RoleInstance{
+				{
+					Name:         "r1",
+					ContextValue: "v1",
+				},
+				{
+					Name:         "r2",
+					ContextValue: "v1",
+				},
+			},
+		},
+	})
+}
+
+func (s *AuthGroupSuite) TestRemoveRole(c *check.C) {
+	err := s.AuthGroupStorage.AddRole("g1", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	err = s.AuthGroupStorage.RemoveRole("g1", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	groups, err := s.AuthGroupStorage.List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.DeepEquals, []auth.Group{
+		{
+			Name:  "g1",
+			Roles: []auth.RoleInstance{},
+		},
+	})
+}
+
+func (s *AuthGroupSuite) TestList(c *check.C) {
+	groups, err := s.AuthGroupStorage.List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 0)
+	err = s.AuthGroupStorage.AddRole("g1", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	err = s.AuthGroupStorage.AddRole("g2", "r1", "v1")
+	c.Assert(err, check.IsNil)
+	groups, err = s.AuthGroupStorage.List(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 2)
+	groups, err = s.AuthGroupStorage.List([]string{})
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 0)
+	groups, err = s.AuthGroupStorage.List([]string{"g1", "g2", "gn"})
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 2)
+	groups, err = s.AuthGroupStorage.List([]string{"g1"})
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 1)
+	c.Assert(groups[0].Name, check.Equals, "g1")
+	groups, err = s.AuthGroupStorage.List([]string{"g2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(groups, check.HasLen, 1)
+	c.Assert(groups[0].Name, check.Equals, "g2")
+}

--- a/types/auth/group.go
+++ b/types/auth/group.go
@@ -1,0 +1,20 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package auth
+
+type Group struct {
+	Name  string         `json:"name"`
+	Roles []RoleInstance `json:"roles,omitempty"`
+}
+
+type GroupStorage interface {
+	GroupService
+}
+
+type GroupService interface {
+	List(filter []string) ([]Group, error)
+	AddRole(name, roleName, contextValue string) error
+	RemoveRole(name, roleName, contextValue string) error
+}

--- a/types/auth/group_mock.go
+++ b/types/auth/group_mock.go
@@ -1,0 +1,36 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package auth
+
+var (
+	_ GroupService = &MockGroupService{}
+)
+
+type MockGroupService struct {
+	OnAddRole    func(name, roleName, contextValue string) error
+	OnRemoveRole func(name, roleName, contextValue string) error
+	OnList       func(filter []string) ([]Group, error)
+}
+
+func (m *MockGroupService) AddRole(name string, roleName, contextValue string) error {
+	if m.OnAddRole == nil {
+		return nil
+	}
+	return m.OnAddRole(name, roleName, contextValue)
+}
+
+func (m *MockGroupService) RemoveRole(name, roleName, contextValue string) error {
+	if m.OnRemoveRole == nil {
+		return nil
+	}
+	return m.OnRemoveRole(name, roleName, contextValue)
+}
+
+func (m *MockGroupService) List(filter []string) ([]Group, error) {
+	if m.OnList == nil {
+		return nil, nil
+	}
+	return m.OnList(filter)
+}

--- a/types/auth/user.go
+++ b/types/auth/user.go
@@ -18,6 +18,7 @@ type User struct {
 	Password string
 	APIKey   string
 	Roles    []RoleInstance
+	Groups   []string
 }
 
 type RoleInstance struct {


### PR DESCRIPTION
This chance makes it possible to assign roles to groups. Groups are entities that the auth provider dynamically set on each user and which tsuru has no control over.

Example of a possible use:

```
tsuru role-assign team-member group:mygroup teamX
```

This means that every user belonging to group `mygroup` (according to information by the auth provider) will now have the role `team-member` with context value of `teamX`.