### PR TITLE
refactor(app/env): move app env var domain for service pattern

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -1177,10 +1177,9 @@ func unsetEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) 
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	evt.SetLogWriter(writer)
 	noRestart, _ := strconv.ParseBool(InputValue(r, "noRestart"))
-	return a.UnsetEnvs(bind.UnsetEnvArgs{
-		VariableNames: variables,
-		ShouldRestart: !noRestart,
+	return servicemanager.AppEnvVar.Unset(r.Context(), &a, variables, appTypes.UnsetEnvArgs{
 		Writer:        evt,
+		ShouldRestart: !noRestart,
 	})
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -1080,7 +1080,7 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	}
 	defer func() { evt.Done(err) }()
 	envs := map[string]string{}
-	variables := []bind.EnvVar{}
+	variables := []appTypes.EnvVar{}
 	for _, v := range e.Envs {
 		envs[v.Name] = v.Value
 		private := false
@@ -1091,7 +1091,7 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		if e.Private {
 			private = true
 		}
-		variables = append(variables, bind.EnvVar{
+		variables = append(variables, appTypes.EnvVar{
 			Name:      v.Name,
 			Value:     v.Value,
 			Public:    !private,
@@ -1104,8 +1104,7 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	defer keepAliveWriter.Stop()
 	writer := &tsuruIo.SimpleJsonMessageEncoderWriter{Encoder: json.NewEncoder(keepAliveWriter)}
 	evt.SetLogWriter(writer)
-	err = a.SetEnvs(bind.SetEnvArgs{
-		Envs:          variables,
+	servicemanager.AppEnvVar.Set(r.Context(), &a, variables, appTypes.SetEnvArgs{
 		ManagedBy:     e.ManagedBy,
 		PruneUnused:   e.PruneUnused,
 		ShouldRestart: !e.NoRestart,
@@ -1116,6 +1115,7 @@ func setEnv(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	}
 	return err
 }
+
 func isInternalEnv(envKey string) bool {
 	for _, internalEnv := range internalEnvs() {
 		if internalEnv == envKey {
@@ -1124,6 +1124,7 @@ func isInternalEnv(envKey string) bool {
 	}
 	return false
 }
+
 func internalEnvs() []string {
 	return []string{"TSURU_APPNAME", "TSURU_APP_TOKEN", "TSURU_SERVICE", "TSURU_APPDIR"}
 }

--- a/api/server.go
+++ b/api/server.go
@@ -108,6 +108,10 @@ func setupServices() error {
 	if err != nil {
 		return err
 	}
+	servicemanager.AppEnvVar, err = app.AppEnvVarService()
+	if err != nil {
+		return err
+	}
 	servicemanager.TeamToken, err = auth.TeamTokenService()
 	if err != nil {
 		return err

--- a/app/actions.go
+++ b/app/actions.go
@@ -188,15 +188,11 @@ var exportEnvironmentsAction = action.Action{
 			return nil, err
 		}
 		t := ctx.Previous.(*auth.Token)
-		envVars := []bind.EnvVar{
+		err = servicemanager.AppEnvVar.Set(ctx.Context, app, []appTypes.EnvVar{
 			{Name: "TSURU_APPNAME", Value: app.Name},
 			{Name: "TSURU_APPDIR", Value: defaultAppDir},
 			{Name: "TSURU_APP_TOKEN", Value: (*t).GetValue()},
-		}
-		err = app.SetEnvs(bind.SetEnvArgs{
-			Envs:          envVars,
-			ShouldRestart: false,
-		})
+		}, appTypes.SetEnvArgs{ShouldRestart: false})
 		if err != nil {
 			return nil, err
 		}

--- a/app/actions.go
+++ b/app/actions.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/action"
-	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
@@ -201,13 +200,12 @@ var exportEnvironmentsAction = action.Action{
 	Backward: func(ctx action.BWContext) {
 		app := ctx.Params[0].(*App)
 		app, err := GetByName(ctx.Context, app.Name)
-		if err == nil {
-			vars := []string{"TSURU_APPNAME", "TSURU_APPDIR", "TSURU_APP_TOKEN"}
-			app.UnsetEnvs(bind.UnsetEnvArgs{
-				VariableNames: vars,
-				ShouldRestart: true,
-			})
+		if err != nil {
+			return
 		}
+		servicemanager.AppEnvVar.Unset(ctx.Context, app, []string{"TSURU_APPNAME", "TSURU_APPDIR", "TSURU_APP_TOKEN"}, appTypes.UnsetEnvArgs{
+			ShouldRestart: true,
+		})
 	},
 	MinParams: 1,
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1761,33 +1761,6 @@ func (app *App) Envs() map[string]bind.EnvVar {
 	return mergedEnvs
 }
 
-// UnsetEnvs removes environment variables from an app, serializing the
-// remaining list of environment variables to all units of the app.
-func (app *App) UnsetEnvs(unsetEnvs bind.UnsetEnvArgs) error {
-	if len(unsetEnvs.VariableNames) == 0 {
-		return nil
-	}
-	if unsetEnvs.Writer != nil {
-		fmt.Fprintf(unsetEnvs.Writer, "---- Unsetting %d environment variables ----\n", len(unsetEnvs.VariableNames))
-	}
-	for _, name := range unsetEnvs.VariableNames {
-		delete(app.Env, name)
-	}
-	conn, err := db.Conn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	err = conn.Apps().Update(bson.M{"name": app.Name}, bson.M{"$set": bson.M{"env": app.Env}})
-	if err != nil {
-		return err
-	}
-	if unsetEnvs.ShouldRestart {
-		return app.restartIfUnits(unsetEnvs.Writer)
-	}
-	return nil
-}
-
 func (app *App) restartIfUnits(w io.Writer) error {
 	units, err := app.GetUnits()
 	if err != nil {

--- a/app/app_env.go
+++ b/app/app_env.go
@@ -31,7 +31,7 @@ type appEnvVarService struct {
 }
 
 func (s *appEnvVarService) List(ctx context.Context, appName string) ([]apptypes.EnvVar, error) {
-	envs, err := s.storage.List(ctx, appName)
+	envs, err := s.storage.ListAppEnvs(ctx, appName)
 	if err != nil {
 		return nil, err
 	}

--- a/app/app_env.go
+++ b/app/app_env.go
@@ -1,0 +1,96 @@
+// Copyright 2022 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/tsuru/tsuru/storage"
+	apptypes "github.com/tsuru/tsuru/types/app"
+)
+
+var _ apptypes.AppEnvVarService = &appEnvVarService{}
+
+func AppEnvVarService() (apptypes.AppEnvVarService, error) {
+	dbDriver, err := storage.GetCurrentDbDriver()
+	if err != nil {
+		dbDriver, err = storage.GetDefaultDbDriver()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &appEnvVarService{storage: dbDriver.AppEnvVarStorage}, nil
+}
+
+type appEnvVarService struct {
+	storage apptypes.AppEnvVarStorage
+}
+
+func (s *appEnvVarService) List(ctx context.Context, appName string) ([]apptypes.EnvVar, error) {
+	envs, err := s.storage.List(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+
+	svcEnvs, err := s.storage.ListServiceEnvs(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+
+	svcEnvVars := fromServiceEnvsToAppEnvVars(svcEnvs)
+
+	finalEnvs := make([]apptypes.EnvVar, 0, len(envs)+len(svcEnvVars))
+	finalEnvs = append(finalEnvs, envs...)
+	finalEnvs = append(finalEnvs, svcEnvVars...)
+
+	return finalEnvs, nil
+}
+
+func fromServiceEnvsToAppEnvVars(vars []apptypes.ServiceEnvVar) []apptypes.EnvVar {
+	envs := make([]apptypes.EnvVar, 0, len(vars)+1)
+	for _, ev := range vars {
+		envs = append(envs, ev.EnvVar)
+	}
+	envs = append(envs, buildTsuruServiceEnvVar(vars))
+	return envs
+}
+
+func buildTsuruServiceEnvVar(vars []apptypes.ServiceEnvVar) apptypes.EnvVar {
+	type serviceInstanceEnvs struct {
+		InstanceName string            `json:"instance_name"`
+		Envs         map[string]string `json:"envs"`
+	}
+
+	result := map[string][]serviceInstanceEnvs{} // env vars from instance by service name
+
+	for _, v := range vars {
+		found := false
+
+		for i, instanceList := range result[v.ServiceName] {
+			if instanceList.InstanceName == v.InstanceName {
+				result[v.ServiceName][i].Envs[v.Name] = v.Value
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			result[v.ServiceName] = append(result[v.ServiceName], serviceInstanceEnvs{
+				InstanceName: v.InstanceName,
+				Envs:         map[string]string{v.Name: v.Value},
+			})
+		}
+	}
+
+	jsonVal, _ := json.Marshal(result)
+
+	return apptypes.EnvVar{
+		Name:   apptypes.TsuruServicesEnvVarName,
+		Value:  string(jsonVal),
+		Public: false,
+	}
+}

--- a/servicemanager/servicemanager.go
+++ b/servicemanager/servicemanager.go
@@ -21,6 +21,7 @@ import (
 var (
 	App                       app.AppService
 	AppCache                  cache.AppCacheService
+	AppEnvVar                 app.AppEnvVarService
 	Plan                      app.PlanService
 	Platform                  app.PlatformService
 	PlatformImage             image.PlatformImageService

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -27,6 +27,7 @@ type DbDriver struct {
 	PlatformStorage                  app.PlatformStorage
 	PlanStorage                      app.PlanStorage
 	AppCacheStorage                  cache.CacheStorage
+	AppEnvVarStorage                 app.AppEnvVarStorage
 	TeamTokenStorage                 auth.TeamTokenStorage
 	UserQuotaStorage                 quota.QuotaStorage
 	AppQuotaStorage                  quota.QuotaStorage

--- a/storage/mongodb/app_env.go
+++ b/storage/mongodb/app_env.go
@@ -17,26 +17,22 @@ var _ apptypes.AppEnvVarStorage = &appEnvVarStorage{}
 
 type appEnvVarStorage struct{}
 
-func (s *appEnvVarStorage) List(ctx context.Context, appName string) ([]apptypes.EnvVar, error) {
+func (s *appEnvVarStorage) ListAppEnvs(ctx context.Context, appName string) ([]apptypes.EnvVar, error) {
 	conn, err := db.Conn()
 	if err != nil {
 		return nil, err
 	}
-
+	defer conn.Close()
 	var app struct{ Env map[string]apptypes.EnvVar }
-
 	err = conn.Apps().Find(bson.M{"name": appName}).One(&app)
 	if err != nil {
 		return nil, err
 	}
-
 	envs := make([]apptypes.EnvVar, 0, len(app.Env))
 	for _, ev := range app.Env {
 		envs = append(envs, ev)
 	}
-
 	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
-
 	return envs, nil
 }
 
@@ -45,15 +41,12 @@ func (s *appEnvVarStorage) ListServiceEnvs(ctx context.Context, appName string) 
 	if err != nil {
 		return nil, err
 	}
-
+	defer conn.Close()
 	var app struct{ ServiceEnvs []apptypes.ServiceEnvVar }
-
 	err = conn.Apps().Find(bson.M{"name": appName}).One(&app)
 	if err != nil {
 		return nil, err
 	}
-
 	sort.Slice(app.ServiceEnvs, func(i, j int) bool { return app.ServiceEnvs[i].Name < app.ServiceEnvs[j].Name })
-
 	return app.ServiceEnvs, nil
 }

--- a/storage/mongodb/app_env.go
+++ b/storage/mongodb/app_env.go
@@ -1,0 +1,59 @@
+// Copyright 2022 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"context"
+	"sort"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/tsuru/tsuru/db"
+	apptypes "github.com/tsuru/tsuru/types/app"
+)
+
+var _ apptypes.AppEnvVarStorage = &appEnvVarStorage{}
+
+type appEnvVarStorage struct{}
+
+func (s *appEnvVarStorage) List(ctx context.Context, appName string) ([]apptypes.EnvVar, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+
+	var app struct{ Env map[string]apptypes.EnvVar }
+
+	err = conn.Apps().Find(bson.M{"name": appName}).One(&app)
+	if err != nil {
+		return nil, err
+	}
+
+	envs := make([]apptypes.EnvVar, 0, len(app.Env))
+	for _, ev := range app.Env {
+		envs = append(envs, ev)
+	}
+
+	sort.Slice(envs, func(i, j int) bool { return envs[i].Name < envs[j].Name })
+
+	return envs, nil
+}
+
+func (s *appEnvVarStorage) ListServiceEnvs(ctx context.Context, appName string) ([]apptypes.ServiceEnvVar, error) {
+	conn, err := db.Conn()
+	if err != nil {
+		return nil, err
+	}
+
+	var app struct{ ServiceEnvs []apptypes.ServiceEnvVar }
+
+	err = conn.Apps().Find(bson.M{"name": appName}).One(&app)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(app.ServiceEnvs, func(i, j int) bool { return app.ServiceEnvs[i].Name < app.ServiceEnvs[j].Name })
+
+	return app.ServiceEnvs, nil
+}

--- a/storage/mongodb/app_env_test.go
+++ b/storage/mongodb/app_env_test.go
@@ -11,5 +11,5 @@ import (
 
 var _ = check.Suite(&storagetest.AppEnvVarSuite{
 	AppEnvVarStorage: &appEnvVarStorage{},
-	SuiteHooks:       &mongodbBaseTest{},
+	SuiteHooks:       &mongodbBaseTest{name: "app_envvar"},
 })

--- a/storage/mongodb/app_env_test.go
+++ b/storage/mongodb/app_env_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.AppEnvVarSuite{
+	AppEnvVarStorage: &appEnvVarStorage{},
+	SuiteHooks:       &mongodbBaseTest{},
+})

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -15,6 +15,7 @@ func init() {
 		PlatformImageStorage:             &PlatformImageStorage{},
 		PlanStorage:                      &PlanStorage{},
 		AppCacheStorage:                  appCacheStorage(),
+		AppEnvVarStorage:                 &appEnvVarStorage{},
 		TeamTokenStorage:                 &teamTokenStorage{},
 		UserQuotaStorage:                 authQuotaStorage(),
 		AppQuotaStorage:                  appQuotaStorage(),

--- a/storage/storagetest/app_env_suite.go
+++ b/storage/storagetest/app_env_suite.go
@@ -1,0 +1,26 @@
+// Copyright 2022 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"github.com/tsuru/tsuru/db"
+	apptypes "github.com/tsuru/tsuru/types/app"
+	check "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type AppEnvVarSuite struct {
+	SuiteHooks
+	AppEnvVarStorage apptypes.AppEnvVarStorage
+}
+
+func (s *AppEnvVarSuite) TestEnvList(c *check.C) {
+	conn, err := db.Conn()
+	c.Assert(err, check.IsNil)
+
+	conn.Apps().Insert(
+		bson.M{"_id": "app-1", "provisioner": "docker", "default": true},
+	)
+}

--- a/storage/storagetest/app_env_suite.go
+++ b/storage/storagetest/app_env_suite.go
@@ -5,6 +5,8 @@
 package storagetest
 
 import (
+	"context"
+
 	"github.com/tsuru/tsuru/db"
 	apptypes "github.com/tsuru/tsuru/types/app"
 	check "gopkg.in/check.v1"
@@ -16,11 +18,38 @@ type AppEnvVarSuite struct {
 	AppEnvVarStorage apptypes.AppEnvVarStorage
 }
 
-func (s *AppEnvVarSuite) TestEnvList(c *check.C) {
+func (s *AppEnvVarSuite) TestListAppEnvs(c *check.C) {
 	conn, err := db.Conn()
 	c.Assert(err, check.IsNil)
+	err = conn.Apps().Insert(bson.M{"name": "app-1", "env": map[string]interface{}{
+		"MY_ENV_1": map[string]interface{}{"name": "MY_ENV_1", "value": "content from env 1"},
+		"MY_ENV_2": map[string]interface{}{"name": "MY_ENV_2", "value": "content from env 2", "public": true},
+		"MY_ENV_3": map[string]interface{}{"name": "MY_ENV_3", "value": "content from env 3", "managedby": "terraform"},
+	}})
+	c.Assert(err, check.IsNil)
+	envs, err := s.AppEnvVarStorage.ListAppEnvs(context.TODO(), "app-1")
+	c.Assert(err, check.IsNil)
+	c.Assert(envs, check.DeepEquals, []apptypes.EnvVar{
+		{Name: "MY_ENV_1", Value: "content from env 1"},
+		{Name: "MY_ENV_2", Value: "content from env 2", Public: true},
+		{Name: "MY_ENV_3", Value: "content from env 3", ManagedBy: "terraform"},
+	})
+}
 
-	conn.Apps().Insert(
-		bson.M{"_id": "app-1", "provisioner": "docker", "default": true},
-	)
+func (s *AppEnvVarSuite) TestListServiceEnvs(c *check.C) {
+	conn, err := db.Conn()
+	c.Assert(err, check.IsNil)
+	err = conn.Apps().Insert(bson.M{"name": "app-1", "serviceenvs": []interface{}{
+		map[string]interface{}{"name": "SVC1_INST1_ENV_1", "value": "v1", "public": true, "servicename": "svc1", "instancename": "instance1"},
+		map[string]interface{}{"name": "SVC1_INST1_ENV_2", "value": "v2", "public": false, "servicename": "svc1", "instancename": "instance1"},
+		map[string]interface{}{"name": "SVC2_INST2_ENV_A", "value": "foo", "public": false, "servicename": "svc2", "instancename": "instance2"},
+	}})
+	c.Assert(err, check.IsNil)
+	svcEnvs, err := s.AppEnvVarStorage.ListServiceEnvs(context.TODO(), "app-1")
+	c.Assert(err, check.IsNil)
+	c.Assert(svcEnvs, check.DeepEquals, []apptypes.ServiceEnvVar{
+		{EnvVar: apptypes.EnvVar{Name: "SVC1_INST1_ENV_1", Value: "v1", Public: true}, ServiceName: "svc1", InstanceName: "instance1"},
+		{EnvVar: apptypes.EnvVar{Name: "SVC1_INST1_ENV_2", Value: "v2"}, ServiceName: "svc1", InstanceName: "instance1"},
+		{EnvVar: apptypes.EnvVar{Name: "SVC2_INST2_ENV_A", Value: "foo"}, ServiceName: "svc2", InstanceName: "instance2"},
+	})
 }

--- a/types/app/envvar.go
+++ b/types/app/envvar.go
@@ -32,14 +32,21 @@ type SetEnvArgs struct {
 	ShouldRestart bool
 }
 
+type UnsetEnvArgs struct {
+	Writer        io.Writer
+	ShouldRestart bool
+}
+
 type AppEnvVarService interface {
 	List(ctx context.Context, appName string) ([]EnvVar, error)
 	Set(ctx context.Context, a App, envs []EnvVar, args SetEnvArgs) error
+	Unset(ctx context.Context, a App, envs []string, args UnsetEnvArgs) error
 }
 
 type AppEnvVarStorage interface {
 	ListAppEnvs(ctx context.Context, appName string) ([]EnvVar, error)
 	UpdateAppEnvs(ctx context.Context, a App, envs []EnvVar) error
+	RemoveAppEnvs(ctx context.Context, a App, envs []string) error
 
 	ListServiceEnvs(ctx context.Context, appName string) ([]ServiceEnvVar, error)
 }

--- a/types/app/envvar.go
+++ b/types/app/envvar.go
@@ -27,6 +27,6 @@ type AppEnvVarService interface {
 }
 
 type AppEnvVarStorage interface {
-	List(ctx context.Context, appName string) ([]EnvVar, error)
+	ListAppEnvs(ctx context.Context, appName string) ([]EnvVar, error)
 	ListServiceEnvs(ctx context.Context, appName string) ([]ServiceEnvVar, error)
 }

--- a/types/app/envvar.go
+++ b/types/app/envvar.go
@@ -1,0 +1,32 @@
+// Copyright 2022 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import "context"
+
+const TsuruServicesEnvVarName = "TSURU_SERVICES"
+
+type EnvVar struct {
+	Name      string `json:"name"`
+	Value     string `json:"value"`
+	Alias     string `json:"alias"`
+	ManagedBy string `json:"managedBy,omitempty"`
+	Public    bool   `json:"public"`
+}
+
+type ServiceEnvVar struct {
+	EnvVar       `bson:",inline"`
+	ServiceName  string `json:"-"`
+	InstanceName string `json:"-"`
+}
+
+type AppEnvVarService interface {
+	List(ctx context.Context, appName string) ([]EnvVar, error)
+}
+
+type AppEnvVarStorage interface {
+	List(ctx context.Context, appName string) ([]EnvVar, error)
+	ListServiceEnvs(ctx context.Context, appName string) ([]ServiceEnvVar, error)
+}

--- a/types/app/envvar.go
+++ b/types/app/envvar.go
@@ -4,7 +4,10 @@
 
 package app
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 const TsuruServicesEnvVarName = "TSURU_SERVICES"
 
@@ -22,11 +25,21 @@ type ServiceEnvVar struct {
 	InstanceName string `json:"-"`
 }
 
+type SetEnvArgs struct {
+	Writer        io.Writer
+	ManagedBy     string
+	PruneUnused   bool
+	ShouldRestart bool
+}
+
 type AppEnvVarService interface {
 	List(ctx context.Context, appName string) ([]EnvVar, error)
+	Set(ctx context.Context, a App, envs []EnvVar, args SetEnvArgs) error
 }
 
 type AppEnvVarStorage interface {
 	ListAppEnvs(ctx context.Context, appName string) ([]EnvVar, error)
+	UpdateAppEnvs(ctx context.Context, a App, envs []EnvVar) error
+
 	ListServiceEnvs(ctx context.Context, appName string) ([]ServiceEnvVar, error)
 }


### PR DESCRIPTION
This PR aims to decouple the env var logic from the app type to ease further improvements.