### PR TITLE
Allow configurable timeout for healthcheck passing during deploy

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1026,6 +1026,8 @@ docker:healing:events_collection
 Collection name in mongodb used to store information about triggered healing
 events. Defaults to ``healing_events``.
 
+.. _config_healthcheck_max_time:
+
 docker:healthcheck:max-time
 +++++++++++++++++++++++++++
 

--- a/docs/using/tsuru.yaml.rst
+++ b/docs/using/tsuru.yaml.rst
@@ -80,15 +80,16 @@ Example on how you can configure a HTTP base health check in your yaml file:
     healthcheck:
       path: /healthcheck
       scheme: http
-      method: GET
       headers:
         Host: test.com
         X-Custom-Header: xxx
       allowed_failures: 0
       interval_seconds: 10
       timeout_seconds: 60
+      deploy_timeout_seconds: 180
 
       // Ignored in kubernetes provisioner pools:
+      method: GET
       status: 200
       use_in_router: false
       match: .*OKAY.*
@@ -122,13 +123,9 @@ Example of a command based healthcheck (kubernetes only):
   regular expression uses `Go syntax
   <https://code.google.com/p/re2/wiki/Syntax>`_ and runs with ``.`` matching
   ``\n`` (``s`` flag).
-* ``healthcheck:command``: Exclusive to the ``kubernetes``
-  provisioner. A command to execute inside the unit container.
-  Exit status of zero is considered healthy and non-zero is unhealthy.
-  This option defaults to an empty string array. If ``healthcheck:path``
-  is set, this option will be ignored.
 * ``healthcheck:allowed_failures``: The number of allowed failures before that
-  the health check consider the application as unhealthy. Defaults to 0.
+  the health check consider the application as unhealthy. Defaults to 3 on
+  kubernetes pools and 0 on docker pools.
 * ``healthcheck:use_in_router``: Whether this health check path should also be
   registered in the router. This field is ignored in ``kubernetes``
   provisioner, which constantly calls the healthcheck every
@@ -140,6 +137,17 @@ Example of a command based healthcheck (kubernetes only):
   use ``healthcheck:command`` if a more complex healthcheck is necessary.
 * ``healthcheck:timeout_seconds``: The timeout for each healthcheck call in
   seconds. Defaults to 60 seconds.
+* ``healthcheck:deploy_timeout_seconds``: The timeout for the first successful
+  healthcheck response after the application process has started during a new
+  deploy. During this time a new healthcheck attempt will be made every
+  ``healthcheck:interval_seconds``. If the healthcheck is not successful in
+  this time the deploy will be aborted and rolled back. Defaults to
+  :ref:`max-time global config <config_healthcheck_max_time>`.
+* ``healthcheck:command``: Exclusive to the ``kubernetes`` provisioner. A
+  command to execute inside the unit container. Exit status of zero is
+  considered healthy and non-zero is unhealthy. This option defaults to an
+  empty string array. If ``healthcheck:path`` is set, this option will be
+  ignored.
 * ``healthcheck:interval_seconds``: Exclusive to the ``kubernetes``
   provisioner. The interval in seconds between each active healthcheck call if
   ``use_in_router`` is set to true. Defaults to 10 seconds.

--- a/provision/docker/healthcheck_test.go
+++ b/provision/docker/healthcheck_test.go
@@ -342,7 +342,7 @@ func (s *S) TestHealthcheckErrorsAfterMaxTime(c *check.C) {
 	host, port, _ := net.SplitHostPort(url.Host)
 	cont := container.Container{Container: types.Container{AppName: a.Name, HostAddr: host, HostPort: port, Image: version.BaseImageName()}}
 	buf := bytes.Buffer{}
-	config.Set("docker:healthcheck:max-time", -1)
+	config.Set("docker:healthcheck:max-time", 1)
 	defer config.Unset("docker:healthcheck:max-time")
 	done := make(chan struct{})
 	go func() {

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -1001,11 +1001,11 @@ func monitorDeployment(ctx context.Context, client *ClusterClient, dep *appsv1.D
 	oldUpdatedReplicas := int32(-1)
 	oldReadyUnits := int32(-1)
 	oldPendingTermination := int32(-1)
-	maxWaitTime, _ := config.GetInt("docker:healthcheck:max-time")
-	if maxWaitTime == 0 {
-		maxWaitTime = 120
+	tsuruYamlData, err := version.TsuruYamlData()
+	if err != nil {
+		return revision, errors.WithStack(err)
 	}
-	maxWaitTimeDuration := time.Duration(maxWaitTime) * time.Second
+	maxWaitTimeDuration := dockercommon.DeployHealthcheckTimeout(tsuruYamlData)
 	var healthcheckTimeout <-chan time.Time
 	t0 := time.Now()
 	largestReady := int32(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==1.7.4
 sphinx-rtd-theme==0.3.1
 tsuru-sphinx==0.1.4
 sphinxcontrib-openapi==0.3.2
+pyrsistent==0.16.0

--- a/types/provision/provision.go
+++ b/types/provision/provision.go
@@ -23,19 +23,20 @@ type TsuruYamlRestartHooks struct {
 }
 
 type TsuruYamlHealthcheck struct {
-	Path            string            `json:"path"`
-	Method          string            `json:"method"`
-	Status          int               `json:"status"`
-	Scheme          string            `json:"scheme"`
-	Command         []string          `json:"command,omitempty" bson:",omitempty"`
-	Headers         map[string]string `json:"headers,omitempty" bson:",omitempty"`
-	Match           string            `json:"match,omitempty" bson:",omitempty"`
-	RouterBody      string            `json:"router_body,omitempty" yaml:"router_body" bson:"router_body,omitempty"`
-	UseInRouter     bool              `json:"use_in_router,omitempty" yaml:"use_in_router" bson:"use_in_router,omitempty"`
-	ForceRestart    bool              `json:"force_restart,omitempty" yaml:"force_restart" bson:"force_restart,omitempty"`
-	AllowedFailures int               `json:"allowed_failures,omitempty" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
-	IntervalSeconds int               `json:"interval_seconds,omitempty" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
-	TimeoutSeconds  int               `json:"timeout_seconds,omitempty" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
+	Path                 string            `json:"path"`
+	Method               string            `json:"method"`
+	Status               int               `json:"status"`
+	Scheme               string            `json:"scheme"`
+	Command              []string          `json:"command,omitempty" bson:",omitempty"`
+	Headers              map[string]string `json:"headers,omitempty" bson:",omitempty"`
+	Match                string            `json:"match,omitempty" bson:",omitempty"`
+	RouterBody           string            `json:"router_body,omitempty" yaml:"router_body" bson:"router_body,omitempty"`
+	UseInRouter          bool              `json:"use_in_router,omitempty" yaml:"use_in_router" bson:"use_in_router,omitempty"`
+	ForceRestart         bool              `json:"force_restart,omitempty" yaml:"force_restart" bson:"force_restart,omitempty"`
+	AllowedFailures      int               `json:"allowed_failures,omitempty" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
+	IntervalSeconds      int               `json:"interval_seconds,omitempty" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
+	TimeoutSeconds       int               `json:"timeout_seconds,omitempty" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
+	DeployTimeoutSeconds int               `json:"deploy_timeout_seconds,omitempty" yaml:"deploy_timeout_seconds" bson:"deploy_timeout_seconds,omitempty"`
 }
 
 type TsuruYamlKubernetesConfig struct {


### PR DESCRIPTION
This PR adds the field `deploy_timeout_seconds` to the health check yaml configuration. I'm open for suggestions on a better name for this field.