### PR TITLE
feat(service): support for multi-cluster services

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -49,6 +49,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/cluster"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
+	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/router"
 	"github.com/tsuru/tsuru/router/rebuild"
 	"github.com/tsuru/tsuru/service"
@@ -170,7 +171,14 @@ func setupServices() error {
 		return err
 	}
 	servicemanager.AuthGroup, err = auth.GroupService()
-	return err
+	if err != nil {
+		return err
+	}
+	servicemanager.Pool, err = pool.PoolService()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func InitializeDBServices() error {

--- a/api/service.go
+++ b/api/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/errors"
@@ -81,6 +82,10 @@ func serviceCreate(w http.ResponseWriter, r *http.Request, t auth.Token) (err er
 		Username: InputValue(r, "username"),
 		Endpoint: map[string]string{"production": InputValue(r, "endpoint")},
 		Password: InputValue(r, "password"),
+	}
+	multiCluster, err := strconv.ParseBool(InputValue(r, "multi-cluster"))
+	if err == nil {
+		s.IsMultiCluster = multiCluster
 	}
 	team := InputValue(r, "team")
 	if team == "" {

--- a/app/app.go
+++ b/app/app.go
@@ -1438,6 +1438,26 @@ func (app *App) GetAddresses() ([]string, error) {
 	return addresses, nil
 }
 
+func (app *App) GetInternalAddresses(ctx context.Context) ([]string, error) {
+	prov, err := app.getProvisioner()
+	if err != nil {
+		return nil, err
+	}
+	interAppProv, ok := prov.(provision.InterAppProvisioner)
+	if !ok {
+		return nil, nil
+	}
+	addrs, err := interAppProv.InternalAddresses(ctx, app)
+	if err != nil {
+		return nil, err
+	}
+	var addresses []string
+	for _, addr := range addrs {
+		addresses = append(addresses, fmt.Sprintf("%s://%s:%d", strings.ToLower(addr.Protocol), addr.Domain, addr.Port))
+	}
+	return addresses, nil
+}
+
 func (app *App) GetQuotaInUse() (int, error) {
 	units, err := app.Units()
 	if err != nil {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5520,3 +5520,15 @@ func (s *S) TestAutoscaleWithAutoscaleProvisioner(c *check.C) {
 		{Process: "p2"},
 	})
 }
+
+func (s *S) TestGetInternalAddresses(c *check.C) {
+	app := App{Name: "myapp", Platform: "go", TeamOwner: s.team.Name, provisioner: s.provisioner}
+	err := CreateApp(context.TODO(), &app, s.user)
+	c.Assert(err, check.IsNil)
+	addresses, err := app.GetInternalAddresses(context.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(addresses, check.DeepEquals, []string{
+		"tcp://myapp-web.fake-cluster.local:80",
+		"udp://myapp-logs.fake-cluster.local:12201",
+	})
+}

--- a/app/bind/binder.go
+++ b/app/bind/binder.go
@@ -7,6 +7,7 @@
 package bind
 
 import (
+	"context"
 	"io"
 )
 
@@ -33,6 +34,9 @@ type Unit interface {
 type App interface {
 	// GetAddresses returns the app addresses.
 	GetAddresses() ([]string, error)
+
+	// GetInternalAddresses returns the app addresses inside the cluster, if any.
+	GetInternalAddresses(context.Context) ([]string, error)
 
 	// GetName returns the app name.
 	GetName() string

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -2904,6 +2904,8 @@ definitions:
         type: object
         additionalProperties:
           type: string
+      pool:
+        type: string
   ServiceInstanceBoundUnit:
     type: object
     properties:

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -582,6 +582,10 @@ func PoolService() (provisionTypes.PoolService, error) {
 	return &poolService{storage: poolStorage}, nil
 }
 
+func (s *poolService) FindByName(ctx context.Context, name string) (*provisionTypes.Pool, error) {
+	return s.storage.FindByName(ctx, name)
+}
+
 func (s *poolService) List(ctx context.Context) ([]provisionTypes.Pool, error) {
 	return s.storage.FindAll(ctx)
 }

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -58,32 +59,33 @@ func init() {
 
 // Fake implementation for provision.App.
 type FakeApp struct {
-	name            string
-	uuid            string
-	cname           []string
-	IP              string
-	platform        string
-	platformVersion string
-	units           []provision.Unit
-	logs            []string
-	logMut          sync.Mutex
-	Commands        []string
-	Memory          int64
-	Swap            int64
-	CpuShare        int
-	MilliCPU        int
-	commMut         sync.Mutex
-	Deploys         uint
-	env             map[string]bind.EnvVar
-	bindCalls       []*provision.Unit
-	bindLock        sync.Mutex
-	serviceEnvs     []bind.ServiceEnvVar
-	serviceLock     sync.Mutex
-	Pool            string
-	UpdatePlatform  bool
-	TeamOwner       string
-	Teams           []string
-	Tags            []string
+	name              string
+	uuid              string
+	cname             []string
+	IP                string
+	platform          string
+	platformVersion   string
+	units             []provision.Unit
+	logs              []string
+	logMut            sync.Mutex
+	Commands          []string
+	Memory            int64
+	Swap              int64
+	CpuShare          int
+	MilliCPU          int
+	commMut           sync.Mutex
+	Deploys           uint
+	env               map[string]bind.EnvVar
+	bindCalls         []*provision.Unit
+	bindLock          sync.Mutex
+	serviceEnvs       []bind.ServiceEnvVar
+	serviceLock       sync.Mutex
+	Pool              string
+	UpdatePlatform    bool
+	TeamOwner         string
+	Teams             []string
+	Tags              []string
+	InternalAddresses []provision.AppInternalAddress
 }
 
 func NewFakeApp(name, platform string, units int) *FakeApp {
@@ -344,6 +346,14 @@ func (app *FakeApp) GetAddresses() ([]string, error) {
 		return nil, err
 	}
 	return []string{addr}, nil
+}
+
+func (app *FakeApp) GetInternalAddresses(ctx context.Context) ([]string, error) {
+	var addresses []string
+	for _, addr := range app.InternalAddresses {
+		addresses = append(addresses, fmt.Sprintf("%s://%s:%d", strings.ToLower(addr.Protocol), addr.Domain, addr.Port))
+	}
+	return addresses, nil
 }
 
 func (app *FakeApp) ListTags() []string {

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -153,15 +153,20 @@ func (c *endpointClient) Destroy(ctx context.Context, instance *ServiceInstance,
 func (c *endpointClient) BindApp(ctx context.Context, instance *ServiceInstance, app bind.App, bindParams BindAppParameters, evt *event.Event, requestID string) (map[string]string, error) {
 	log.Debugf("Calling bind of instance %q and %q app at %q API",
 		instance.Name, app.GetName(), instance.ServiceName)
+	internalAddrs, err := app.GetInternalAddresses(ctx)
+	if err != nil {
+		return nil, err
+	}
 	appAddrs, err := app.GetAddresses()
 	if err != nil {
 		return nil, err
 	}
 	params := map[string][]string{
-		"app-name":  {app.GetName()},
-		"app-hosts": appAddrs,
-		"user":      {evt.Owner.Name},
-		"eventid":   {evt.UniqueID.Hex()},
+		"app-name":           {app.GetName()},
+		"app-hosts":          appAddrs,
+		"app-internal-hosts": internalAddrs,
+		"user":               {evt.Owner.Name},
+		"eventid":            {evt.UniqueID.Hex()},
 	}
 	addParameters(params, bindParams)
 	if len(appAddrs) > 0 {

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/net"
 	"github.com/tsuru/tsuru/servicemanager"
+	"github.com/tsuru/tsuru/types/provision"
 )
 
 var (
@@ -523,6 +524,9 @@ func multiClusterHeader(ctx context.Context, si *ServiceInstance, header http.He
 	header.Set("X-Tsuru-Pool-Provisioner", p.Provisioner)
 	c, err := servicemanager.Cluster.FindByPool(ctx, p.Provisioner, p.Name)
 	if err != nil {
+		if err == provision.ErrNoCluster {
+			return header, nil
+		}
 		return header, err
 	}
 	header.Set("X-Tsuru-Cluster-Name", c.Name)

--- a/service/service.go
+++ b/service/service.go
@@ -31,6 +31,12 @@ type Service struct {
 	Teams        []string
 	Doc          string
 	IsRestricted bool `bson:"is_restricted"`
+	// IsMultiCluster indicates whether Service Instances (children of this Service)
+	// run within the user's Cluster (same pool of Tsuru Apps). When enabled, creating
+	// a Service Instance must require a valid Pool.
+	//
+	// This field is immutable (after creating Service).
+	IsMultiCluster bool `bson:"is_multi_cluster"`
 
 	ctx context.Context
 }

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
-	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 )
 
@@ -234,9 +233,6 @@ func (si *ServiceInstance) updateData(update bson.M) error {
 
 // BindApp makes the bind between the service instance and an app.
 func (si *ServiceInstance) BindApp(app bind.App, params BindAppParameters, shouldRestart bool, writer io.Writer, evt *event.Event, requestID string) error {
-	if err := validateMultiClusterAppBind(si.ctx, si, app); err != nil {
-		return err
-	}
 	args := bindPipelineArgs{
 		serviceInstance: si,
 		app:             app,
@@ -625,24 +621,6 @@ func validateMultiCluster(ctx context.Context, s *Service, si ServiceInstance) e
 	_, err := servicemanager.Pool.FindByName(ctx, si.Pool)
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-func validateMultiClusterAppBind(ctx context.Context, si *ServiceInstance, app bind.App) error {
-	if si == nil || si.Pool == "" {
-		return nil
-	}
-	a, ok := app.(appTypes.App)
-	if !ok {
-		var err error
-		a, err = servicemanager.App.GetByName(ctx, app.GetName())
-		if err != nil {
-			return err
-		}
-	}
-	if a.GetPool() != si.Pool {
-		return ErrMultiClusterPoolDoesNotMatch
 	}
 	return nil
 }

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -1344,33 +1344,6 @@ func (s *InstanceSuite) TestBindAppMultipleApps(c *check.C) {
 	c.Assert(siDB.Apps, check.DeepEquals, expectedNames)
 }
 
-func (s *InstanceSuite) TestBindAppMultiClusterInstancePoolDoesNotMatchWithAppPool(c *check.C) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Fail()
-	}))
-	defer ts.Close()
-	err := s.conn.Services().Insert(Service{
-		Name:       "multi-cluster-service",
-		Username:   "user",
-		Password:   "s3cr3t",
-		Endpoint:   map[string]string{"production": ts.URL},
-		OwnerTeams: []string{s.team.Name},
-	})
-	c.Assert(err, check.IsNil)
-	err = s.conn.ServiceInstances().Insert(ServiceInstance{
-		Name:        "my-instance",
-		ServiceName: "multi-cluster-service",
-		Teams:       []string{s.team.Name},
-		Pool:        "pool-A",
-	})
-	c.Assert(err, check.IsNil)
-	si, err := GetServiceInstance(context.TODO(), "multi-cluster-service", "my-instance")
-	c.Assert(err, check.IsNil)
-	a := provisiontest.NewFakeAppWithPool("myapp", "python", "pool-B", 1)
-	err = si.BindApp(a, BindAppParameters{}, true, nil, nil, "")
-	c.Assert(err, check.Equals, ErrMultiClusterPoolDoesNotMatch)
-}
-
 func (s *InstanceSuite) TestUnbindAppMultipleApps(c *check.C) {
 	originalMaxProcs := runtime.GOMAXPROCS(4)
 	defer runtime.GOMAXPROCS(originalMaxProcs)

--- a/servicemanager/mock/servicemanager_mock.go
+++ b/servicemanager/mock/servicemanager_mock.go
@@ -32,6 +32,7 @@ type MockService struct {
 	InstanceTracker           tracker.InstanceService
 	DynamicRouter             *router.MockDynamicRouterService
 	AuthGroup                 auth.GroupService
+	Pool                      *provision.MockPoolService
 }
 
 // SetMockService return a new MockService and set as a servicemanager
@@ -49,6 +50,7 @@ func SetMockService(m *MockService) {
 	m.InstanceTracker = &tracker.MockInstanceService{}
 	m.DynamicRouter = &router.MockDynamicRouterService{}
 	m.AuthGroup = &auth.MockGroupService{}
+	m.Pool = &provision.MockPoolService{}
 	servicemanager.AppCache = m.Cache
 	servicemanager.Plan = m.Plan
 	servicemanager.Platform = m.Platform
@@ -62,6 +64,7 @@ func SetMockService(m *MockService) {
 	servicemanager.InstanceTracker = m.InstanceTracker
 	servicemanager.DynamicRouter = m.DynamicRouter
 	servicemanager.AuthGroup = m.AuthGroup
+	servicemanager.Pool = m.Pool
 }
 
 func (m *MockService) ResetCache() {
@@ -136,4 +139,9 @@ func (m *MockService) ResetServiceBroker() {
 func (m *MockService) ResetServiceBrokerCatalogCache() {
 	m.ServiceBrokerCatalogCache.OnSave = nil
 	m.ServiceBrokerCatalogCache.OnLoad = nil
+}
+
+func (m *MockService) ResetPool() {
+	m.Pool.OnFindByName = nil
+	m.Pool.OnList = nil
 }

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -36,4 +36,5 @@ var (
 	AppVersion                app.AppVersionService
 	DynamicRouter             router.DynamicRouterService
 	AuthGroup                 auth.GroupService
+	Pool                      provision.PoolService
 )

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -39,6 +39,7 @@ type DbDriver struct {
 	AppVersionStorage                app.AppVersionStorage
 	DynamicRouterStorage             router.DynamicRouterStorage
 	AuthGroupStorage                 auth.GroupStorage
+	PoolStorage                      provision.PoolStorage
 }
 
 var (

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -27,6 +27,7 @@ func init() {
 		AppVersionStorage:                &appVersionStorage{},
 		DynamicRouterStorage:             &dynamicRouterStorage{},
 		AuthGroupStorage:                 &authGroupStorage{},
+		PoolStorage:                      &PoolStorage{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/pool.go
+++ b/storage/mongodb/pool.go
@@ -1,0 +1,58 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"context"
+
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/types/provision"
+)
+
+var _ provision.PoolStorage = &PoolStorage{}
+
+type PoolStorage struct{}
+
+func (ps *PoolStorage) FindAll(ctx context.Context) ([]provision.Pool, error) {
+	return findPoolsByQuery(ctx, nil)
+}
+
+func (ps *PoolStorage) FindByName(ctx context.Context, name string) (*provision.Pool, error) {
+	return findPoolByQuery(ctx, bson.M{"_id": name})
+}
+
+func findPoolByQuery(ctx context.Context, filter bson.M) (*provision.Pool, error) {
+	pools, err := findPoolsByQuery(ctx, filter)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return nil, provision.ErrPoolNotFound
+		}
+		return nil, err
+	}
+	switch len(pools) {
+	case 0:
+		return nil, provision.ErrPoolNotFound
+	case 1:
+		return &pools[0], nil
+	default:
+		return nil, provision.ErrTooManyPoolsFound
+	}
+}
+
+func findPoolsByQuery(ctx context.Context, filter bson.M) ([]provision.Pool, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	pools := []provision.Pool{}
+	err = conn.Pools().Find(filter).All(&pools)
+	if err != nil {
+		return nil, err
+	}
+	return pools, err
+}

--- a/storage/mongodb/pool_test.go
+++ b/storage/mongodb/pool_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.PoolSuite{
+	PoolStorage: &PoolStorage{},
+	SuiteHooks:  &mongodbBaseTest{},
+})

--- a/storage/storagetest/pool_suite.go
+++ b/storage/storagetest/pool_suite.go
@@ -21,6 +21,7 @@ type PoolSuite struct {
 func (s *PoolSuite) TestFindAll(c *check.C) {
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)
+	defer conn.Close()
 	err = conn.Pools().Insert(
 		bson.M{"_id": "pool-A", "provisioner": "docker", "default": true},
 		bson.M{"_id": "pool-B", "provisioner": "kubernetes"},
@@ -37,6 +38,7 @@ func (s *PoolSuite) TestFindAll(c *check.C) {
 func (s *PoolSuite) TestFindByName(c *check.C) {
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)
+	defer conn.Close()
 	err = conn.Pools().Insert(
 		bson.M{"_id": "pool-A", "provisioner": "docker", "default": true},
 		bson.M{"_id": "pool-B", "provisioner": "kubernetes"},

--- a/storage/storagetest/pool_suite.go
+++ b/storage/storagetest/pool_suite.go
@@ -1,0 +1,55 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"context"
+
+	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/types/provision"
+	"gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type PoolSuite struct {
+	SuiteHooks
+	PoolStorage provision.PoolStorage
+}
+
+func (s *PoolSuite) TestFindAll(c *check.C) {
+	conn, err := db.Conn()
+	c.Assert(err, check.IsNil)
+	err = conn.Pools().Insert(
+		bson.M{"_id": "pool-A", "provisioner": "docker", "default": true},
+		bson.M{"_id": "pool-B", "provisioner": "kubernetes"},
+	)
+	c.Assert(err, check.IsNil)
+	pools, err := s.PoolStorage.FindAll(context.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(pools, check.DeepEquals, []provision.Pool{
+		{Name: "pool-A", Provisioner: "docker", Default: true},
+		{Name: "pool-B", Provisioner: "kubernetes"},
+	})
+}
+
+func (s *PoolSuite) TestFindByName(c *check.C) {
+	conn, err := db.Conn()
+	c.Assert(err, check.IsNil)
+	err = conn.Pools().Insert(
+		bson.M{"_id": "pool-A", "provisioner": "docker", "default": true},
+		bson.M{"_id": "pool-B", "provisioner": "kubernetes"},
+	)
+	c.Assert(err, check.IsNil)
+	pool, err := s.PoolStorage.FindByName(context.TODO(), "pool-B")
+	c.Assert(err, check.IsNil)
+	c.Assert(pool, check.DeepEquals, &provision.Pool{Name: "pool-B", Provisioner: "kubernetes"})
+
+}
+
+func (s *PoolSuite) TestFindByName_PoolNotFound(c *check.C) {
+	_, err := s.PoolStorage.FindByName(context.TODO(), "pool-not-found")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.DeepEquals, provision.ErrPoolNotFound)
+}

--- a/types/provision/pool.go
+++ b/types/provision/pool.go
@@ -24,3 +24,7 @@ type PoolStorage interface {
 	FindAll(ctx context.Context) ([]Pool, error)
 	FindByName(ctx context.Context, name string) (*Pool, error)
 }
+
+type PoolService interface {
+	List(ctx context.Context) ([]Pool, error)
+}

--- a/types/provision/pool.go
+++ b/types/provision/pool.go
@@ -1,0 +1,26 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package provision
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrPoolNotFound      = errors.New("pool does not exist")
+	ErrTooManyPoolsFound = errors.New("too many pools found")
+)
+
+type Pool struct {
+	Name        string `bson:"_id"`
+	Provisioner string
+	Default     bool
+}
+
+type PoolStorage interface {
+	FindAll(ctx context.Context) ([]Pool, error)
+	FindByName(ctx context.Context, name string) (*Pool, error)
+}

--- a/types/provision/pool.go
+++ b/types/provision/pool.go
@@ -27,4 +27,5 @@ type PoolStorage interface {
 
 type PoolService interface {
 	List(ctx context.Context) ([]Pool, error)
+	FindByName(ctx context.Context, name string) (*Pool, error)
 }

--- a/types/provision/pool_mock.go
+++ b/types/provision/pool_mock.go
@@ -1,0 +1,48 @@
+// Copyright 2020 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package provision
+
+import "context"
+
+var _ PoolStorage = &MockPoolStorage{}
+var _ PoolService = &MockPoolService{}
+
+type MockPoolStorage struct {
+	OnFindAll    func() ([]Pool, error)
+	OnFindByName func(string) (*Pool, error)
+}
+
+func (m *MockPoolStorage) FindAll(ctx context.Context) ([]Pool, error) {
+	if m.OnFindAll != nil {
+		return m.OnFindAll()
+	}
+	return nil, nil
+}
+
+func (m *MockPoolStorage) FindByName(ctx context.Context, name string) (*Pool, error) {
+	if m.OnFindByName != nil {
+		return m.OnFindByName(name)
+	}
+	return nil, nil
+}
+
+type MockPoolService struct {
+	OnList       func() ([]Pool, error)
+	OnFindByName func(string) (*Pool, error)
+}
+
+func (m *MockPoolService) List(ctx context.Context) ([]Pool, error) {
+	if m.OnList != nil {
+		return m.OnList()
+	}
+	return nil, nil
+}
+
+func (m *MockPoolService) FindByName(ctx context.Context, name string) (*Pool, error) {
+	if m.OnFindByName != nil {
+		return m.OnFindByName(name)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Some Tsuru Services likely run on the same region/zone/cluster/nodes of Tsuru Apps, e.g. some database service to reduce the network latency and bandwidth. Before this PR, we'd to create several Tsuru Services for each cluster/pool (e.g `db-service-pool-aws-east`, `db-service-pool-south-america`, etc). That demands a lot of operational work.

This PR creates a new sort of Tsuru Services, the multi-cluster ones. They're like regular Tsuru Services but (their service instances) should run into a valid Tsuru Pool. All subsequent requests to Service API the Tsuru is going to include HTTP headers to identify the pool and cluster where the Service Instance is running on.

HTTP headers sent by Tsuru API to Service API:

* `X-Tsuru-Pool-Name`: the pool name;
* `X-Tsuru-Pool-Provisioner`: the provisioner name (`docker`, `kubernetes`);
* `X-Tsuru-Cluster-Name`: the cluster where this pool is running;
* `X-Tsuru-Cluster-Provisioner`: the provisioner name;
* `X-Tsuru-Cluster-Addresses`: the endpoint(s) of the cluster;

Carrying those information the Tsuru Service may find the best location to deploy your instances in.

Tsuru won't apply any validation between the pools of service instance and app. We advise doing that on the Service API. Regarding that, new fields about the app pool/cluster will be sent on the payload for app bind calls.

New HTTP values (encoded as URL form) sent on app bind calls are:

* `app-internal-hosts`: the internal addresses (may only be valid in the cluster) to reach on app (on Kubernetes provisioner that means the [Service DNS][Kubernetes - DNS]);
* `app-pool-name`: the app's pool name;
* `app-pool-name`: the app's pool provisioner (e.g. `docker`, `kubernetes`);
* `app-cluster-name`: the cluster where this pool is running;
* `app-cluster-provisioner`: the provisioner name;
* `app-cluster-addresses`:  the endpoint(s) of the cluster;

[Kubernetes - DNS]: https://kubernetes.io/docs/concepts/services-networking/service/#dns