### PR TITLE
bugfix: Wrapping url parameter with quotes to prevent keyword use

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -32,7 +32,7 @@ func open(url string) error {
 
 	if isWSL() {
 		cmd = "powershell.exe"
-		args = []string{"-c", "start", "'"+url+"'"}
+		args = []string{"-c", "start", "'" + url + "'"}
 	}
 
 	opts := exec.ExecuteOptions{

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -32,7 +32,7 @@ func open(url string) error {
 
 	if isWSL() {
 		cmd = "powershell.exe"
-		args = []string{"-c", "start", url}
+		args = []string{"-c", "start", "'"+url+"'"}
 	}
 
 	opts := exec.ExecuteOptions{


### PR DESCRIPTION
### Bugfix

In WSL, the command `powershell.exe` it's being called to open GUI. The `url` parameter must be wrapped with quotes to prevent keyword use.


### Error Message
```
No linha:1 caractere:93
... .globoi.com/authorize?client_id=z4kjNVz4XJMUwc2YjgBCuw%3D%3D&redirect ...
                                                                 ~
O caráter de E comercial (&) não é permitido. O operador & está reservado para uso futuro; coloque um E comercial entre aspas duplas ("&") para
transmiti-lo como parte de uma cadeia de caracteres.
No linha:1 caractere:129
... NVz4XJMUwc2YjgBCuw%3D%3D&redirect_uri=http://localhost:37621&response ...
                                                                 ~
O caráter de E comercial (&) não é permitido. O operador & está reservado para uso futuro; coloque um E comercial entre aspas duplas ("&") para
transmiti-lo como parte de uma cadeia de caracteres.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : AmpersandNotAllowed
```

