### PR TITLE
feat(app/shell): fallback to dash when bash is not found

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2390,7 +2390,7 @@ func (app *App) Shell(opts provision.ExecOptions) error {
 		return provision.ProvisionerNotSupported{Prov: prov, Action: "running shell"}
 	}
 	opts.App = app
-	opts.Cmds = cmdsForExec("bash -l")
+	opts.Cmds = cmdsForExec("[ -x /bin/bash ] && /bin/bash -l || sh -l")
 	return execProv.ExecuteCommand(app.ctx, opts)
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4426,7 +4426,7 @@ func (s *S) TestShellToUnit(c *check.C) {
 	allExecs := s.provisioner.AllExecs()
 	c.Assert(allExecs, check.HasLen, 1)
 	c.Assert(allExecs[unit.GetID()], check.HasLen, 1)
-	c.Assert(allExecs[unit.GetID()][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", "[ -f /home/application/apprc ] && source /home/application/apprc; [ -d /home/application/current ] && cd /home/application/current; bash -l"})
+	c.Assert(allExecs[unit.GetID()][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", "[ -f /home/application/apprc ] && source /home/application/apprc; [ -d /home/application/current ] && cd /home/application/current; [ -x /bin/bash ] && /bin/bash -l || sh -l"})
 }
 
 func (s *S) TestShellNoUnits(c *check.C) {
@@ -4449,7 +4449,7 @@ func (s *S) TestShellNoUnits(c *check.C) {
 	allExecs := s.provisioner.AllExecs()
 	c.Assert(allExecs, check.HasLen, 1)
 	c.Assert(allExecs["isolated"], check.HasLen, 1)
-	c.Assert(allExecs["isolated"][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", "[ -f /home/application/apprc ] && source /home/application/apprc; [ -d /home/application/current ] && cd /home/application/current; bash -l"})
+	c.Assert(allExecs["isolated"][0].Cmds, check.DeepEquals, []string{"/bin/sh", "-c", "[ -f /home/application/apprc ] && source /home/application/apprc; [ -d /home/application/current ] && cd /home/application/current; [ -x /bin/bash ] && /bin/bash -l || sh -l"})
 }
 
 func (s *S) TestSetCertificateForApp(c *check.C) {


### PR DESCRIPTION
Today we cannot run app shell command against an app that doesn't have `bash`, such as Alpine-based platforms. This PR tries to find `bash` executable before executing it or calls `dash` otherwise.