### PR TITLE
 README: fix git clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ tsuru install create
 You need to have [Go](https://golang.org/doc/install) properly installed on your machine.
 
 ```
-$ git clone github.com/tsuru/tsuru-client $GOPATH/src/github.com/tsuru/tsuru-client
+$ git clone https://github.com/tsuru/tsuru-client $GOPATH/src/github.com/tsuru/tsuru-client
 $ cd $GOPATH/src/github.com/tsuru/tsuru-client
 $ make install
 ```


### PR DESCRIPTION
While following the instructions to install tsuru-client from source I found that the `git clone` command was missing the protocol. The command returned an error: `fatal: repository 'github.com/tsuru/tsuru-client' does not exist`. So I added the protocol to the command.