### PR TITLE
Add labels to pools

### DIFF
--- a/api/pool_test.go
+++ b/api/pool_test.go
@@ -789,7 +789,8 @@ func (s *S) TestPoolGetHandler(c *check.C) {
 	err = pool.AddTeamsToPool(p.Name, []string{teamName})
 	c.Assert(err, check.IsNil)
 	expected := pool.Pool{
-		Name: "pool1",
+		Name:   "pool1",
+		Labels: map[string]string{},
 	}
 	req, err := http.NewRequest(http.MethodGet, "/pools/pool1", nil)
 	c.Assert(err, check.IsNil)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/felixge/fgprof v0.9.1
 	github.com/fsouza/go-dockerclient v0.0.0-20180427001620-3a206030a28a
 	github.com/garyburd/redigo v1.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/google/go-querystring v0.0.0-20150414214848-547ef5ac9797 // indirect
 	github.com/google/gops v0.0.0-20180311052415-160b358b10d6

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -74,7 +74,7 @@ var (
 		singlePoolKey:                 "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
 		ephemeralStorageKey:           fmt.Sprintf("Sets limit for ephemeral storage for created pods. This config may be prefixed with `<pool-name>:`. Defaults to %s.", defaultEphemeralStorageLimit.String()),
 		preStopSleepKey:               fmt.Sprintf("Number of seconds to sleep in the preStop lifecycle hook. This config may be prefixed with `<pool-name>:`. Defaults to %d.", defaultPreStopSleepSeconds),
-		disableDefaultNodeSelectorKey: "Disables the use of node selector in the cluster if set to true",
+		disableDefaultNodeSelectorKey: "Disables the use of node selector in the cluster if enabled",
 
 		enableLogsFromAPIServerKey: "Enable tsuru to request application logs from kubernetes api-server, will be enabled by default in next tsuru major version",
 	}

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -50,7 +50,6 @@ const (
 	ephemeralStorageKey           = "ephemeral-storage"
 	preStopSleepKey               = "pre-stop-sleep"
 	disableDefaultNodeSelectorKey = "disable-default-node-selector"
-	defaultNodeSelector           = true
 
 	enableLogsFromAPIServerKey = "enable-logs-from-apiserver"
 	defaultLogsFromAPIServer   = false

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -50,6 +50,8 @@ const (
 	ephemeralStorageKey    = "ephemeral-storage"
 	preStopSleepKey        = "pre-stop-sleep"
 
+	nodeSelectorKey = "node-selector"
+
 	enableLogsFromAPIServerKey = "enable-logs-from-apiserver"
 	defaultLogsFromAPIServer   = false
 
@@ -73,6 +75,7 @@ var (
 		singlePoolKey:          "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
 		ephemeralStorageKey:    fmt.Sprintf("Sets limit for ephemeral storage for created pods. This config may be prefixed with `<pool-name>:`. Defaults to %s.", defaultEphemeralStorageLimit.String()),
 		preStopSleepKey:        fmt.Sprintf("Number of seconds to sleep in the preStop lifecycle hook. This config may be prefixed with `<pool-name>:`. Defaults to %d.", defaultPreStopSleepSeconds),
+		nodeSelectorKey:        "Enable cluster nodeSelector during deployment, if not present use pool nodeSelector, if not present, use none",
 
 		enableLogsFromAPIServerKey: "Enable tsuru to request application logs from kubernetes api-server, will be enabled by default in next tsuru major version",
 	}

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -35,22 +35,22 @@ import (
 )
 
 const (
-	namespaceClusterKey    = "namespace"
-	tokenClusterKey        = "token"
-	userClusterKey         = "username"
-	passwordClusterKey     = "password"
-	overcommitClusterKey   = "overcommit-factor"
-	namespaceLabelsKey     = "namespace-labels"
-	externalPolicyLocalKey = "external-policy-local"
-	routerAddressLocalKey  = "router-local"
-	disableHeadlessKey     = "disable-headless"
-	maxSurgeKey            = "max-surge"
-	maxUnavailableKey      = "max-unavailable"
-	singlePoolKey          = "single-pool"
-	ephemeralStorageKey    = "ephemeral-storage"
-	preStopSleepKey        = "pre-stop-sleep"
-
-	nodeSelectorKey = "node-selector"
+	namespaceClusterKey           = "namespace"
+	tokenClusterKey               = "token"
+	userClusterKey                = "username"
+	passwordClusterKey            = "password"
+	overcommitClusterKey          = "overcommit-factor"
+	namespaceLabelsKey            = "namespace-labels"
+	externalPolicyLocalKey        = "external-policy-local"
+	routerAddressLocalKey         = "router-local"
+	disableHeadlessKey            = "disable-headless"
+	maxSurgeKey                   = "max-surge"
+	maxUnavailableKey             = "max-unavailable"
+	singlePoolKey                 = "single-pool"
+	ephemeralStorageKey           = "ephemeral-storage"
+	preStopSleepKey               = "pre-stop-sleep"
+	disableDefaultNodeSelectorKey = "disable-default-node-selector"
+	defaultNodeSelector           = true
 
 	enableLogsFromAPIServerKey = "enable-logs-from-apiserver"
 	defaultLogsFromAPIServer   = false
@@ -61,21 +61,21 @@ const (
 
 var (
 	clusterHelp = map[string]string{
-		namespaceClusterKey:    "Namespace used to create resources unless kubernetes:use-pool-namespaces config is enabled.",
-		tokenClusterKey:        "Token used to connect to the cluster,",
-		userClusterKey:         "User used to connect to the cluster.",
-		passwordClusterKey:     "Password used to connect to the cluster.",
-		overcommitClusterKey:   "Overcommit factor for memory resources. The requested value will be divided by this factor. This config may be prefixed with `<pool-name>:`.",
-		namespaceLabelsKey:     "Extra labels added to dynamically created namespaces in the format <label1>=<value1>,<label2>=<value2>... This config may be prefixed with `<pool-name>:`.",
-		externalPolicyLocalKey: "Use external policy local in created services. This is not recommended as depending on the used router it can cause downtimes during restarts. This config may be prefixed with `<pool-name>:`.",
-		routerAddressLocalKey:  "Only add node addresses that contains a pod from an app to the router. This config may be prefixed with `<pool-name>:`.",
-		disableHeadlessKey:     "Disable headless service creation for every app-process. This config may be prefixed with `<pool-name>:`.",
-		maxSurgeKey:            "Max surge for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 100%.",
-		maxUnavailableKey:      "Max unavailable for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 0.",
-		singlePoolKey:          "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
-		ephemeralStorageKey:    fmt.Sprintf("Sets limit for ephemeral storage for created pods. This config may be prefixed with `<pool-name>:`. Defaults to %s.", defaultEphemeralStorageLimit.String()),
-		preStopSleepKey:        fmt.Sprintf("Number of seconds to sleep in the preStop lifecycle hook. This config may be prefixed with `<pool-name>:`. Defaults to %d.", defaultPreStopSleepSeconds),
-		nodeSelectorKey:        "Enable cluster nodeSelector during deployment, if not present use pool nodeSelector, if not present, use none",
+		namespaceClusterKey:           "Namespace used to create resources unless kubernetes:use-pool-namespaces config is enabled.",
+		tokenClusterKey:               "Token used to connect to the cluster,",
+		userClusterKey:                "User used to connect to the cluster.",
+		passwordClusterKey:            "Password used to connect to the cluster.",
+		overcommitClusterKey:          "Overcommit factor for memory resources. The requested value will be divided by this factor. This config may be prefixed with `<pool-name>:`.",
+		namespaceLabelsKey:            "Extra labels added to dynamically created namespaces in the format <label1>=<value1>,<label2>=<value2>... This config may be prefixed with `<pool-name>:`.",
+		externalPolicyLocalKey:        "Use external policy local in created services. This is not recommended as depending on the used router it can cause downtimes during restarts. This config may be prefixed with `<pool-name>:`.",
+		routerAddressLocalKey:         "Only add node addresses that contains a pod from an app to the router. This config may be prefixed with `<pool-name>:`.",
+		disableHeadlessKey:            "Disable headless service creation for every app-process. This config may be prefixed with `<pool-name>:`.",
+		maxSurgeKey:                   "Max surge for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 100%.",
+		maxUnavailableKey:             "Max unavailable for deployments rollout. This config may be prefixed with `<pool-name>:`. Defaults to 0.",
+		singlePoolKey:                 "Set to use entire cluster to a pool instead only designated nodes. Defaults do false.",
+		ephemeralStorageKey:           fmt.Sprintf("Sets limit for ephemeral storage for created pods. This config may be prefixed with `<pool-name>:`. Defaults to %s.", defaultEphemeralStorageLimit.String()),
+		preStopSleepKey:               fmt.Sprintf("Number of seconds to sleep in the preStop lifecycle hook. This config may be prefixed with `<pool-name>:`. Defaults to %d.", defaultPreStopSleepSeconds),
+		disableDefaultNodeSelectorKey: "Disables the use of node selector in the cluster if set to true",
 
 		enableLogsFromAPIServerKey: "Enable tsuru to request application logs from kubernetes api-server, will be enabled by default in next tsuru major version",
 	}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -517,6 +517,9 @@ func defineSelectorAndAffinity(ctx context.Context, a provision.App, client *Clu
 		return nil, nil, err
 	}
 	affinity, err := pool.GetAffinity()
+	if err != nil {
+		return nil, nil, err
+	}
 	if affinity != nil && affinity.NodeAffinity != nil {
 		return nil, affinity, nil
 	}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -513,7 +513,8 @@ func defineSelector(ctx context.Context, a provision.App, client *ClusterClient)
 	}
 
 	if val, ok := client.GetCluster().CustomData[disableDefaultNodeSelectorKey]; ok {
-		shouldDisable, err := strconv.ParseBool(val)
+		var shouldDisable bool
+		shouldDisable, err = strconv.ParseBool(val)
 		if err != nil {
 			return nil, errors.WithMessage(err, fmt.Sprintf("error while parsing cluster custom data entry: %s", disableDefaultNodeSelectorKey))
 		}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -526,7 +526,18 @@ func defineSelector(ctx context.Context, a provision.App, client *ClusterClient)
 	if err != nil {
 		return nil, err
 	}
-	return pool.GetNodeSelector()
+	selector, err := pool.GetNodeSelector()
+	if err != nil {
+		return nil, err
+	}
+	if selector != nil {
+		return selector, nil
+	}
+
+	return provision.NodeLabels(provision.NodeLabelsOpts{
+		Pool:   a.GetPool(),
+		Prefix: tsuruLabelPrefix,
+	}).ToNodeByPoolSelector(), nil
 }
 
 func podAffinity(ctx context.Context, a provision.App) (*apiv1.Affinity, error) {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -518,10 +518,7 @@ func getNodeSelector(ctx context.Context, a provision.App, client *ClusterClient
 		if err != nil {
 			return nil, err
 		}
-		if pool.Labels.Selector != nil {
-			return pool.Labels.Selector, nil
-		}
-		return map[string]string{}, nil
+		return pool.GetNodeSelector()
 	}
 
 	return provision.NodeLabels(provision.NodeLabelsOpts{
@@ -530,17 +527,13 @@ func getNodeSelector(ctx context.Context, a provision.App, client *ClusterClient
 	}).ToNodeByPoolSelector(), nil
 }
 
-func getPoolAffinity(ctx context.Context, a provision.App) (*apiv1.Affinity, error) {
+func podAffinity(ctx context.Context, a provision.App) (*apiv1.Affinity, error) {
 	pool, err := pool.GetPoolByName(ctx, a.GetPool())
 	if err != nil {
 		return nil, err
 	}
 
-	if pool.Labels.Affinity != nil {
-		return pool.Labels.Affinity, nil
-	}
-
-	return pool.Labels.Affinity, nil
+	return pool.GetAffinity()
 }
 
 func createAppDeployment(ctx context.Context, client *ClusterClient, depName string, oldDeployment *appsv1.Deployment, a provision.App, process string, version appTypes.AppVersion, replicas int, labels *provision.LabelSet, selector map[string]string) (*appsv1.Deployment, *provision.LabelSet, error) {
@@ -611,7 +604,7 @@ func createAppDeployment(ctx context.Context, client *ClusterClient, depName str
 		return nil, nil, err
 	}
 
-	affinity, err := getPoolAffinity(ctx, a)
+	affinity, err := podAffinity(ctx, a)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -1979,7 +1979,7 @@ func (s *S) TestServiceManagerDeploySinglePoolEnable(c *check.C) {
 	c.Assert(err, check.IsNil)
 	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
 	c.Assert(err, check.IsNil)
-	c.Assert(dep.Spec.Template.Spec.NodeSelector, check.DeepEquals, map[string]string{})
+	c.Assert(dep.Spec.Template.Spec.NodeSelector, check.DeepEquals, map[string]string(nil))
 }
 
 func (s *S) TestServiceManagerDeployServiceWithPreserveVersions(c *check.C) {

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/nodecontainer"
+	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/provision/servicecommon"
 	"github.com/tsuru/tsuru/safe"
 	"github.com/tsuru/tsuru/servicemanager"
@@ -341,6 +342,464 @@ func (s *S) TestServiceManagerDeployService(c *check.C) {
 			},
 		},
 	})
+}
+
+func (s *S) TestServiceManagerDeployServiceWithPoolNodeSelector(c *check.C) {
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	err := pool.PoolUpdate(context.TODO(), "test-default", pool.UpdatePoolOptions{Labels: map[string]string{"nodeSelector": `{"beta.kubernetes.io/os":"linux"}`}})
+	c.Assert(err, check.IsNil)
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err = app.CreateApp(context.TODO(), a, s.user)
+	c.Assert(err, check.IsNil)
+	version := newCommittedVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cm1",
+			"p2": "cmd2",
+		},
+	})
+	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
+		App:     a,
+		Version: version,
+	}, servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	c.Assert(err, check.IsNil)
+	waitDep()
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	one := int32(1)
+	ten := int32(10)
+	maxSurge := intstr.FromString("100%")
+	maxUnavailable := intstr.FromInt(0)
+	expectedUID := int64(1000)
+	depLabels := map[string]string{
+		"tsuru.io/is-tsuru":        "true",
+		"tsuru.io/is-service":      "true",
+		"tsuru.io/is-build":        "false",
+		"tsuru.io/is-stopped":      "false",
+		"tsuru.io/is-deploy":       "false",
+		"tsuru.io/is-isolated-run": "false",
+		"tsuru.io/is-routable":     "true",
+		"tsuru.io/app-name":        "myapp",
+		"tsuru.io/app-process":     "p1",
+		"tsuru.io/app-team":        "admin",
+		"tsuru.io/app-platform":    "",
+		"tsuru.io/app-pool":        "test-default",
+		"tsuru.io/provisioner":     "kubernetes",
+		"tsuru.io/builder":         "",
+		"app":                      "myapp-p1",
+	}
+	podLabels := make(map[string]string)
+	for k, v := range depLabels {
+		podLabels[k] = v
+	}
+	podLabels["tsuru.io/app-version"] = "1"
+	podLabels["version"] = "v1"
+	nsName, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	expected := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "myapp-p1",
+			Namespace:   nsName,
+			Labels:      depLabels,
+			Annotations: map[string]string{},
+		},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas: 1,
+			Replicas:        1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+			Replicas:             &one,
+			RevisionHistoryLimit: &ten,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"tsuru.io/app-name":        "myapp",
+					"tsuru.io/app-process":     "p1",
+					"tsuru.io/is-build":        "false",
+					"tsuru.io/is-isolated-run": "false",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: apiv1.PodSpec{
+					EnableServiceLinks: func(b bool) *bool { return &b }(false),
+					ServiceAccountName: "app-myapp",
+					SecurityContext: &apiv1.PodSecurityContext{
+						RunAsUser: &expectedUID,
+					},
+					NodeSelector: map[string]string{
+						"beta.kubernetes.io/os": "linux",
+					},
+					RestartPolicy:                 "Always",
+					Subdomain:                     "myapp-p1-units",
+					TerminationGracePeriodSeconds: func(v int64) *int64 { return &v }(40),
+					Containers: []apiv1.Container{
+						{
+							Name:  "myapp-p1",
+							Image: version.BaseImageName(),
+							Command: []string{
+								"/bin/sh",
+								"-lc",
+								"[ -d /home/application/current ] && cd /home/application/current; curl -sSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
+							},
+							Env: []apiv1.EnvVar{
+								{Name: "TSURU_SERVICES", Value: "{}"},
+								{Name: "TSURU_PROCESSNAME", Value: "p1"},
+								{Name: "TSURU_APPVERSION", Value: "1"},
+								{Name: "TSURU_HOST", Value: ""},
+								{Name: "port", Value: "8888"},
+								{Name: "PORT", Value: "8888"},
+								{Name: "PORT_p1", Value: "8888"},
+							},
+							Resources: apiv1.ResourceRequirements{
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+								},
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: *resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+							Ports: []apiv1.ContainerPort{
+								{ContainerPort: 8888},
+							},
+							Lifecycle: &apiv1.Lifecycle{
+								PreStop: &apiv1.Handler{
+									Exec: &apiv1.ExecAction{
+										Command: []string{"sh", "-c", "sleep 10 || true"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Assert(dep, check.DeepEquals, expected)
+	err = pool.PoolUpdate(context.TODO(), "test-default", pool.UpdatePoolOptions{Labels: map[string]string{}})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestServiceManagerDeployServiceWithClusterNodeSelectorDisabled(c *check.C) {
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	m.client.CustomData[disableDefaultNodeSelectorKey] = "true"
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), a, s.user)
+	c.Assert(err, check.IsNil)
+	version := newCommittedVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cm1",
+			"p2": "cmd2",
+		},
+	})
+	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
+		App:     a,
+		Version: version,
+	}, servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	c.Assert(err, check.IsNil)
+	waitDep()
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	one := int32(1)
+	ten := int32(10)
+	maxSurge := intstr.FromString("100%")
+	maxUnavailable := intstr.FromInt(0)
+	expectedUID := int64(1000)
+	depLabels := map[string]string{
+		"tsuru.io/is-tsuru":        "true",
+		"tsuru.io/is-service":      "true",
+		"tsuru.io/is-build":        "false",
+		"tsuru.io/is-stopped":      "false",
+		"tsuru.io/is-deploy":       "false",
+		"tsuru.io/is-isolated-run": "false",
+		"tsuru.io/is-routable":     "true",
+		"tsuru.io/app-name":        "myapp",
+		"tsuru.io/app-process":     "p1",
+		"tsuru.io/app-team":        "admin",
+		"tsuru.io/app-platform":    "",
+		"tsuru.io/app-pool":        "test-default",
+		"tsuru.io/provisioner":     "kubernetes",
+		"tsuru.io/builder":         "",
+		"app":                      "myapp-p1",
+	}
+	podLabels := make(map[string]string)
+	for k, v := range depLabels {
+		podLabels[k] = v
+	}
+	podLabels["tsuru.io/app-version"] = "1"
+	podLabels["version"] = "v1"
+	nsName, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	expected := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "myapp-p1",
+			Namespace:   nsName,
+			Labels:      depLabels,
+			Annotations: map[string]string{},
+		},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas: 1,
+			Replicas:        1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+			Replicas:             &one,
+			RevisionHistoryLimit: &ten,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"tsuru.io/app-name":        "myapp",
+					"tsuru.io/app-process":     "p1",
+					"tsuru.io/is-build":        "false",
+					"tsuru.io/is-isolated-run": "false",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: apiv1.PodSpec{
+					EnableServiceLinks: func(b bool) *bool { return &b }(false),
+					ServiceAccountName: "app-myapp",
+					SecurityContext: &apiv1.PodSecurityContext{
+						RunAsUser: &expectedUID,
+					},
+					NodeSelector:                  nil,
+					RestartPolicy:                 "Always",
+					Subdomain:                     "myapp-p1-units",
+					TerminationGracePeriodSeconds: func(v int64) *int64 { return &v }(40),
+					Containers: []apiv1.Container{
+						{
+							Name:  "myapp-p1",
+							Image: version.BaseImageName(),
+							Command: []string{
+								"/bin/sh",
+								"-lc",
+								"[ -d /home/application/current ] && cd /home/application/current; curl -sSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
+							},
+							Env: []apiv1.EnvVar{
+								{Name: "TSURU_SERVICES", Value: "{}"},
+								{Name: "TSURU_PROCESSNAME", Value: "p1"},
+								{Name: "TSURU_APPVERSION", Value: "1"},
+								{Name: "TSURU_HOST", Value: ""},
+								{Name: "port", Value: "8888"},
+								{Name: "PORT", Value: "8888"},
+								{Name: "PORT_p1", Value: "8888"},
+							},
+							Resources: apiv1.ResourceRequirements{
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+								},
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: *resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+							Ports: []apiv1.ContainerPort{
+								{ContainerPort: 8888},
+							},
+							Lifecycle: &apiv1.Lifecycle{
+								PreStop: &apiv1.Handler{
+									Exec: &apiv1.ExecAction{
+										Command: []string{"sh", "-c", "sleep 10 || true"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Assert(dep, check.DeepEquals, expected)
+	err = pool.PoolUpdate(context.TODO(), "test-default", pool.UpdatePoolOptions{Labels: map[string]string{}})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestServiceManagerDeployServiceWithPoolNodeAffinity(c *check.C) {
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	err := pool.PoolUpdate(context.TODO(), "test-default", pool.UpdatePoolOptions{Labels: map[string]string{"affinity": `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`}})
+	c.Assert(err, check.IsNil)
+	a := &app.App{Name: "myapp", TeamOwner: s.team.Name}
+	err = app.CreateApp(context.TODO(), a, s.user)
+	c.Assert(err, check.IsNil)
+	version := newCommittedVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"p1": "cm1",
+			"p2": "cmd2",
+		},
+	})
+	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
+		App:     a,
+		Version: version,
+	}, servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	c.Assert(err, check.IsNil)
+	waitDep()
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
+	c.Assert(err, check.IsNil)
+	one := int32(1)
+	ten := int32(10)
+	maxSurge := intstr.FromString("100%")
+	maxUnavailable := intstr.FromInt(0)
+	expectedUID := int64(1000)
+	depLabels := map[string]string{
+		"tsuru.io/is-tsuru":        "true",
+		"tsuru.io/is-service":      "true",
+		"tsuru.io/is-build":        "false",
+		"tsuru.io/is-stopped":      "false",
+		"tsuru.io/is-deploy":       "false",
+		"tsuru.io/is-isolated-run": "false",
+		"tsuru.io/is-routable":     "true",
+		"tsuru.io/app-name":        "myapp",
+		"tsuru.io/app-process":     "p1",
+		"tsuru.io/app-team":        "admin",
+		"tsuru.io/app-platform":    "",
+		"tsuru.io/app-pool":        "test-default",
+		"tsuru.io/provisioner":     "kubernetes",
+		"tsuru.io/builder":         "",
+		"app":                      "myapp-p1",
+	}
+	podLabels := make(map[string]string)
+	for k, v := range depLabels {
+		podLabels[k] = v
+	}
+	podLabels["tsuru.io/app-version"] = "1"
+	podLabels["version"] = "v1"
+	nsName, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	expected := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "myapp-p1",
+			Namespace:   nsName,
+			Labels:      depLabels,
+			Annotations: map[string]string{},
+		},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas: 1,
+			Replicas:        1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+			Replicas:             &one,
+			RevisionHistoryLimit: &ten,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"tsuru.io/app-name":        "myapp",
+					"tsuru.io/app-process":     "p1",
+					"tsuru.io/is-build":        "false",
+					"tsuru.io/is-isolated-run": "false",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: apiv1.PodSpec{
+					EnableServiceLinks: func(b bool) *bool { return &b }(false),
+					ServiceAccountName: "app-myapp",
+					NodeSelector: map[string]string{
+						"tsuru.io/pool": "test-default",
+					},
+					SecurityContext: &apiv1.PodSecurityContext{
+						RunAsUser: &expectedUID,
+					},
+					Affinity: &apiv1.Affinity{
+						NodeAffinity: &apiv1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+								NodeSelectorTerms: []apiv1.NodeSelectorTerm{
+									{
+										MatchExpressions: []apiv1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: "In",
+												Values:   []string{"minikube"},
+											},
+										},
+									}},
+							},
+						},
+					},
+					RestartPolicy:                 "Always",
+					Subdomain:                     "myapp-p1-units",
+					TerminationGracePeriodSeconds: func(v int64) *int64 { return &v }(40),
+					Containers: []apiv1.Container{
+						{
+							Name:  "myapp-p1",
+							Image: version.BaseImageName(),
+							Command: []string{
+								"/bin/sh",
+								"-lc",
+								"[ -d /home/application/current ] && cd /home/application/current; curl -sSL -m15 -XPOST -d\"hostname=$(hostname)\" -o/dev/null -H\"Content-Type:application/x-www-form-urlencoded\" -H\"Authorization:bearer \" http://apps/myapp/units/register || true && exec cm1",
+							},
+							Env: []apiv1.EnvVar{
+								{Name: "TSURU_SERVICES", Value: "{}"},
+								{Name: "TSURU_PROCESSNAME", Value: "p1"},
+								{Name: "TSURU_APPVERSION", Value: "1"},
+								{Name: "TSURU_HOST", Value: ""},
+								{Name: "port", Value: "8888"},
+								{Name: "PORT", Value: "8888"},
+								{Name: "PORT_p1", Value: "8888"},
+							},
+							Resources: apiv1.ResourceRequirements{
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+								},
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceEphemeralStorage: *resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+							Ports: []apiv1.ContainerPort{
+								{ContainerPort: 8888},
+							},
+							Lifecycle: &apiv1.Lifecycle{
+								PreStop: &apiv1.Handler{
+									Exec: &apiv1.ExecAction{
+										Command: []string{"sh", "-c", "sleep 10 || true"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Assert(dep, check.DeepEquals, expected)
 }
 
 func (s *S) TestServiceManagerDeployServiceRaceWithHPA(c *check.C) {

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -38,6 +38,7 @@ var (
 	ErrPoolHasNoService               = errors.New("no service found for pool")
 	ErrPoolHasNoPlan                  = errors.New("no plan found for pool")
 	ErrPoolHasNoVolumePlan            = errors.New("no volume-plan found for pool")
+	ErrNodeSelectorNotValid           = errors.New("node selector is not a valid map")
 )
 
 const (
@@ -372,7 +373,7 @@ func (p *Pool) validate() error {
 	}
 
 	if len(p.Labels) > 0 {
-		validateLabels(p.Labels)
+		return validateLabels(p.Labels)
 	}
 	return nil
 }

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -624,7 +624,7 @@ func PoolUpdate(ctx context.Context, name string, opts UpdatePoolOptions) error 
 		query["default"] = *opts.Default
 	}
 	if len(opts.Labels) > 0 {
-		if err := validateLabels(opts.Labels); err != nil {
+		if err = validateLabels(opts.Labels); err != nil {
 			return err
 		}
 	}

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
@@ -75,7 +76,7 @@ type UpdatePoolOptions struct {
 func (p *Pool) GetAffinity() (*apiv1.Affinity, error) {
 	if affinity, ok := p.Labels[affinityKey]; ok {
 		var k8sAffinity apiv1.Affinity
-		if err := json.Unmarshal([]byte(affinity), &k8sAffinity); err != nil {
+		if err := yaml.Unmarshal([]byte(affinity), &k8sAffinity); err != nil {
 			return nil, err
 		}
 		return &k8sAffinity, nil

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -38,12 +38,10 @@ var (
 	ErrPoolHasNoService               = errors.New("no service found for pool")
 	ErrPoolHasNoPlan                  = errors.New("no plan found for pool")
 	ErrPoolHasNoVolumePlan            = errors.New("no volume-plan found for pool")
-	ErrNodeSelectorNotValid           = errors.New("node selector is not a valid map")
 )
 
 const (
-	nodeSelectorKey = "nodeSelector"
-	affinityKey     = "affinity"
+	affinityKey = "affinity"
 )
 
 type Pool struct {
@@ -72,18 +70,6 @@ type UpdatePoolOptions struct {
 	Force   bool
 
 	Labels map[string]string
-}
-
-func (p *Pool) GetNodeSelector() (map[string]string, error) {
-	var nodeSelectorValues map[string]string
-	if values, ok := p.Labels[nodeSelectorKey]; ok {
-		err := json.Unmarshal([]byte(values), &nodeSelectorValues)
-		if err != nil {
-			return nil, err
-		}
-		return nodeSelectorValues, nil
-	}
-	return nil, nil
 }
 
 func (p *Pool) GetAffinity() (*apiv1.Affinity, error) {
@@ -344,13 +330,6 @@ func (p *Pool) MarshalJSON() ([]byte, error) {
 }
 
 func validateLabels(labels map[string]string) error {
-	if selectorValues, ok := labels[nodeSelectorKey]; ok {
-		var sMap map[string]string
-		if err := json.Unmarshal([]byte(selectorValues), &sMap); err != nil {
-			return err
-		}
-	}
-
 	if affinityStr, ok := labels[affinityKey]; ok {
 		var affinity apiv1.Affinity
 		if err := json.Unmarshal([]byte(affinityStr), &affinity); err != nil {

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -230,59 +230,30 @@ func (s *S) TestAddPoolWithLabels(c *check.C) {
 		assertion func(testName string, c *check.C, pool *Pool, err error)
 	}{
 		{
-			testName: "create pool with node selector label",
-			opts: AddPoolOptions{
-				Name: "pool1",
-				Labels: map[string]string{
-					nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`,
-				},
-			},
-			assertion: func(testName string, c *check.C, pool *Pool, err error) {
-				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool1", check.Commentf("%s", testName))
-				c.Assert(pool.Labels, check.DeepEquals, map[string]string{nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`}, check.Commentf("%s", testName))
-			},
-		},
-		{
 			testName: "create pool with affinity label",
 			opts: AddPoolOptions{
-				Name: "pool2",
+				Name: "pool1",
 				Labels: map[string]string{
 					affinityKey: `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`,
 				},
 			},
 			assertion: func(testName string, c *check.C, pool *Pool, err error) {
 				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool2", check.Commentf("%s", testName))
+				c.Assert(pool.Name, check.Equals, "pool1", check.Commentf("%s", testName))
 				c.Assert(pool.Labels, check.DeepEquals, map[string]string{affinityKey: `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`}, check.Commentf("%s", testName))
-			},
-		},
-		{
-			testName: "create pool with affinity and node selector labels",
-			opts: AddPoolOptions{
-				Name: "pool3",
-				Labels: map[string]string{
-					nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`,
-					affinityKey:     `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`,
-				},
-			},
-			assertion: func(testName string, c *check.C, pool *Pool, err error) {
-				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool3", check.Commentf("%s", testName))
-				c.Assert(pool.Labels, check.DeepEquals, map[string]string{nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`, affinityKey: `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`}, check.Commentf("%s", testName))
 			},
 		},
 		{
 			testName: "create pool with custom label",
 			opts: AddPoolOptions{
-				Name: "pool4",
+				Name: "pool2",
 				Labels: map[string]string{
 					"testLabel": "something",
 				},
 			},
 			assertion: func(testName string, c *check.C, pool *Pool, err error) {
 				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool4", check.Commentf("%s", testName))
+				c.Assert(pool.Name, check.Equals, "pool2", check.Commentf("%s", testName))
 				c.Assert(pool.Labels, check.DeepEquals, map[string]string{"testLabel": "something"}, check.Commentf("%s", testName))
 			},
 		},
@@ -301,14 +272,6 @@ func (s *S) TestAddPoolValidateLabels(c *check.C) {
 		opts        AddPoolOptions
 		expectedErr string
 	}{
-		{
-			testName: "selector label with invalid format",
-			opts: AddPoolOptions{
-				Name:   "pool1",
-				Labels: map[string]string{nodeSelectorKey: "invalid map"},
-			},
-			expectedErr: "invalid character 'i' looking for beginning of value",
-		},
 		{
 			testName: "affinity label with invalid format",
 			opts: AddPoolOptions{
@@ -533,25 +496,9 @@ func (s *S) TestPoolUpdateWithLabels(c *check.C) {
 		assertion func(testName string, c *check.C, pool *Pool, err error)
 	}{
 		{
-			testName: "create pool with node selector label",
-			aOpts: AddPoolOptions{
-				Name: "pool1",
-			},
-			uOpts: UpdatePoolOptions{
-				Labels: map[string]string{
-					nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`,
-				},
-			},
-			assertion: func(testName string, c *check.C, pool *Pool, err error) {
-				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool1", check.Commentf("%s", testName))
-				c.Assert(pool.Labels, check.DeepEquals, map[string]string{nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`}, check.Commentf("%s", testName))
-			},
-		},
-		{
 			testName: "create pool with affinity label",
 			aOpts: AddPoolOptions{
-				Name: "pool2",
+				Name: "pool1",
 			},
 			uOpts: UpdatePoolOptions{
 				Labels: map[string]string{
@@ -560,31 +507,14 @@ func (s *S) TestPoolUpdateWithLabels(c *check.C) {
 			},
 			assertion: func(testName string, c *check.C, pool *Pool, err error) {
 				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool2", check.Commentf("%s", testName))
+				c.Assert(pool.Name, check.Equals, "pool1", check.Commentf("%s", testName))
 				c.Assert(pool.Labels, check.DeepEquals, map[string]string{affinityKey: `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`}, check.Commentf("%s", testName))
-			},
-		},
-		{
-			testName: "create pool with affinity and node selector labels",
-			aOpts: AddPoolOptions{
-				Name: "pool3",
-			},
-			uOpts: UpdatePoolOptions{
-				Labels: map[string]string{
-					nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`,
-					affinityKey:     `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`,
-				},
-			},
-			assertion: func(testName string, c *check.C, pool *Pool, err error) {
-				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool3", check.Commentf("%s", testName))
-				c.Assert(pool.Labels, check.DeepEquals, map[string]string{nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`, affinityKey: `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikube"]}]}]}}}`}, check.Commentf("%s", testName))
 			},
 		},
 		{
 			testName: "create pool with custom label",
 			aOpts: AddPoolOptions{
-				Name: "pool4",
+				Name: "pool2",
 			},
 			uOpts: UpdatePoolOptions{
 				Labels: map[string]string{
@@ -593,7 +523,7 @@ func (s *S) TestPoolUpdateWithLabels(c *check.C) {
 			},
 			assertion: func(testName string, c *check.C, pool *Pool, err error) {
 				c.Assert(err, check.IsNil, check.Commentf("%s", testName))
-				c.Assert(pool.Name, check.Equals, "pool4", check.Commentf("%s", testName))
+				c.Assert(pool.Name, check.Equals, "pool2", check.Commentf("%s", testName))
 				c.Assert(pool.Labels, check.DeepEquals, map[string]string{"testLabel": "something"}, check.Commentf("%s", testName))
 			},
 		},
@@ -959,43 +889,6 @@ func (s *S) TestGetProvisionerForPool(c *check.C) {
 	prov, err = GetProvisionerForPool(context.TODO(), "not found")
 	c.Assert(prov, check.IsNil)
 	c.Assert(err, check.Equals, ErrPoolNotFound)
-}
-
-func (s *S) TestGetNodeSelector(c *check.C) {
-	tt := []struct {
-		testName  string
-		pool      Pool
-		assertion func(testName string, c *check.C, selector map[string]string, err error)
-	}{
-		{
-			testName: "when a valid node selector is present",
-			pool:     Pool{Name: "pool1", Labels: map[string]string{nodeSelectorKey: `{"beta.kubernetes.io/os":"linux"}`}},
-			assertion: func(testName string, c *check.C, selector map[string]string, err error) {
-				c.Assert(err, check.IsNil)
-				c.Assert(selector, check.DeepEquals, map[string]string{"beta.kubernetes.io/os": "linux"})
-			},
-		},
-		{
-			testName: "when an invalid node selector is present",
-			pool:     Pool{Name: "pool1", Labels: map[string]string{nodeSelectorKey: `wrong format`}},
-			assertion: func(testName string, c *check.C, selector map[string]string, err error) {
-				c.Assert(err, check.ErrorMatches, "invalid character 'w' looking for beginning of value")
-			},
-		},
-		{
-			testName: "when there's no label in pool",
-			pool:     Pool{Name: "pool1"},
-			assertion: func(testName string, c *check.C, selector map[string]string, err error) {
-				c.Assert(err, check.IsNil)
-				c.Assert(selector, check.IsNil)
-			},
-		},
-	}
-
-	for _, t := range tt {
-		selector, err := t.pool.GetNodeSelector()
-		t.assertion(t.testName, c, selector, err)
-	}
 }
 
 func (s *S) TestGetAffinity(c *check.C) {

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -927,7 +927,7 @@ func (s *S) TestGetAffinity(c *check.C) {
 			pool:     Pool{Name: "pool1", Labels: map[string]string{affinityKey: `invalid affinity`}},
 			assertion: func(testName string, c *check.C, affinity *apiv1.Affinity, err error) {
 				c.Assert(affinity, check.IsNil)
-				c.Assert(err, check.ErrorMatches, "invalid character 'i' looking for beginning of value")
+				c.Assert(err, check.ErrorMatches, "error unmarshaling JSON: json: cannot unmarshal string into Go value of type v1.Affinity")
 			},
 		},
 		{


### PR DESCRIPTION
feat: add nodeAffinity according to pool label to pods when deploying in kubernetes
feat: use pool nodeSelector if cluster does not specify a node selector
change: don't use any nodeSelector if one is not found in cluster or pool