### PR TITLE
refactor: improve env-vars API for easier integration with terraform

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -984,6 +984,10 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		msg := "You must provide the list of environment variables"
 		return &errors.HTTP{Code: http.StatusBadRequest, Message: msg}
 	}
+	if e.PruneUnused && e.ManagedBy == "" {
+		msg := "Prune unused requires a managed-by value"
+		return &errors.HTTP{Code: http.StatusBadRequest, Message: msg}
+	}
 	appName := r.URL.Query().Get(":app")
 	a, err := getAppFromContext(appName, r)
 	if err != nil {
@@ -995,8 +999,8 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	var toExclude []string
 
+	var toExclude []string
 	for i := 0; i < len(e.Envs); i++ {
 		if (e.Envs[i].Private != nil && *e.Envs[i].Private) || e.Private {
 			toExclude = append(toExclude, fmt.Sprintf("Envs.%d.Value", i))

--- a/app/app.go
+++ b/app/app.go
@@ -1594,6 +1594,9 @@ func (app *App) SetEnvs(setEnvs bind.SetEnvArgs) error {
 			ok := envInSet(name, setEnvs.Envs)
 			// only prune variables managed by requested
 			if !ok && value.ManagedBy == setEnvs.ManagedBy {
+				if setEnvs.Writer != nil {
+					fmt.Fprintf(setEnvs.Writer, "---- Pruning %s from environment variables ----\n", name)
+				}
 				delete(app.Env, name)
 			}
 		}

--- a/app/bind/binder.go
+++ b/app/bind/binder.go
@@ -12,10 +12,11 @@ import (
 
 // EnvVar represents a environment variable for an app.
 type EnvVar struct {
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	Alias  string `json:"alias"`
-	Public bool   `json:"public"`
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	Alias     string `json:"alias"`
+	Public    bool   `json:"public"`
+	ManagedBy string `json:"managedBy,omitempty"`
 }
 
 type ServiceEnvVar struct {
@@ -56,6 +57,8 @@ type App interface {
 type SetEnvArgs struct {
 	Envs          []EnvVar
 	Writer        io.Writer
+	ManagedBy     string
+	PruneUnused   bool
 	ShouldRestart bool
 }
 

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -1108,8 +1108,6 @@ paths:
       responses:
         "200":
           description: Envs updated
-          schema:
-            $ref: "#/definitions/EnvSetResponse"
         "400":
           description: Invalid data
           schema:
@@ -1142,7 +1140,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: "#/definitions/Env"
+              $ref: "#/definitions/EnvVar"
         "401":
           description: Unauthorized
           schema:
@@ -4457,7 +4455,7 @@ definitions:
         type: string
       delete:
         type: boolean
-  Env:
+  EnvVar:
     description: Environment variable.
     type: object
     properties:
@@ -4469,6 +4467,22 @@ definitions:
         type: string
       public:
         type: boolean
+      managedBy:
+        type: string
+  Env:
+    description: Environment variable.
+    type: object
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+      alias:
+        type: string
+      private:
+        type: boolean
+      managedBy:
+        type: string
   EnvSetData:
     description: Data sent to the environment set endpoint.
     type: object
@@ -4479,22 +4493,14 @@ definitions:
           type: object
           $ref: "#/definitions/Env"
         minItems: 1
+      managedBy:
+        type: string
+      pruneUnused:
+        type: boolean
       norestart:
         type: boolean
       private:
         type: boolean
-  EnvSetResponse:
-    description: Environment variables response information.
-    type: array
-    items:
-      type: object
-      properties:
-        name:
-          type: string
-        value:
-          type: string
-        public:
-          type: boolean
   Unit:
     type: object
     properties:

--- a/types/api/env.go
+++ b/types/api/env.go
@@ -7,7 +7,17 @@ package api
 // Envs represents the configuration of an environment variable data
 // for the remote API
 type Envs struct {
-	Envs      []struct{ Name, Value, Alias string }
-	NoRestart bool
-	Private   bool
+	Envs        []Env
+	ManagedBy   string `json:"managedBy"`
+	NoRestart   bool
+	Private     bool
+	PruneUnused bool `json:"pruneUnused"`
+}
+
+type Env struct {
+	Name      string
+	Value     string
+	Alias     string
+	Private   *bool  `json:"private,omitempty"`
+	ManagedBy string `json:"-" bson:"managedBy"`
 }


### PR DESCRIPTION
EnvVars API is not really terraform friendly, and we have to create a diff locally and remove / update with multiple requests.

This PR lets we push update all variables with a single requests, pruning unneeded variables if requested. The pruning only happens to variables managed by the same service ie. `terraform`, `tsuru-client`, and so on.

What is missing from this PR is a change to the database model, making all variables public, except those marked as `private`. 