### PR TITLE
events: optimize the query for deploy events

### DIFF
--- a/db/storage.go
+++ b/db/storage.go
@@ -154,6 +154,10 @@ func (s *Storage) Events() *storage.Collection {
 	runningIndex := mgo.Index{Key: []string{"running"}}
 	removedIndex := mgo.Index{Key: []string{"removedate"}}
 	allowedSchemeIndex := mgo.Index{Key: []string{"allowed.scheme"}}
+	latestTargetKindIndex := mgo.Index{Key: []string{"target.value", "kind.name", "-starttime"}, Background: true}
+	latestTargetIndex := mgo.Index{Key: []string{"target.value", "-starttime"}, Background: true}
+	latestExtraTargetIndex := mgo.Index{Key: []string{"extratargets.target.value", "-starttime"}, Background: true}
+
 	c := s.Collection("events")
 	c.EnsureIndex(ownerIndex)
 	c.EnsureIndex(targetIndex)
@@ -164,6 +168,9 @@ func (s *Storage) Events() *storage.Collection {
 	c.EnsureIndex(runningIndex)
 	c.EnsureIndex(removedIndex)
 	c.EnsureIndex(allowedSchemeIndex)
+	c.EnsureIndex(latestTargetKindIndex)
+	c.EnsureIndex(latestTargetIndex)
+	c.EnsureIndex(latestExtraTargetIndex)
 	return c
 }
 

--- a/event/event.go
+++ b/event/event.go
@@ -55,6 +55,13 @@ var (
 	}, []string{"kind"})
 
 	defaultAppRetryTimeout = 10 * time.Second
