### PR TITLE
refactor: support PATCH method on router.AddAll

### DIFF
--- a/api/router/router.go
+++ b/api/router/router.go
@@ -88,7 +88,7 @@ func (r *DelayedRouter) Add(version, method, path string, h http.Handler) *mux.R
 
 // AddAll binds a path to GET, POST, PUT and DELETE methods.
 func (r *DelayedRouter) AddAll(version, path string, h http.Handler) *mux.Route {
-	return r.addRoute("", version, path, h, "GET", "POST", "PUT", "DELETE")
+	return r.addRoute("", version, path, h, "GET", "POST", "PUT", "PATCH", "DELETE")
 }
 
 func (r *DelayedRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/api/router/router_test.go
+++ b/api/router/router_test.go
@@ -97,7 +97,7 @@ func (s *S) TestDelayedRouterAddAll(c *check.C) {
 	router.AddAll("1.0", "/dream/{world}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 	}))
-	for _, method := range []string{"GET", "POST", "PUT", "DELETE"} {
+	for _, method := range []string{"GET", "POST", "PUT", "PATCH", "DELETE"} {
 		recorder := httptest.NewRecorder()
 		request, err := http.NewRequest(method, "/dream/tel'aran'rhiod", nil)
 		c.Assert(err, check.IsNil)


### PR DESCRIPTION
PATCH method is not currently supported, this leads to services APIs not being able to use it through the services proxy.