### PR TITLE
feat(build/k8s): support deploy with Dockerfile

### DIFF
--- a/api/deploy.go
+++ b/api/deploy.go
@@ -172,6 +172,8 @@ func permSchemeForDeploy(opts app.DeployOptions) *permission.PermissionScheme {
 		return permission.PermAppDeployArchiveUrl
 	case app.DeployRollback:
 		return permission.PermAppDeployRollback
+	case app.DeployDockerfile:
+		return permission.PermAppDeployDockerfile
 	default:
 		return permission.PermAppDeploy
 	}

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -859,7 +859,7 @@ func (s *DeploySuite) TestPermSchemeForDeploy(c *check.C) {
 			permission.PermAppDeployBuild,
 		},
 		{
-			app.DeployOptions{Dockerfile: "FROM busybox", File: ioutil.NopCloser(bytes.NewReader(nil))},
+			app.DeployOptions{Dockerfile: "FROM busybox"},
 			permission.PermAppDeployDockerfile,
 		},
 		{

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -781,7 +781,7 @@ func (s *DeploySuite) TestDeployWithTokenForInternalAppName(c *check.C) {
 	c.Assert(recorder.Body.String(), check.Matches, ".*Builder deploy called\nOK\n")
 }
 
-func (s *DeploySuite) TestDeployWithoutArchiveURL(c *check.C) {
+func (s *DeploySuite) TestDeployNoMandatoryFields(c *check.C) {
 	a := app.App{Name: "abc", Platform: "python", TeamOwner: s.team.Name}
 	err := app.CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
@@ -794,7 +794,47 @@ func (s *DeploySuite) TestDeployWithoutArchiveURL(c *check.C) {
 	server.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
 	message := recorder.Body.String()
-	c.Assert(message, check.Equals, "you must specify either the archive-url, a image url or upload a file.\n")
+	c.Assert(message, check.Equals, "You must provide at least one of: \"archive-url\", \"dockerfile\", \"image\" or \"file\"\n")
+}
+
+func (s *DeploySuite) TestDeploySetBothFieldsArchiveURLAndImage(c *check.C) {
+	a := app.App{Name: "my-app", Platform: "python", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	values := url.Values{
+		"archive-url": []string{"https://example.com/team/my-app/v1.tar.gz"},
+		"image":       []string{"example.com/team/my-app:v1"},
+	}
+	request, err := http.NewRequest("POST", "/apps/my-app/deploy", strings.NewReader(values.Encode()))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	server := RunServer(true)
+	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+	message := recorder.Body.String()
+	c.Assert(message, check.Equals, "Cannot set \"archive-url\" mutually with \"dockerfile\", \"file\" or \"image\" fields\n")
+}
+
+func (s *DeploySuite) TestDeploySetBothFieldsImageAndDockerfile(c *check.C) {
+	a := app.App{Name: "my-app", Platform: "python", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	values := url.Values{
+		"image":      []string{"example.com/team/my-app:v1"},
+		"dockerfile": []string{"FROM busybox"},
+	}
+	request, err := http.NewRequest("POST", "/apps/my-app/deploy", strings.NewReader(values.Encode()))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+	request.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	server := RunServer(true)
+	server.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+	message := recorder.Body.String()
+	c.Assert(message, check.Equals, "Cannot set \"image\" mutually with \"archive-url\", \"dockerfile\" or \"file\" fields\n")
 }
 
 func (s *DeploySuite) TestPermSchemeForDeploy(c *check.C) {
@@ -817,6 +857,14 @@ func (s *DeploySuite) TestPermSchemeForDeploy(c *check.C) {
 		{
 			app.DeployOptions{File: ioutil.NopCloser(bytes.NewReader(nil)), Build: true},
 			permission.PermAppDeployBuild,
+		},
+		{
+			app.DeployOptions{Dockerfile: "FROM busybox", File: ioutil.NopCloser(bytes.NewReader(nil))},
+			permission.PermAppDeployDockerfile,
+		},
+		{
+			app.DeployOptions{Dockerfile: "FROM busybox", File: ioutil.NopCloser(bytes.NewReader(nil))},
+			permission.PermAppDeployDockerfile,
 		},
 		{
 			app.DeployOptions{},

--- a/app/deploy.go
+++ b/app/deploy.go
@@ -41,6 +41,7 @@ const (
 	DeployUpload       DeployKind = "upload"
 	DeployUploadBuild  DeployKind = "uploadbuild"
 	DeployRebuild      DeployKind = "rebuild"
+	DeployDockerfile   DeployKind = "dockerfile"
 )
 
 var reImageVersion = regexp.MustCompile(":v([0-9]+)$")
@@ -183,6 +184,7 @@ type DeployOptions struct {
 	Commit           string
 	BuildTag         string
 	ArchiveURL       string
+	Dockerfile       string
 	FileSize         int64
 	File             io.ReadCloser `bson:"-"`
 	OutputStream     io.Writer     `bson:"-"`
@@ -214,6 +216,10 @@ func (o *DeployOptions) GetKind() (kind DeployKind) {
 	}
 
 	defer func() { o.Kind = kind }()
+
+	if o.Dockerfile != "" {
+		return DeployDockerfile
+	}
 
 	if o.Rollback {
 		return DeployRollback
@@ -438,6 +444,7 @@ func builderDeploy(ctx context.Context, prov provision.BuilderDeploy, opts *Depl
 		Tag:         opts.BuildTag,
 		Message:     opts.Message,
 		Output:      evt,
+		Dockerfile:  opts.Dockerfile,
 	}
 
 	b, err := opts.App.getBuilder()

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -29,7 +29,6 @@ var (
 
 type BuildOpts struct {
 	IsTsuruBuilderImage bool
-	BuildFromFile       bool
 	Rebuild             bool
 	Redeploy            bool
 	ArchiveURL          string

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -39,6 +39,7 @@ type BuildOpts struct {
 	Tag                 string
 	Message             string
 	Output              io.Writer
+	Dockerfile          string
 }
 
 type BuilderV2 interface {

--- a/builder/docker/builder.go
+++ b/builder/docker/builder.go
@@ -79,7 +79,7 @@ func (b *dockerBuilder) Build(ctx context.Context, prov provision.BuilderDeploy,
 		return nil, errors.New("provisioner not supported: doesn't implement docker builder")
 	}
 	archiveFullPath := fmt.Sprintf("%s/%s", defaultArchivePath, defaultArchiveName)
-	if opts.BuildFromFile {
+	if opts.Dockerfile != "" {
 		return nil, errors.New("build image from Dockerfile is not yet supported")
 	}
 	client, err := p.GetClient(app)

--- a/builder/kubernetes/build_v2.go
+++ b/builder/kubernetes/build_v2.go
@@ -258,6 +258,7 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app provisi
 		SourceImage:       baseImage,
 		DestinationImages: dstImages,
 		Data:              data,
+		Containerfile:     opts.Dockerfile,
 	}
 
 	tc, err := callBuildService(ctx, bs, req, w)
@@ -358,6 +359,10 @@ func callBuildService(ctx context.Context, bc buildpb.BuildClient, req *buildpb.
 func kindToBuildKind(opts builder.BuildOpts) buildpb.BuildKind {
 	if opts.ImageID != "" {
 		return buildpb.BuildKind_BUILD_KIND_APP_BUILD_WITH_CONTAINER_IMAGE
+	}
+
+	if opts.Dockerfile != "" {
+		return buildpb.BuildKind_BUILD_KIND_APP_BUILD_WITH_CONTAINER_FILE
 	}
 
 	if opts.ArchiveSize > 0 {

--- a/builder/kubernetes/builder.go
+++ b/builder/kubernetes/builder.go
@@ -33,7 +33,7 @@ func (b *kubernetesBuilder) Build(ctx context.Context, prov provision.BuilderDep
 	if !ok {
 		return nil, errors.New("provisioner not supported")
 	}
-	if opts.BuildFromFile {
+	if opts.Dockerfile != "" {
 		return nil, errors.New("build image from Dockerfile is not yet supported")
 	}
 	if opts.ArchiveURL != "" {

--- a/builder/kubernetes/builder_test.go
+++ b/builder/kubernetes/builder_test.go
@@ -393,3 +393,19 @@ func (s *S) TestRebuild(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(testBuildImage2, check.Equals, "tsuru/app-myapp:v2-builder")
 }
+
+func (s *S) TestBuildWithDockerfile(c *check.C) {
+	a, _, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	evt, err := event.New(&event.Opts{
+		Target:  event.Target{Type: event.TargetTypeApp, Value: a.GetName()},
+		Kind:    permission.PermAppDeploy,
+		Owner:   s.token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	c.Assert(err, check.IsNil)
+	_, err = s.b.Build(context.TODO(), s.p, a, evt, &builder.BuildOpts{
+		Dockerfile: "FROM busybox:latest",
+	})
+	c.Assert(err, check.ErrorMatches, "build image from Dockerfile is not yet supported")
+}

--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -1110,7 +1110,9 @@ paths:
         description: |-
           App's source files (tarball compressed with gzip).
 
-          NOTE: Cannot be presented mutually with `archive-url` or `image`.
+          NOTE 1: When `dockerfile` field is set, this field contains the container build context files.
+
+          NOTE 2: Cannot be presented mutually with `archive-url` or `image`.
         x-mimetype: application/gzip
       - in: formData
         name: archive-url
@@ -1120,7 +1122,7 @@ paths:
 
           NOTE 1: Tsuru API must be able to download the file over HTTP and the downloaded file must be a tarball compressed with gzip.
 
-          NOTE 2: Cannot be presented mutually with `file` or `image`.
+          NOTE 2: Cannot be presented mutually with `dockerfile`, `file` or `image`.
 
           Example: `https://my-org.example.com/my-app/v42.tar.gz`.
       - in: formData
@@ -1129,9 +1131,29 @@ paths:
         description: |-
           Container image name. It must be a valid container image name according to [container image's name specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests).
 
-          NOTE: Cannote be presented mutually with `archive-url` or `file`.
+          NOTE: Cannot be presented mutually with `archive-url`, `dockerfile` or `file`.
 
           Example: `registry.example.com/my-org/my-app:v42`
+
+      - in: formData
+        name: dockerfile
+        type: string
+        description: |-
+          Content of container file (Dockerfile). It must be a valid file according to [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).
+
+          NOTE: Cannot be presented mutually with `archive-url` or `image`.
+
+          Example:
+          ```
+          FROM alpine:3.16
+          RUN set -x \
+              apk add --update --no-cache curl ca-certificates
+          COPY ./app.sh ./tsuru.yaml /var/my-app/
+          WORKDIR /var/my-app
+          EXPOSE 8888/tcp
+          ENTRYPOINT ["/var/my-app/app.sh"]
+          CMD ["--port", "8888"]
+          ```
       responses:
         "200":
           description: Build finished successfully
@@ -1199,7 +1221,9 @@ paths:
         description: |-
           App's source files (tarball compressed with gzip).
 
-          NOTE: Cannot be presented mutually with `archive-url` or `image`.
+          NOTE 1: When `dockerfile` field is set, this field contains the container build context files.
+
+          NOTE 2: Cannot be presented mutually with `archive-url` or `image`.
         x-mimetype: application/gzip
       - in: formData
         name: archive-url
@@ -1209,7 +1233,7 @@ paths:
 
           NOTE 1: Tsuru API must be able to download the file over HTTP and the downloaded file must be a tarball compressed with gzip.
 
-          NOTE 2: Cannot be presented mutually with `file` or `image`.
+          NOTE 2: Cannot be presented mutually with `dockerfile`, `file` or `image`.
 
           Example: `https://my-org.example.com/my-app/v42.tar.gz`.
       - in: formData
@@ -1218,9 +1242,29 @@ paths:
         description: |-
           Container image name. It must be a valid container image name according to [container image's name specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests).
 
-          NOTE: Cannot be presented mutually with `archive-url` or `file`.
+          NOTE: Cannot be presented mutually with `archive-url`, `dockerfile` or `file`.
 
           Example: `registry.example.com/my-org/my-app:v42`
+
+      - in: formData
+        name: dockerfile
+        type: string
+        description: |-
+          Content of container file (Dockerfile). It must be a valid file according to [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).
+
+          NOTE: Cannot be presented mutually with `archive-url` or `image`.
+
+          Example:
+          ```
+          FROM alpine:3.16
+          RUN set -x \
+              apk add --update --no-cache curl ca-certificates
+          COPY ./app.sh ./tsuru.yaml /var/my-app/
+          WORKDIR /var/my-app
+          EXPOSE 8888/tcp
+          ENTRYPOINT ["/var/my-app/app.sh"]
+          CMD ["--port", "8888"]
+          ```
       consumes:
       - multipart/form-data
       produces:

--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -1,7 +1,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT!
 // Please run 'go generate' to update this file.
 //
-// Copyright 2022 tsuru authors. All rights reserved.
+// Copyright 2023 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -19,6 +19,7 @@ var (
 	PermAppDeploy                        = PermissionRegistry.get("app.deploy")                          // [global app team pool]
 	PermAppDeployArchiveUrl              = PermissionRegistry.get("app.deploy.archive-url")              // [global app team pool]
 	PermAppDeployBuild                   = PermissionRegistry.get("app.deploy.build")                    // [global app team pool]
+	PermAppDeployDockerfile              = PermissionRegistry.get("app.deploy.dockerfile")               // [global app team pool]
 	PermAppDeployGit                     = PermissionRegistry.get("app.deploy.git")                      // [global app team pool]
 	PermAppDeployImage                   = PermissionRegistry.get("app.deploy.image")                    // [global app team pool]
 	PermAppDeployRollback                = PermissionRegistry.get("app.deploy.rollback")                 // [global app team pool]
@@ -78,9 +79,9 @@ var (
 	PermAppUpdateUnitAutoscale           = PermissionRegistry.get("app.update.unit.autoscale")           // [global app team pool]
 	PermAppUpdateUnitAutoscaleAdd        = PermissionRegistry.get("app.update.unit.autoscale.add")       // [global app team pool]
 	PermAppUpdateUnitAutoscaleRemove     = PermissionRegistry.get("app.update.unit.autoscale.remove")    // [global app team pool]
+	PermAppUpdateUnitKill                = PermissionRegistry.get("app.update.unit.kill")                // [global app team pool]
 	PermAppUpdateUnitRegister            = PermissionRegistry.get("app.update.unit.register")            // [global app team pool]
 	PermAppUpdateUnitRemove              = PermissionRegistry.get("app.update.unit.remove")              // [global app team pool]
-	PermAppUpdateUnitKill                = PermissionRegistry.get("app.update.unit.kill")                // [global app team pool]
 	PermAppUpdateUnitStatus              = PermissionRegistry.get("app.update.unit.status")              // [global app team pool]
 	PermCluster                          = PermissionRegistry.get("cluster")                             // [global]
 	PermClusterAdmin                     = PermissionRegistry.get("cluster.admin")                       // [global]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -62,6 +62,7 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"app.deploy.image",
 	"app.deploy.rollback",
 	"app.deploy.upload",
+	"app.deploy.dockerfile",
 	"app.read",
 	"app.read.deploy",
 	"app.read.router",

--- a/router/api/routeriface.go
+++ b/router/api/routeriface.go
@@ -1,7 +1,7 @@
 // AUTOMATICALLY GENERATED FILE - DO NOT EDIT!
 // Please run 'go generate' to update this file.
 //
-// Copyright 2022 tsuru authors. All rights reserved.
+// Copyright 2023 tsuru authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
As of https://github.com/tsuru/deploy-agent/commit/701d1f514f7a08da5f5be87f6c54df98d095a099, Deploy Agent v2 supports deploy w/ Dockerfile. Following that changes, this PR implements the support deploy w/ Dockerfile from Tsuru API as wel.