### PR TITLE
Fix vulnerability in sphinx 1.7.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==1.7.4
+Sphinx==3.0.4
 sphinx-rtd-theme==0.3.1
 sphinx-tabs==1.1.13
 tsuru-sphinx==0.1.5


### PR DESCRIPTION
-> Vulnerability found in sphinx version 1.7.4
   Vulnerability ID: 38330
   Affected spec: <3.0.4
   ADVISORY: Sphinx 3.0.4 updates jQuery version from 3.4.1 to 3.5.1 for security reasons.
   CVE-2020-11022
   For more information, please visit https://pyup.io/vulnerabilities/CVE-2020-11022/38330/

-> Vulnerability found in sphinx version 1.7.4
   Vulnerability ID: 45775
   Affected spec: <3.0.4
   ADVISORY: Sphinx 3.0.4 updates jQuery version from 3.4.1 to 3.5.1 for security reasons.
   CVE-2020-11023
   For more information, please visit https://pyup.io/vulnerabilities/CVE-2020-11023/45775/