### PR TITLE
fix(api/app): preventing to add non-UNIX env var names

### DIFF
--- a/types/api/env.go
+++ b/types/api/env.go
@@ -4,6 +4,11 @@
 
 package api
 
+import "errors"
+
+var ErrWriteProtectedEnvVar = errors.New("write-protected environment variable")
+var ErrInvalidEnvVarName = errors.New("invalid environment variable name")
+
 // Envs represents the configuration of an environment variable data
 // for the remote API
 type Envs struct {


### PR DESCRIPTION
This PR prevents user adding env var that aren't UNIX compliant onto app.