+
+	extraTargetKindNames = map[string]bool{
+		"app.update.bind":   true,
+		"app.update.unbind": true,
+		"app.update.swap":   true,
+		"healer":            true,
+	}
 )
 
 const (
@@ -491,6 +498,7 @@ func (f *Filter) toQuery() (bson.M, error) {
 	query := bson.M{}
 	permMap := map[string][]permTypes.PermissionContext{}
 	andBlock := []bson.M{}
+	enableExtraTargets := allowToQueryExtraTargets(f.KindNames)
 	if f.Permissions != nil {
 		for _, p := range f.Permissions {
 			permMap[p.Scheme.FullName()] = append(permMap[p.Scheme.FullName()], p.Context)
@@ -535,18 +543,26 @@ func (f *Filter) toQuery() (bson.M, error) {
 		andBlock = append(andBlock, bson.M{"$or": orBlock})
 	}
 	if f.Target.Type != "" {
-		orBlock := []bson.M{
-			{"target.type": f.Target.Type},
-			{"extratargets.target.type": f.Target.Type},
+		if enableExtraTargets {
+			orBlock := []bson.M{
+				{"target.type": f.Target.Type},
+				{"extratargets.target.type": f.Target.Type},
+			}
+			andBlock = append(andBlock, bson.M{"$or": orBlock})
+		} else {
+			query["target.type"] = f.Target.Type
 		}
-		andBlock = append(andBlock, bson.M{"$or": orBlock})
 	}
 	if f.Target.Value != "" {
-		orBlock := []bson.M{
-			{"target.value": f.Target.Value},
-			{"extratargets.target.value": f.Target.Value},
+		if enableExtraTargets {
+			orBlock := []bson.M{
+				{"target.value": f.Target.Value},
+				{"extratargets.target.value": f.Target.Value},
+			}
+			andBlock = append(andBlock, bson.M{"$or": orBlock})
+		} else {
+			query["target.value"] = f.Target.Value
 		}
-		andBlock = append(andBlock, bson.M{"$or": orBlock})
 	}
 	if f.KindType != "" {
 		query["kind.type"] = f.KindType
@@ -1394,4 +1410,16 @@ func addLinePrefix(data string, prefix string) string {
 	}
 	replacement := "\n" + prefix
 	return prefix + strings.ReplaceAll(data, "\n", replacement) + suffix
+}
+
+func allowToQueryExtraTargets(kindNames []string) bool {
+	enableExtraTargets := len(kindNames) == 0
+	for _, kindName := range kindNames {
+		if extraTargetKindNames[kindName] {
+			enableExtraTargets = true
+			break
+		}
+	}
+
+	return enableExtraTargets
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/safe"
 	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
+	tsuruTest "github.com/tsuru/tsuru/test"
 	permTypes "github.com/tsuru/tsuru/types/permission"
 	trackerTypes "github.com/tsuru/tsuru/types/tracker"
 	"golang.org/x/crypto/bcrypt"
@@ -1066,6 +1067,103 @@ func (s *S) TestListWithFilters(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(evts, check.HasLen, 1)
 	c.Assert(evts[0].Target.Type, check.Equals, TargetType("node"))
+}
+
+func (s *S) TestFilterToQuery(c *check.C) {
+	cases := []struct {
+		f             Filter
+		expectedQuery bson.M
+	}{
+		{
+			f: Filter{
+				Target:    Target{Type: "app", Value: "myapp"},
+				KindType:  KindTypePermission,
+				KindNames: []string{"app.deploy"},
+				OwnerType: OwnerTypeUser,
+				OwnerName: "u",
+				Limit:     20,
+			},
+			expectedQuery: bson.M{
+				"target.type":  "app",
+				"target.value": "myapp",
+				"removedate":   bson.M{"$exists": false},
+				"kind.name": bson.M{
+					"$in": []string{"app.deploy"},
+				},
+				"kind.type":  "permission",
+				"owner.name": "u",
+				"owner.type": "user",
+			},
+		},
+		{
+			f: Filter{
+				Target:    Target{Type: "app", Value: "myapp"},
+				KindType:  KindTypePermission,
+				KindNames: []string{"healer"},
+				OwnerType: OwnerTypeUser,
+				OwnerName: "u",
+				Limit:     20,
+			},
+			expectedQuery: bson.M{
+				"$and": []bson.M{
+					{
+						"$or": []bson.M{
+							{"target.type": "app"},
+							{"extratargets.target.type": "app"},
+						},
+					},
+					{
+						"$or": []bson.M{
+							{"target.value": "myapp"},
+							{"extratargets.target.value": "myapp"},
+						},
+					},
+				},
+				"kind.name": bson.M{
+					"$in": []string{"healer"},
+				},
+				"kind.type":  "permission",
+				"owner.name": "u",
+				"owner.type": "user",
+				"removedate": bson.M{"$exists": false},
+			},
+		},
+		{
+			f: Filter{
+				Target:    Target{Type: "app", Value: "myapp"},
+				KindType:  KindTypePermission,
+				OwnerType: OwnerTypeUser,
+				OwnerName: "u",
+				Limit:     20,
+			},
+			expectedQuery: bson.M{
+				"$and": []bson.M{
+					{
+						"$or": []bson.M{
+							{"target.type": "app"},
+							{"extratargets.target.type": "app"},
+						},
+					},
+					{
+						"$or": []bson.M{
+							{"target.value": "myapp"},
+							{"extratargets.target.value": "myapp"},
+						},
+					},
+				},
+				"kind.type":  "permission",
+				"owner.name": "u",
+				"owner.type": "user",
+				"removedate": bson.M{"$exists": false},
+			},
+		},
+	}
+
+	for _, itemCase := range cases {
+		query, err := itemCase.f.toQuery()
+		c.Assert(err, check.IsNil)
+		c.Assert(query, tsuruTest.JSONEquals, itemCase.expectedQuery)
+	}
 }
 
 func (s *S) TestListFilterPruneUserValues(c *check.C) {


### PR DESCRIPTION
To take less time searching events, it created 3 new indexes, besides that, it is dropped the use of extraTargets in the query