### PR TITLE
Save and retrieve unit status from storage

### DIFF
--- a/api/app_test.go
+++ b/api/app_test.go
@@ -2616,7 +2616,7 @@ func (s *S) TestSetNodeStatus(c *check.C) {
 		Address: "addr1",
 	})
 	c.Assert(err, check.IsNil)
-	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1")
+	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1", nil)
 	c.Assert(err, check.IsNil)
 	status := []string{"started", "error", "stopped"}
 	unitsStatus := []provision.UnitStatusData{
@@ -2666,7 +2666,7 @@ func (s *S) TestSetNodeStatusNotFound(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = s.provisioner.AddUnits(context.TODO(), &a, 3, "web", nil, nil)
 	c.Assert(err, check.IsNil)
-	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1")
+	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1", nil)
 	c.Assert(err, check.IsNil)
 	unitsStatus := []provision.UnitStatusData{
 		{ID: units[0].ID, Status: "started"},

--- a/api/node_test.go
+++ b/api/node_test.go
@@ -1045,7 +1045,7 @@ func (s *S) TestNodeRebalanceEmptyBodyHandler(c *check.C) {
 	a := app.App{Name: "myapp", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
-	_, err = s.provisioner.AddUnitsToNode(&a, 4, "web", nil, "n1")
+	_, err = s.provisioner.AddUnitsToNode(&a, 4, "web", nil, "n1", nil)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest("POST", "/node/rebalance", nil)
@@ -1086,7 +1086,7 @@ func (s *S) TestNodeRebalanceFilters(c *check.C) {
 	a := app.App{Name: "myapp", Platform: "zend", TeamOwner: s.team.Name}
 	err = app.CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
-	_, err = s.provisioner.AddUnitsToNode(&a, 4, "web", nil, "n1")
+	_, err = s.provisioner.AddUnitsToNode(&a, 4, "web", nil, "n1", nil)
 	c.Assert(err, check.IsNil)
 	opts := provision.RebalanceNodesOptions{
 		MetadataFilter: map[string]string{"pool": "pool1"},

--- a/app/app.go
+++ b/app/app.go
@@ -1392,6 +1392,7 @@ func (app *App) Restart(ctx context.Context, process, versionStr string, w io.Wr
 	return nil
 }
 
+// vpPair represents each version-process pair
 type vpPair struct {
 	version int
 	process string
@@ -1450,9 +1451,6 @@ func (app *App) updatePastUnits(ctx context.Context, version appTypes.AppVersion
 
 	vpMap := generateVersionProcessPastUnitsMap(version, units, process)
 
-	// 1- get each version by version number
-	// 2- add field {Process: "xpto", Replicas: 12345}
-	// 3- call UpdateVersionPastUnits -> updates it in storage
 	for vp, replicas := range vpMap {
 		versionStr := strconv.Itoa(vp.version)
 		v, err := app.getVersion(ctx, versionStr)

--- a/app/app.go
+++ b/app/app.go
@@ -1400,7 +1400,7 @@ type vpPair struct {
 
 func cleanupOtherProcesses(vpMap map[vpPair]int, process string) {
 	for pair := range vpMap {
-		if strings.Compare(pair.process, process) != 0 {
+		if pair.process != process {
 			delete(vpMap, pair)
 		}
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2561,9 +2561,12 @@ func (s *S) TestStopPastUnits(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = a.Stop(context.TODO(), &buf, "", "")
 	c.Assert(err, check.IsNil)
-	pastUnits := version.VersionInfo().PastUnits
+	var updatedVersion appTypes.AppVersion
+	updatedVersion, err = a.getVersion(context.TODO(), strconv.Itoa(version.Version()))
+	c.Assert(err, check.IsNil)
+	pastUnits := updatedVersion.VersionInfo().PastUnits
 	c.Assert(pastUnits, check.HasLen, 1)
-	c.Assert(pastUnits, check.DeepEquals, map[string]int{"web": 1})
+	c.Assert(pastUnits, check.DeepEquals, map[string]int{"web": 2})
 }
 
 func (s *S) TestSleep(c *check.C) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1123,7 +1123,7 @@ func (s *S) TestUpdateNodeStatus(c *check.C) {
 		Address: "addr1",
 	})
 	c.Assert(err, check.IsNil)
-	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1")
+	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1", nil)
 	c.Assert(err, check.IsNil)
 	unitStates := []provision.UnitStatusData{
 		{ID: units[0].ID, Status: provision.Status("started")},
@@ -1229,7 +1229,7 @@ func (s *S) TestUpdateNodeStatusNotFound(c *check.C) {
 	a := App{Name: "lapname", Platform: "python", TeamOwner: s.team.Name}
 	err := CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
-	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1")
+	units, err := s.provisioner.AddUnitsToNode(&a, 3, "web", nil, "addr1", nil)
 	c.Assert(err, check.IsNil)
 	unitStates := []provision.UnitStatusData{
 		{ID: units[0].ID, Status: provision.Status("started")},
@@ -2537,15 +2537,33 @@ func (s *S) TestStop(c *check.C) {
 	c.Assert(err, check.IsNil)
 	var buf bytes.Buffer
 	newSuccessfulAppVersion(c, &a)
+	err = a.AddUnits(2, "web", "", nil)
+	c.Assert(err, check.IsNil)
 	err = a.Stop(context.TODO(), &buf, "", "")
 	c.Assert(err, check.IsNil)
 	err = s.conn.Apps().Find(bson.M{"name": a.GetName()}).One(&a)
 	c.Assert(err, check.IsNil)
 	units, err := a.Units()
 	c.Assert(err, check.IsNil)
+	c.Assert(units, check.HasLen, 2)
 	for _, u := range units {
 		c.Assert(u.Status, check.Equals, provision.StatusStopped)
 	}
+}
+
+func (s *S) TestStopPastUnits(c *check.C) {
+	a := App{Name: "app", TeamOwner: s.team.Name}
+	err := CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	var buf bytes.Buffer
+	version := newSuccessfulAppVersion(c, &a)
+	err = a.AddUnits(2, "web", strconv.Itoa(version.Version()), nil)
+	c.Assert(err, check.IsNil)
+	err = a.Stop(context.TODO(), &buf, "", "")
+	c.Assert(err, check.IsNil)
+	pastUnits := version.VersionInfo().PastUnits
+	c.Assert(pastUnits, check.HasLen, 1)
+	c.Assert(pastUnits, check.DeepEquals, map[string]int{"web": 1})
 }
 
 func (s *S) TestSleep(c *check.C) {
@@ -2732,7 +2750,7 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 	}
 	err = CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
-	_, err = s.provisioner.AddUnitsToNode(&app, 1, "web", nil, "addr1")
+	_, err = s.provisioner.AddUnitsToNode(&app, 1, "web", nil, "addr1", nil)
 	c.Assert(err, check.IsNil)
 
 	units, err := app.Units()

--- a/app/version/service_test.go
+++ b/app/version/service_test.go
@@ -116,8 +116,8 @@ func (s *S) TestAppVersionService_AppVersions(c *check.C) {
 	c.Assert(versions.AppName, check.DeepEquals, "myapp")
 	c.Assert(versions.Count, check.DeepEquals, 2)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -169,13 +169,13 @@ func (s *S) TestAppVersionService_AllAppVersions(c *check.C) {
 	c.Assert(allVersions[0].AppName, check.Equals, "myapp1")
 	c.Assert(allVersions[0].Count, check.Equals, 1)
 	c.Assert(allVersions[0].Versions[1], check.DeepEquals, appTypes.AppVersionInfo{
-		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{},
+		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
 	})
 
 	c.Assert(allVersions[1].AppName, check.Equals, "myapp2")
 	c.Assert(allVersions[1].Count, check.Equals, 1)
 	c.Assert(allVersions[1].Versions[1], check.DeepEquals, appTypes.AppVersionInfo{
-		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{},
+		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
 	})
 }
 
@@ -206,7 +206,7 @@ func (s *S) TestAppVersionService_DeleteVersionIDs(c *check.C) {
 	c.Assert(versions.Count, check.Equals, 2)
 	c.Assert(versions.LastSuccessfulVersion, check.Equals, 0)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -157,7 +157,8 @@ func (v *appVersionImpl) UpdatePastUnits(process string, replicas int) error {
 	if err != nil {
 		return err
 	}
-	v.versionInfo.PastUnits[process] = replicas
+
+	v.versionInfo.PastUnits = map[string]int{process: replicas}
 
 	return v.storage.UpdateVersion(v.ctx, v.app.GetName(), v.versionInfo)
 }

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -158,7 +158,11 @@ func (v *appVersionImpl) UpdatePastUnits(process string, replicas int) error {
 		return err
 	}
 
-	v.versionInfo.PastUnits = map[string]int{process: replicas}
+	if v.versionInfo.PastUnits == nil {
+		v.versionInfo.PastUnits = map[string]int{process: replicas}
+	} else {
+		v.versionInfo.PastUnits[process] = replicas
+	}
 
 	return v.storage.UpdateVersion(v.ctx, v.app.GetName(), v.versionInfo)
 }

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -152,6 +152,16 @@ func (v *appVersionImpl) AddData(args appTypes.AddVersionDataArgs) error {
 	return v.storage.UpdateVersion(v.ctx, v.app.GetName(), v.versionInfo)
 }
 
+func (v *appVersionImpl) UpdatePastUnits(process string, replicas int) error {
+	err := v.refresh()
+	if err != nil {
+		return err
+	}
+	v.versionInfo.PastUnits[process] = replicas
+
+	return v.storage.UpdateVersion(v.ctx, v.app.GetName(), v.versionInfo)
+}
+
 func (v *appVersionImpl) ToggleEnabled(enabled bool, reason string) error {
 	err := v.refresh()
 	if err != nil {

--- a/autoscale/autoscale_test.go
+++ b/autoscale/autoscale_test.go
@@ -118,7 +118,7 @@ func (s *S) TearDownTest(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunOnce(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -175,7 +175,7 @@ func (s *S) TestAutoScaleConfigRunOnce(c *check.C) {
 func (s *S) TestAutoScaleConfigRunOnceNoRebalance(c *check.C) {
 	config.Set("docker:auto-scale:prevent-rebalance", true)
 	defer config.Unset("docker:auto-scale:prevent-rebalance")
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -248,7 +248,7 @@ func (s *S) TestAutoScaleConfigRunOnceNoContainersMultipleNodes(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunOnceMultipleNodes(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -281,7 +281,7 @@ func (s *S) TestAutoScaleConfigRunOnceMultipleNodes(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunOnceMultipleNodesRoundUp(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 5, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 5, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -314,7 +314,7 @@ func (s *S) TestAutoScaleConfigRunOnceMultipleNodesRoundUp(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunOnceAddsAtLeastOne(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 3, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 3, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -345,7 +345,7 @@ func (s *S) TestAutoScaleConfigRunOnceAddsAtLeastOne(c *check.C) {
 
 func (s *S) TestAutoScaleConfigRunOnceMultipleNodesPartialError(c *check.C) {
 	s.p.PrepareFailure("AddNode:http://n3:3", errors.New("error adding node"))
-	_, err := s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -389,7 +389,7 @@ func (s *S) TestAutoScaleConfigRunOnceMultipleNodesAddNodesErrorRunRebalance(c *
 	})
 	c.Assert(err, check.IsNil)
 	s.p.PrepareFailure("AddNode:http://n3:3", errors.New("my error adding node"))
-	_, err = s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 6, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -426,7 +426,7 @@ func (s *S) TestAutoScaleConfigRunOnceMultipleNodesAddNodesErrorRunRebalance(c *
 
 func (s *S) TestAutoScaleConfigRunOnceSingleNodeAddNodesErrorNoRebalance(c *check.C) {
 	s.p.PrepareFailure("AddNode:http://n2:2", errors.New("my error adding node"))
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -467,7 +467,7 @@ func (s *S) TestAutoScaleConfigRunRebalanceOnly(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()
@@ -508,7 +508,7 @@ func (s *S) TestAutoScaleConfigRunNoMatch(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -553,7 +553,7 @@ func (s *S) TestAutoScaleConfigRunNoMatch(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunStress(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	wg := sync.WaitGroup{}
 	for i := 0; i < 50; i++ {
@@ -595,7 +595,7 @@ func (s *S) TestAutoScaleConfigRunMemoryBased(c *check.C) {
 	config.Unset("docker:auto-scale:max-container-count")
 	config.Set("docker:scheduler:max-used-memory", 0.8)
 	config.Set("docker:scheduler:total-memory-metadata", "totalMem")
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -641,7 +641,7 @@ func (s *S) TestAutoScaleConfigRunMemoryBasedMultipleNodes(c *check.C) {
 	config.Unset("docker:auto-scale:max-container-count")
 	config.Set("docker:scheduler:max-used-memory", 0.8)
 	config.Set("docker:scheduler:total-memory-metadata", "totalMem")
-	_, err := s.p.AddUnitsToNode(s.appInstance, 9, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 9, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -707,7 +707,7 @@ func (s *S) TestAutoScaleConfigRunOnceMemoryBasedNoContainersMultipleNodes(c *ch
 func (s *S) TestAutoScaleConfigRunPriorityToCountBased(c *check.C) {
 	config.Set("docker:scheduler:max-used-memory", 0.8)
 	config.Set("docker:scheduler:total-memory-metadata", "totalMem")
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -743,7 +743,7 @@ func (s *S) TestAutoScaleConfigRunMemoryBasedPlanTooBig(c *check.C) {
 	s.mockService.Plan.OnList = func() ([]appTypes.Plan, error) {
 		return []appTypes.Plan{plan}, nil
 	}
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -769,9 +769,9 @@ func (s *S) TestAutoScaleConfigRunScaleDown(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -813,11 +813,11 @@ func (s *S) TestAutoScaleConfigRunScaleDownMultipleNodes(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n3:3")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n3:3", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -852,9 +852,9 @@ func (s *S) TestAutoScaleConfigRunScaleDownMemoryScaler(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -898,11 +898,11 @@ func (s *S) TestAutoScaleConfigRunScaleDownMemoryScalerMultipleNodes(c *check.C)
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n3:3")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n3:3", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -946,9 +946,9 @@ func (s *S) TestAutoScaleConfigRunScaleDownRespectsMinNodes(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 1, "web", nil, "n2:2", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	a.runOnce()
@@ -961,7 +961,7 @@ func (s *S) TestAutoScaleConfigRunScaleDownRespectsMinNodes(c *check.C) {
 }
 
 func (s *S) TestAutoScaleConfigRunLockedApp(c *check.C) {
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	_, err = event.NewInternal(&event.Opts{
 		Target:       event.Target{Type: event.TargetTypeApp, Value: s.appInstance.GetName()},
@@ -985,7 +985,7 @@ func (s *S) TestAutoScaleConfigRunMemoryBasedLockedApp(c *check.C) {
 	config.Unset("docker:auto-scale:max-container-count")
 	config.Set("docker:scheduler:max-used-memory", 0.8)
 	config.Set("docker:scheduler:total-memory-metadata", "totalMem")
-	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err := s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
 	_, err = event.NewInternal(&event.Opts{
 		Target:       event.Target{Type: event.TargetTypeApp, Value: s.appInstance.GetName()},
@@ -1047,9 +1047,9 @@ func (s *S) TestAutoScaleConfigRunOnceRulesPerPool(c *check.C) {
 	}
 	err = s.conn.Apps().Insert(appStruct)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1")
+	_, err = s.p.AddUnitsToNode(s.appInstance, 4, "web", nil, "n1:1", nil)
 	c.Assert(err, check.IsNil)
-	_, err = s.p.AddUnitsToNode(appInstance2, 6, "web", nil, "nx:9")
+	_, err = s.p.AddUnitsToNode(appInstance2, 6, "web", nil, "nx:9", nil)
 	c.Assert(err, check.IsNil)
 	a := newConfig()
 	err = a.runOnce()

--- a/provision/kubernetes/deploy_simple_test.go
+++ b/provision/kubernetes/deploy_simple_test.go
@@ -162,7 +162,7 @@ func (s *S) TestServiceManagerDeployMulti(c *check.C) {
 				{
 					startStep: &startStep{version: 5, proc: "p2"},
 					check: func() {
-						s.hasDepWithVersion(c, "myapp0-p2", 5, 1)
+						s.hasDepWithVersion(c, "myapp0-p2", 5, 3)
 						s.hasSvc(c, "myapp0-p2")
 					},
 				},
@@ -295,21 +295,18 @@ func (s *S) TestServiceManagerDeployMulti(c *check.C) {
 					check: func() {
 						s.hasDepWithVersion(c, "myapp3-p2", 1, 0)
 						s.hasDepWithVersion(c, "myapp3-p1", 1, 0)
-						s.noSvc(c, "myapp3-p2-v1")
 					},
 				},
 				{
 					startStep: &startStep{proc: "p1", version: 1},
 					check: func() {
 						s.hasDepWithVersion(c, "myapp3-p1", 1, 3)
-						s.hasSvc(c, "myapp3-p1-v1")
 					},
 				},
 				{
 					startStep: &startStep{proc: "p2", version: 1},
 					check: func() {
 						s.hasDepWithVersion(c, "myapp3-p2", 1, 4)
-						s.hasSvc(c, "myapp3-p2-v1")
 					},
 				},
 			},
@@ -350,6 +347,7 @@ func (s *S) TestServiceManagerDeployMulti(c *check.C) {
 					}, procSpec)
 					c.Assert(err, check.IsNil)
 					waitDep()
+					a.Deploys++
 					if step.deployStep.routable {
 						err = a.SetRoutable(context.TODO(), version, true)
 						c.Assert(err, check.IsNil)
@@ -359,8 +357,7 @@ func (s *S) TestServiceManagerDeployMulti(c *check.C) {
 					var version appTypes.AppVersion
 					version, err = servicemanager.AppVersion.VersionByImageOrVersion(context.TODO(), a, strconv.Itoa(step.unitStep.version))
 					c.Assert(err, check.IsNil)
-					err = servicecommon.ChangeAppState(context.TODO(), &m, a, step.unitStep.proc, servicecommon.ProcessState{Increment: step.units, Start: true}, version)
-
+					err = servicecommon.ChangeUnits(context.TODO(), &m, a, step.unitStep.units, step.unitStep.proc, version)
 					c.Assert(err, check.IsNil)
 					waitDep()
 				}
@@ -431,16 +428,17 @@ func (s *S) noDep(c *check.C, name string) {
 }
 
 func (s *S) updatePastUnits(c *check.C, appName string, v appTypes.AppVersion, p string) {
-	nameLabel := "tsuru.io/app-name=" + appName
-	versionLabel := "tsuru.io/app-version=" + strconv.Itoa(v.Version())
+	nameLabel := "app=" + appName + "-" + p
 	deps, err := s.client.Clientset.AppsV1().Deployments("default").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: versionLabel + "," + nameLabel,
+		LabelSelector: nameLabel,
 	})
 	c.Assert(err, check.IsNil)
 	for _, dep := range deps.Items {
-		if dep.Spec.Replicas != nil {
-			err = v.UpdatePastUnits(p, int(*dep.Spec.Replicas))
-			c.Assert(err, check.IsNil)
+		if version, ok := dep.Spec.Template.Labels["tsuru.io/app-version"]; ok {
+			if dep.Spec.Replicas != nil && strconv.Itoa(v.Version()) == version {
+				err = v.UpdatePastUnits(p, int(*dep.Spec.Replicas))
+				c.Assert(err, check.IsNil)
+			}
 		}
 	}
 }

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1008,11 +1008,11 @@ func (p *FakeProvisioner) DestroyVersion(ctx context.Context, app provision.App,
 }
 
 func (p *FakeProvisioner) AddUnits(ctx context.Context, app provision.App, n uint, process string, version appTypes.AppVersion, w io.Writer) error {
-	_, err := p.AddUnitsToNode(app, n, process, w, "")
+	_, err := p.AddUnitsToNode(app, n, process, w, "", version)
 	return err
 }
 
-func (p *FakeProvisioner) AddUnitsToNode(app provision.App, n uint, process string, w io.Writer, nodeAddr string) ([]provision.Unit, error) {
+func (p *FakeProvisioner) AddUnitsToNode(app provision.App, n uint, process string, w io.Writer, nodeAddr string, version appTypes.AppVersion) ([]provision.Unit, error) {
 	if err := p.getError("AddUnits"); err != nil {
 		return nil, err
 	}
@@ -1029,6 +1029,11 @@ func (p *FakeProvisioner) AddUnitsToNode(app provision.App, n uint, process stri
 	platform := app.GetPlatform()
 	length := uint(len(pApp.units))
 	var addresses []*url.URL
+
+	var versionNum int
+	if version != nil {
+		versionNum = version.Version()
+	}
 	for i := uint(0); i < n; i++ {
 		val := atomic.AddInt32(&uniqueIpCounter, 1)
 		var hostAddr string
@@ -1053,6 +1058,7 @@ func (p *FakeProvisioner) AddUnitsToNode(app provision.App, n uint, process stri
 				Scheme: "http",
 				Host:   fmt.Sprintf("%s:%d", hostAddr, val),
 			},
+			Version: versionNum,
 		}
 		addresses = append(addresses, unit.Address)
 		pApp.units = append(pApp.units, unit)

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -600,7 +600,7 @@ func (s *S) TestAddUnitsToNode(c *check.C) {
 		Address: "http://n1:123",
 	})
 	c.Assert(err, check.IsNil)
-	_, err = p.AddUnitsToNode(app, 2, "web", nil, "nother")
+	_, err = p.AddUnitsToNode(app, 2, "web", nil, "nother", nil)
 	c.Assert(err, check.IsNil)
 	allUnits := p.GetUnits(app)
 	c.Assert(allUnits, check.HasLen, 2)
@@ -1096,7 +1096,7 @@ func (s *S) TestFakeProvisionerRebalanceNodes(c *check.C) {
 	p.Provision(context.TODO(), app)
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode1", Pool: "mypool"})
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode2", Pool: "mypool"})
-	p.AddUnitsToNode(app, 4, "web", nil, "mynode1")
+	p.AddUnitsToNode(app, 4, "web", nil, "mynode1", nil)
 	w := bytes.Buffer{}
 	evt, err := event.New(&event.Opts{
 		Target:   event.Target{Type: "global"},
@@ -1135,8 +1135,8 @@ func (s *S) TestFakeProvisionerRebalanceNodesMultiplePools(c *check.C) {
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode1", Pool: "mypool"})
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode2", Pool: "mypool"})
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode3", Pool: "mypool2"})
-	p.AddUnitsToNode(app1, 4, "web", nil, "mynode1")
-	p.AddUnitsToNode(app2, 4, "web", nil, "mynode3")
+	p.AddUnitsToNode(app1, 4, "web", nil, "mynode1", nil)
+	p.AddUnitsToNode(app2, 4, "web", nil, "mynode3", nil)
 	w := bytes.Buffer{}
 	evt, err := event.New(&event.Opts{
 		Target:   event.Target{Type: "global"},
@@ -1174,8 +1174,8 @@ func (s *S) TestFakeProvisionerRebalanceNodesBalanced(c *check.C) {
 	p.AddNode(context.TODO(), provision.AddNodeOptions{Address: "mynode2", Metadata: map[string]string{
 		"pool": "mypool",
 	}})
-	p.AddUnitsToNode(app, 2, "web", nil, "mynode1")
-	p.AddUnitsToNode(app, 2, "web", nil, "mynode2")
+	p.AddUnitsToNode(app, 2, "web", nil, "mynode1", nil)
+	p.AddUnitsToNode(app, 2, "web", nil, "mynode2", nil)
 	w := bytes.Buffer{}
 	evt, err := event.New(&event.Opts{
 		Target:   event.Target{Type: "global"},

--- a/provision/servicecommon/state.go
+++ b/provision/servicecommon/state.go
@@ -31,6 +31,9 @@ func ChangeAppState(ctx context.Context, manager ServiceManager, a provision.App
 	}
 	spec := ProcessSpec{}
 	for _, procName := range processes {
+		if replicas, ok := version.VersionInfo().PastUnits[procName]; ok && (state.Start && !state.Restart) {
+			state.Increment = replicas
+		}
 		spec[procName] = state
 	}
 	err = RunServicePipeline(ctx, manager, version.Version(), provision.DeployArgs{App: a, Version: version, PreserveVersions: true}, spec)

--- a/provision/servicecommon/state.go
+++ b/provision/servicecommon/state.go
@@ -12,6 +12,12 @@ import (
 	appTypes "github.com/tsuru/tsuru/types/app"
 )
 
+func patchWithPastUnits(process string, pastUnitsMap map[string]int, state *ProcessState) {
+	if replicas, ok := pastUnitsMap[process]; ok && (state.Start && !state.Restart) {
+		state.Increment = replicas
+	}
+}
+
 func ChangeAppState(ctx context.Context, manager ServiceManager, a provision.App, process string, state ProcessState, version appTypes.AppVersion) error {
 	var (
 		processes []string
@@ -31,9 +37,7 @@ func ChangeAppState(ctx context.Context, manager ServiceManager, a provision.App
 	}
 	spec := ProcessSpec{}
 	for _, procName := range processes {
-		if replicas, ok := version.VersionInfo().PastUnits[procName]; ok && (state.Start && !state.Restart) {
-			state.Increment = replicas
-		}
+		patchWithPastUnits(procName, version.VersionInfo().PastUnits, &state)
 		spec[procName] = state
 	}
 	err = RunServicePipeline(ctx, manager, version.Version(), provision.DeployArgs{App: a, Version: version, PreserveVersions: true}, spec)

--- a/storage/mongodb/app_version_test.go
+++ b/storage/mongodb/app_version_test.go
@@ -129,6 +129,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			8: {
 				Version:          8,
@@ -145,6 +146,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			9: {
 				Version:          9,
@@ -161,6 +163,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			10: {
 				Version:          10,
@@ -177,6 +180,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			11: {
 				Version:          11,
@@ -193,6 +197,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			12: {
 				Version:          12,
@@ -204,6 +209,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp2.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			13: {
 				Version:          13,
@@ -215,6 +221,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp2.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			15: {
 				Version:          15,
@@ -226,6 +233,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp2.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			16: {
 				Version:          16,
@@ -237,6 +245,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp2.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			17: {
 				Version:          17,
@@ -248,6 +257,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				Processes: map[string][]string{
 					"web": {"python myapp2.py"},
 				},
+				PastUnits: map[string]int{},
 			},
 			19: {
 				Version:          19,
@@ -258,6 +268,7 @@ func (s *appVersionSuite) TestLegacyImport(c *check.C) {
 				ExposedPorts:     []string{},
 				CustomBuildTag:   "mycustomtag",
 				DeploySuccessful: false,
+				PastUnits:        map[string]int{},
 			},
 		},
 	}
@@ -335,6 +346,7 @@ func (s *appVersionSuite) TestLegacyImportWithSuccessfulLastCount(c *check.C) {
 				},
 				CustomData:   map[string]interface{}{},
 				ExposedPorts: []string{},
+				PastUnits:    map[string]int{},
 			},
 			2: {
 				Version:          2,
@@ -346,6 +358,7 @@ func (s *appVersionSuite) TestLegacyImportWithSuccessfulLastCount(c *check.C) {
 				},
 				CustomData:   map[string]interface{}{},
 				ExposedPorts: []string{},
+				PastUnits:    map[string]int{},
 			},
 			3: {
 				Version:        3,
@@ -354,6 +367,7 @@ func (s *appVersionSuite) TestLegacyImportWithSuccessfulLastCount(c *check.C) {
 				CustomData:     map[string]interface{}{},
 				Processes:      map[string][]string{},
 				ExposedPorts:   []string{},
+				PastUnits:      map[string]int{},
 			},
 			4: {
 				Version:        4,
@@ -362,6 +376,7 @@ func (s *appVersionSuite) TestLegacyImportWithSuccessfulLastCount(c *check.C) {
 				CustomData:     map[string]interface{}{},
 				Processes:      map[string][]string{},
 				ExposedPorts:   []string{},
+				PastUnits:      map[string]int{},
 			},
 		},
 	}

--- a/storage/storagetest/app_version_suite.go
+++ b/storage/storagetest/app_version_suite.go
@@ -116,8 +116,8 @@ func (s *AppVersionSuite) TestAppVersionStorage_AppVersions(c *check.C) {
 	c.Assert(versions.AppName, check.Equals, "myapp")
 	c.Assert(versions.Count, check.Equals, 2)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -165,14 +165,14 @@ func (s *AppVersionSuite) TestAppVersionStorage_AllAppVersions(c *check.C) {
 	c.Assert(allVersions[0].Count, check.Equals, 1)
 	c.Assert(allVersions[0].UpdatedAt.Unix() <= time.Now().UTC().Unix(), check.Equals, true)
 	c.Assert(allVersions[0].Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 
 	c.Assert(allVersions[1].AppName, check.Equals, "myapp2")
 	c.Assert(allVersions[1].Count, check.Equals, 1)
 	c.Assert(allVersions[1].UpdatedAt.Unix() <= time.Now().UTC().Unix(), check.Equals, true)
 	c.Assert(allVersions[1].Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -206,7 +206,7 @@ func (s *AppVersionSuite) TestAppVersionStorage_DeleteVersionIDs(c *check.C) {
 	c.Assert(versions.LastSuccessfulVersion, check.DeepEquals, 0)
 	c.Assert(versions.UpdatedAt.IsZero(), check.Equals, false)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}},
+		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 

--- a/types/app/version.go
+++ b/types/app/version.go
@@ -50,6 +50,7 @@ type AppVersion interface {
 	AddData(AddVersionDataArgs) error
 	String() string
 	ToggleEnabled(enabled bool, reason string) error
+	UpdatePastUnits(process string, replicas int) error
 }
 
 type AddVersionDataArgs struct {
@@ -84,6 +85,7 @@ type AppVersionInfo struct {
 	Disabled         bool                   `json:"disabled"`
 	DeploySuccessful bool                   `json:"deploySuccessful"`
 	MarkedToRemoval  bool                   `json:"markedToRemoval"`
+	PastUnits        map[string]int         `json:"pastUnits"`
 }
 
 type NewVersionArgs struct {


### PR DESCRIPTION
This PR reintroduces a feature removed in [#2539](https://github.com/tsuru/tsuru/pull/2539), tsuru-api persists the last state of the process-version pair inside its storage provider and tries to restore it when attempting to start a previously stopped deployment.

TLDR: if `tsuru app stop -a <appname> --process <processname> --version <versionnumber>` had 3 units running, a `tsuru app start -a <appname> --process <processname> --version <versionnumber>` will restore it with 3 units