### PR TITLE
Fixing issue 2582 and adding mongo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,13 +117,20 @@ local-mac:
 	minikube start --driver=virtualbox
 	minikube addons enable registry
 	docker run -d --rm --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
+	@make local-api
+
+local-mac-m1:
+	minikube start --driver=docker --alsologtostderr
+	minikube addons enable registry
+	docker run -d --rm --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
+	@make local-api
+
+local:
+	minikube start --driver=none
+	@make local-api
+
+local-api:
 	docker-compose up -d
 	go build -o $(TSR_BIN) $(TSR_SRC)
 	$(TSR_BIN) api -c ./etc/tsuru-local.conf
 
-local:
-	minikube start --driver=none
-	docker-compose up -d
-	go build -o $(TSR_BIN) $(TSR_SRC)
-	$(TSR_BIN) api -c ./etc/tsuru-local.conf
-	

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     mongo:
-        image: mongo
+        image: mongo:4
         volumes:
             - ./data/mongo:/data/db
         ports:


### PR DESCRIPTION
This PR fix the issue #2582 and adds a mongo version supported by tsuru on docker compose.