### PR TITLE
Avoid to remove appVersion document

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -113,8 +113,10 @@ func (s *S) TestDelete(c *check.C) {
 	c.Assert(err.Error(), check.Equals, "repository not found")
 	_, err = router.Retrieve(a.Name)
 	c.Assert(err, check.Equals, router.ErrBackendNotFound)
-	_, err = servicemanager.AppVersion.AppVersions(app)
-	c.Assert(err, check.Equals, appTypes.ErrNoVersionsAvailable)
+	appVersion, err := servicemanager.AppVersion.AppVersions(app)
+	c.Assert(err, check.IsNil)
+	c.Assert(appVersion.Count, check.Not(check.Equals), 0)
+	c.Assert(appVersion.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{})
 }
 
 func (s *S) TestDeleteWithEvents(c *check.C) {

--- a/app/image/gc/gc_test.go
+++ b/app/image/gc/gc_test.go
@@ -193,7 +193,7 @@ func (s *S) TestGCStartAppNotFound(c *check.C) {
 		"/v2/tsuru/app-myapp/manifests//v2/tsuru/app-myapp/manifests/v11-builder",
 	})
 	versions, err := servicemanager.AppVersion.AppVersions(fakeApp)
-	c.Assert(err, check.Equals, appTypes.ErrNoVersionsAvailable)
+	c.Assert(err, check.IsNil)
 	c.Assert(len(versions.Versions), check.Equals, 0)
 }
 

--- a/app/image/image_test.go
+++ b/app/image/image_test.go
@@ -67,14 +67,14 @@ func (s *S) TestGetBuildImage(c *check.C) {
 			name:              "more deploys with version",
 			successfulVersion: true,
 			app:               appTypes.MockApp{Platform: "python", Deploys: 1, PlatformVersion: "latest"},
-			expectedImage:     "tsuru/app-myapp:v1",
+			expectedImage:     "tsuru/app-myapp:v2",
 		},
 		{
 			name:              "more deploys with version with ns",
 			successfulVersion: true,
 			ns:                "other-tsuru",
 			app:               appTypes.MockApp{Platform: "python", Deploys: 1, PlatformVersion: "latest"},
-			expectedImage:     "other-tsuru/app-myapp:v1",
+			expectedImage:     "other-tsuru/app-myapp:v3",
 		},
 		{
 			name:              "multiple 10 deploys with version",
@@ -87,7 +87,7 @@ func (s *S) TestGetBuildImage(c *check.C) {
 			registry:          "mock.registry.com",
 			successfulVersion: true,
 			app:               appTypes.MockApp{Platform: "python", Deploys: 1, PlatformVersion: "latest"},
-			expectedImage:     "mock.registry.com/tsuru/app-myapp:v1",
+			expectedImage:     "mock.registry.com/tsuru/app-myapp:v5",
 		},
 	}
 
@@ -97,7 +97,6 @@ func (s *S) TestGetBuildImage(c *check.C) {
 		config.Set("docker:registry", tt.registry)
 		tt.app.Name = "myapp"
 		if tt.successfulVersion {
-			servicemanager.AppVersion.DeleteVersions("myapp")
 			version, err := servicemanager.AppVersion.NewAppVersion(appTypes.NewVersionArgs{
 				App: &appTypes.MockApp{Name: "myapp"},
 			})

--- a/app/version/service_test.go
+++ b/app/version/service_test.go
@@ -134,8 +134,9 @@ func (s *S) TestAppVersionService_DeleteVersions(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = svc.DeleteVersions(app.Name)
 	c.Assert(err, check.IsNil)
-	_, err = svc.AppVersions(app)
-	c.Assert(err, check.Equals, appTypes.ErrNoVersionsAvailable)
+	appVersion, err := svc.AppVersions(app)
+	c.Assert(err, check.IsNil)
+	c.Assert(appVersion.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{})
 }
 
 func (s *S) TestAppVersionService_AllAppVersions(c *check.C) {

--- a/storage/storagetest/app_version_suite.go
+++ b/storage/storagetest/app_version_suite.go
@@ -132,8 +132,9 @@ func (s *AppVersionSuite) TestAppVersionStorage_DeleteVersions(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = s.AppVersionStorage.DeleteVersions(app.Name)
 	c.Assert(err, check.IsNil)
-	_, err = s.AppVersionStorage.AppVersions(app)
-	c.Assert(err, check.Equals, appTypes.ErrNoVersionsAvailable)
+	appVersion, err := s.AppVersionStorage.AppVersions(app)
+	c.Assert(err, check.IsNil)
+	c.Assert(appVersion.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{})
 }
 
 func (s *AppVersionSuite) TestAppVersionStorage_AllAppVersions(c *check.C) {
@@ -372,6 +373,7 @@ func (s *AppVersionSuite) TestAppVersionStorage_ConcurrencyDeleteVersions(c *che
 		PreviousUpdatedHash: oldVersions.UpdatedHash,
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.AppVersionStorage.AppVersions(app)
-	c.Assert(err, check.Equals, appTypes.ErrNoVersionsAvailable)
+	appVersion, err := s.AppVersionStorage.AppVersions(app)
+	c.Assert(err, check.IsNil)
+	c.Assert(appVersion.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{})
 }


### PR DESCRIPTION
It means that we won't remove the appVersion anymore for these reasons:

* When user removes a app and create again, could generate inconsistency in nodes by a previous docker image cached, ie myapp:v1.
* ensure that image could safety used by `IfNotPresent` image policy, because we won't reuse previous version number of any app.  
