### PR TITLE
fix(app): starting with past units should not increase the process units

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1419,8 +1419,8 @@ func (app *App) Stop(ctx context.Context, w io.Writer, process, versionStr strin
 		return err
 	}
 
-	if crg, ok := prov.(provision.CurrentReplicasGetter); ok {
-		if err = saveCurrentReplicasOnProcessPastUnits(ctx, app, process, version, crg); err != nil {
+	if cr, ok := prov.(provision.CurrentReplicasProvisioner); ok {
+		if err = saveCurrentReplicasOnProcessPastUnits(ctx, app, process, version, cr); err != nil {
 			log.Errorf("[stop] could not store the old process number: %s", err)
 			return err
 		}
@@ -2933,7 +2933,7 @@ func (app *App) GetRegistry() (imgTypes.ImageRegistry, error) {
 	return registryProv.RegistryForApp(app.ctx, app)
 }
 
-func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, process string, version appTypes.AppVersion, crg provision.CurrentReplicasGetter) error {
+func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, process string, version appTypes.AppVersion, cr provision.CurrentReplicasProvisioner) error {
 	if version == nil {
 		return nil // nothing to do
 	}
@@ -2949,7 +2949,7 @@ func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, proces
 		}
 
 		var replicas int32
-		replicas, err = crg.CurrentReplicas(ctx, app, p, version.Version())
+		replicas, err = cr.CurrentReplicas(ctx, app, p, version.Version())
 		if err != nil {
 			return err
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -2949,7 +2949,7 @@ func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, proces
 		}
 
 		var replicas int32
-		replicas, err = crg.CurrentReplicas(ctx, app, p, version)
+		replicas, err = crg.CurrentReplicas(ctx, app, p, version.Version())
 		if err != nil {
 			return err
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -1408,30 +1408,19 @@ func (app *App) Stop(ctx context.Context, w io.Writer, process, versionStr strin
 		msg = fmt.Sprintf("\n ---> Stopping the app %q", app.Name)
 	}
 	fmt.Fprintf(w, "%s\n", msg)
-
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return err
 	}
-
 	version, err := app.getVersionAllowNil(versionStr)
 	if err != nil {
 		return err
 	}
-
-	if cr, ok := prov.(provision.CurrentReplicasProvisioner); ok {
-		if err = saveCurrentReplicasOnProcessPastUnits(ctx, app, process, version, cr); err != nil {
-			log.Errorf("[stop] could not store the old process number: %s", err)
-			return err
-		}
-	}
-
 	err = prov.Stop(ctx, app, process, version, w)
 	if err != nil {
 		log.Errorf("[stop] error on stop the app %s - %s", app.Name, err)
 		return err
 	}
-
 	return nil
 }
 
@@ -2244,15 +2233,11 @@ func (app *App) Start(ctx context.Context, w io.Writer, process, versionStr stri
 	if err != nil {
 		return err
 	}
-
 	err = prov.Start(ctx, app, process, version, w)
 	if err != nil {
 		log.Errorf("[start] error on start the app %s - %s", app.Name, err)
 		return newErrorWithLog(err, app, "start")
 	}
-
-	addUnitsFromLastStop(ctx, app, process, version, prov, w)
-
 	rebuild.RoutesRebuildOrEnqueueWithProgress(app.Name, w)
 	return err
 }
@@ -2931,58 +2916,4 @@ func (app *App) GetRegistry() (imgTypes.ImageRegistry, error) {
 		return "", nil
 	}
 	return registryProv.RegistryForApp(app.ctx, app)
-}
-
-func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, process string, version appTypes.AppVersion, cr provision.CurrentReplicasProvisioner) error {
-	if version == nil {
-		return nil // nothing to do
-	}
-
-	processes, err := version.Processes()
-	if err != nil {
-		return err
-	}
-
-	for p := range processes {
-		if process != "" && process != p { // if process is set, only matches with the selected
-			continue
-		}
-
-		var replicas int32
-		replicas, err = cr.CurrentReplicas(ctx, app, p, version.Version())
-		if err != nil {
-			return err
-		}
-
-		err = version.UpdatePastUnits(p, int(replicas))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func addUnitsFromLastStop(ctx context.Context, app *App, process string, version appTypes.AppVersion, prov provision.Provisioner, w io.Writer) {
-	if version == nil {
-		return
-	}
-
-	for p, replicas := range version.VersionInfo().PastUnits {
-		if process != "" && process != p {
-			continue
-		}
-
-		fmt.Fprintf(w, "Before being stopped, the %q process had %d replicas... re-adding them.\n", p, replicas)
-
-		err := prov.AddUnits(ctx, app, uint(replicas), p, version, w)
-		if err != nil {
-			fmt.Fprintf(w, "Failed to add units to %q process\n\tError: %s\n", p, err)
-		}
-
-		err = version.UpdatePastUnits(p, -1) // unsets past units for process
-		if err != nil {
-			fmt.Fprintf(w, "Failed to unset past units for %q process:\n\tError: %s\n", p, err)
-		}
-	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1420,8 +1420,7 @@ func (app *App) Stop(ctx context.Context, w io.Writer, process, versionStr strin
 	}
 
 	if crg, ok := prov.(provision.CurrentReplicasGetter); ok {
-		err = recordNumberOfReplicas(ctx, app, process, version, crg)
-		if err != nil {
+		if err = saveCurrentReplicasOnProcessPastUnits(ctx, app, process, version, crg); err != nil {
 			log.Errorf("[stop] could not store the old process number: %s", err)
 			return err
 		}
@@ -2934,7 +2933,7 @@ func (app *App) GetRegistry() (imgTypes.ImageRegistry, error) {
 	return registryProv.RegistryForApp(app.ctx, app)
 }
 
-func recordNumberOfReplicas(ctx context.Context, app *App, process string, version appTypes.AppVersion, crg provision.CurrentReplicasGetter) error {
+func saveCurrentReplicasOnProcessPastUnits(ctx context.Context, app *App, process string, version appTypes.AppVersion, crg provision.CurrentReplicasGetter) error {
 	if version == nil {
 		return nil // nothing to do
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2625,8 +2625,8 @@ func (s *S) TestStop(c *check.C) {
 	version := newSuccessfulAppVersion(c, &a)
 	err = version.AddData(appTypes.AddVersionDataArgs{
 		Processes: map[string][]string{
-			"web":    []string{"/path/to/server.sh"},
-			"worker": []string{"/path/to/worker.sh"},
+			"web":    {"/path/to/server.sh"},
+			"worker": {"/path/to/worker.sh"},
 		},
 	})
 	c.Assert(err, check.IsNil)
@@ -4524,10 +4524,11 @@ func (s *S) TestStart_StartProcessesUsingReplicasFromLastAppStop(c *check.C) {
 	version := newSuccessfulAppVersion(c, &a)
 	err = version.AddData(appTypes.AddVersionDataArgs{
 		Processes: map[string][]string{
-			"web":    []string{"/path/to/server.sh"},
-			"worker": []string{"/path/to/worker.sh"},
+			"web":    {"/path/to/server.sh"},
+			"worker": {"/path/to/worker.sh"},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	err = version.UpdatePastUnits("web", 5)
 	c.Assert(err, check.IsNil)
 	err = version.UpdatePastUnits("worker", 3)

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -159,9 +159,13 @@ func (v *appVersionImpl) UpdatePastUnits(process string, replicas int) error {
 	}
 
 	if v.versionInfo.PastUnits == nil {
-		v.versionInfo.PastUnits = map[string]int{process: replicas}
-	} else {
+		v.versionInfo.PastUnits = make(map[string]int)
+	}
+
+	if replicas > 0 {
 		v.versionInfo.PastUnits[process] = replicas
+	} else {
+		delete(v.versionInfo.PastUnits, process)
 	}
 
 	return v.storage.UpdateVersion(v.ctx, v.app.GetName(), v.versionInfo)

--- a/provision/kubernetes/deploy_simple_test.go
+++ b/provision/kubernetes/deploy_simple_test.go
@@ -220,7 +220,6 @@ func (s *S) TestServiceManagerDeploySimple(c *check.C) {
 					var version appTypes.AppVersion
 					version, err = servicemanager.AppVersion.VersionByImageOrVersion(context.TODO(), a, strconv.Itoa(step.stopStep.version))
 					c.Assert(err, check.IsNil)
-					s.updatePastUnits(c, a.Name, version, step.stopStep.proc)
 					err = servicecommon.ChangeAppState(context.TODO(), &m, a, step.stopStep.proc, servicecommon.ProcessState{Stop: true}, version)
 					c.Assert(err, check.IsNil)
 					waitDep()

--- a/provision/kubernetes/deploy_simple_test.go
+++ b/provision/kubernetes/deploy_simple_test.go
@@ -160,7 +160,7 @@ func (s *S) TestServiceManagerDeploySimple(c *check.C) {
 				{
 					startStep: &startStep{version: 5, proc: "p2"},
 					check: func() {
-						s.hasDepWithVersion(c, "myapp0-p2", 5, 3)
+						s.hasDepWithVersion(c, "myapp0-p2", 5, 1)
 						s.hasSvc(c, "myapp0-p2")
 					},
 				},

--- a/provision/kubernetes/multiple_deploy_actions_test.go
+++ b/provision/kubernetes/multiple_deploy_actions_test.go
@@ -58,9 +58,12 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 					deployStep: &deployStep{procs: []string{"p1", "p2"}},
 					check: func() {
 						s.hasDepWithVersion(c, "myapp0-p1", 1, 1)
+						s.hasDepWithVersion(c, "myapp0-p2", 1, 1)
 						s.hasSvc(c, "myapp0-p1")
+						s.hasSvc(c, "myapp0-p2")
 
 						s.noSvc(c, "myapp0-p1-v1")
+						s.noSvc(c, "myapp0-p2-v1")
 					},
 				},
 				{
@@ -77,9 +80,9 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 				{
 					unitStep: &unitStep{version: 2, units: 2, proc: "p1"},
 					check: func() {
-						s.hasDepWithVersion(c, "myapp0-p1-v2", 2, 3)
-
 						s.hasDepWithVersion(c, "myapp0-p1", 1, 1)
+						s.hasDepWithVersion(c, "myapp0-p2", 1, 1)
+						s.hasDepWithVersion(c, "myapp0-p1-v2", 2, 3)
 						s.hasDepWithVersion(c, "myapp0-p2-v2", 2, 1)
 						s.hasSvc(c, "myapp0-p1")
 						s.hasSvc(c, "myapp0-p1-v2")
@@ -101,6 +104,7 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 				},
 			},
 		},
+
 		{
 			steps: []stepDef{
 				{
@@ -142,6 +146,7 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 				},
 			},
 		},
+
 		{
 			steps: []stepDef{
 				{
@@ -170,8 +175,12 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 				{
 					stopStep: &stopStep{proc: "p1", version: 1},
 					check: func() {
+						s.hasDepWithVersion(c, "myapp2-p1", 1, 0)
 						s.hasDepWithVersion(c, "myapp2-p2", 1, 4)
+						s.hasSvc(c, "myapp2-p1")
+						s.hasSvc(c, "myapp2-p2")
 						s.noSvc(c, "myapp2-p1-v1")
+						s.noSvc(c, "myapp2-p2-v1")
 					},
 				},
 				{
@@ -179,22 +188,27 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 					check: func() {
 						s.hasDepWithVersion(c, "myapp2-p2", 1, 0)
 						s.hasDepWithVersion(c, "myapp2-p1", 1, 0)
+						s.hasSvc(c, "myapp2-p1")
+						s.hasSvc(c, "myapp2-p2")
+						s.noSvc(c, "myapp2-p1-v1")
+						s.noSvc(c, "myapp2-p2-v1")
 					},
 				},
 				{
 					startStep: &startStep{proc: "p1", version: 1},
 					check: func() {
-						s.hasDepWithVersion(c, "myapp2-p1", 1, 3)
+						s.hasDepWithVersion(c, "myapp2-p1", 1, 1)
 					},
 				},
 				{
 					startStep: &startStep{proc: "p2", version: 1},
 					check: func() {
-						s.hasDepWithVersion(c, "myapp2-p2", 1, 4)
+						s.hasDepWithVersion(c, "myapp2-p2", 1, 1)
 					},
 				},
 			},
 		},
+
 		{
 			steps: []stepDef{
 				{
@@ -249,15 +263,41 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 				},
 			},
 		},
+
 		{
 			steps: []stepDef{
 				{
 					deployStep: &deployStep{procs: []string{"p1", "p2", "p3"}},
-					check:      func() {},
+					check: func() {
+						s.hasDepWithVersion(c, "myapp4-p1", 1, 1)
+						s.hasDepWithVersion(c, "myapp4-p2", 1, 1)
+						s.hasDepWithVersion(c, "myapp4-p3", 1, 1)
+
+						s.hasSvc(c, "myapp4-p1")
+						s.hasSvc(c, "myapp4-p2")
+						s.hasSvc(c, "myapp4-p3")
+					},
 				},
 				{
 					deployStep: &deployStep{procs: []string{"p1", "p2", "p3"}, newVersion: true},
-					check:      func() {},
+					check: func() {
+						s.hasDepWithVersion(c, "myapp4-p1", 1, 1)
+						s.hasDepWithVersion(c, "myapp4-p2", 1, 1)
+						s.hasDepWithVersion(c, "myapp4-p3", 1, 1)
+						s.hasSvc(c, "myapp4-p1")
+						s.hasSvc(c, "myapp4-p2")
+						s.hasSvc(c, "myapp4-p3")
+						s.hasSvc(c, "myapp4-p1-v1")
+						s.hasSvc(c, "myapp4-p2-v1")
+						s.hasSvc(c, "myapp4-p3-v1")
+
+						s.hasDepWithVersion(c, "myapp4-p1-v2", 2, 1)
+						s.hasDepWithVersion(c, "myapp4-p2-v2", 2, 1)
+						s.hasDepWithVersion(c, "myapp4-p3-v2", 2, 1)
+						s.hasSvc(c, "myapp4-p1-v2")
+						s.hasSvc(c, "myapp4-p2-v2")
+						s.hasSvc(c, "myapp4-p3-v2")
+					},
 				},
 				{
 					unitStep: &unitStep{version: 1, units: 1, proc: "p1"},
@@ -282,17 +322,33 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 						s.hasDepWithVersion(c, "myapp4-p1", 1, 0)
 						s.hasDepWithVersion(c, "myapp4-p2", 1, 0)
 						s.hasDepWithVersion(c, "myapp4-p3", 1, 0)
+						s.hasSvc(c, "myapp4-p1")
+						s.hasSvc(c, "myapp4-p2")
+						s.hasSvc(c, "myapp4-p3")
+
 						s.noDep(c, "myapp4-p1-v2")
 						s.noDep(c, "myapp4-p2-v2")
 						s.noDep(c, "myapp4-p3-v2")
+
+						s.noSvc(c, "myapp4-p1-v2")
+						s.noSvc(c, "myapp4-p2-v2")
+						s.noSvc(c, "myapp4-p3-v2")
 					},
 				},
 				{
 					startStep: &startStep{},
 					check: func() {
+						s.hasDepWithVersion(c, "myapp4-p1", 1, 0)
+						s.hasDepWithVersion(c, "myapp4-p2", 1, 0)
+						s.hasDepWithVersion(c, "myapp4-p3", 1, 0)
+
 						s.hasDepWithVersion(c, "myapp4-p1-v2", 2, 1)
 						s.hasDepWithVersion(c, "myapp4-p2-v2", 2, 1)
 						s.hasDepWithVersion(c, "myapp4-p3-v2", 2, 1)
+
+						s.hasSvc(c, "myapp4-p1-v2")
+						s.hasSvc(c, "myapp4-p2-v2")
+						s.hasSvc(c, "myapp4-p3-v2")
 					},
 				},
 			},
@@ -367,9 +423,6 @@ func (s *S) TestServiceManagerDeployMultipleFlows(c *check.C) {
 					} else {
 						versions, err = versionsForAppProcess(context.TODO(), s.clusterClient, a, step.stopStep.proc, true)
 						c.Assert(err, check.IsNil)
-						for _, v := range versions {
-							s.updatePastUnitsAllProcesses(c, a.Name, v)
-						}
 					}
 					for _, v := range versions {
 						err = servicecommon.ChangeAppState(context.TODO(), &serviceManager{
@@ -469,23 +522,6 @@ func (s *S) updatePastUnits(c *check.C, appName string, v appTypes.AppVersion, p
 			if dep.Spec.Replicas != nil && strconv.Itoa(v.Version()) == version {
 				err = v.UpdatePastUnits(p, int(*dep.Spec.Replicas))
 				c.Assert(err, check.IsNil)
-			}
-		}
-	}
-}
-
-func (s *S) updatePastUnitsAllProcesses(c *check.C, appName string, v appTypes.AppVersion) {
-	deps, err := s.client.Clientset.AppsV1().Deployments("default").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("tsuru.io/app-name=%s", appName),
-	})
-	c.Assert(err, check.IsNil)
-	for _, dep := range deps.Items {
-		if version, ok := dep.Spec.Template.Labels["tsuru.io/app-version"]; ok {
-			if strconv.Itoa(v.Version()) == version && dep.Spec.Replicas != nil {
-				if process, ok := dep.Spec.Template.Labels["tsuru.io/app-process"]; ok {
-					err = v.UpdatePastUnits(process, int(*dep.Spec.Replicas))
-					c.Assert(err, check.IsNil)
-				}
 			}
 		}
 	}

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -83,27 +83,27 @@ type kubernetesProvisioner struct {
 }
 
 var (
-	_ provision.Provisioner              = &kubernetesProvisioner{}
-	_ provision.NodeProvisioner          = &kubernetesProvisioner{}
-	_ provision.NodeContainerProvisioner = &kubernetesProvisioner{}
-	_ provision.MessageProvisioner       = &kubernetesProvisioner{}
-	_ provision.SleepableProvisioner     = &kubernetesProvisioner{}
-	_ provision.VolumeProvisioner        = &kubernetesProvisioner{}
-	_ provision.BuilderDeploy            = &kubernetesProvisioner{}
-	_ provision.BuilderDeployKubeClient  = &kubernetesProvisioner{}
-	_ provision.InitializableProvisioner = &kubernetesProvisioner{}
-	_ provision.InterAppProvisioner      = &kubernetesProvisioner{}
-	_ provision.HCProvisioner            = &kubernetesProvisioner{}
-	_ provision.VersionsProvisioner      = &kubernetesProvisioner{}
-	_ provision.LogsProvisioner          = &kubernetesProvisioner{}
-	_ provision.MetricsProvisioner       = &kubernetesProvisioner{}
-	_ provision.AutoScaleProvisioner     = &kubernetesProvisioner{}
-	_ cluster.ClusteredProvisioner       = &kubernetesProvisioner{}
-	_ provision.UpdatableProvisioner     = &kubernetesProvisioner{}
-	_ provision.MultiRegistryProvisioner = &kubernetesProvisioner{}
-	_ provision.KillUnitProvisioner      = &kubernetesProvisioner{}
-	_ provision.JobProvisioner           = &kubernetesProvisioner{}
-	_ provision.CurrentReplicasGetter    = &kubernetesProvisioner{}
+	_ provision.Provisioner                = &kubernetesProvisioner{}
+	_ provision.NodeProvisioner            = &kubernetesProvisioner{}
+	_ provision.NodeContainerProvisioner   = &kubernetesProvisioner{}
+	_ provision.MessageProvisioner         = &kubernetesProvisioner{}
+	_ provision.SleepableProvisioner       = &kubernetesProvisioner{}
+	_ provision.VolumeProvisioner          = &kubernetesProvisioner{}
+	_ provision.BuilderDeploy              = &kubernetesProvisioner{}
+	_ provision.BuilderDeployKubeClient    = &kubernetesProvisioner{}
+	_ provision.InitializableProvisioner   = &kubernetesProvisioner{}
+	_ provision.InterAppProvisioner        = &kubernetesProvisioner{}
+	_ provision.HCProvisioner              = &kubernetesProvisioner{}
+	_ provision.VersionsProvisioner        = &kubernetesProvisioner{}
+	_ provision.LogsProvisioner            = &kubernetesProvisioner{}
+	_ provision.MetricsProvisioner         = &kubernetesProvisioner{}
+	_ provision.AutoScaleProvisioner       = &kubernetesProvisioner{}
+	_ cluster.ClusteredProvisioner         = &kubernetesProvisioner{}
+	_ provision.UpdatableProvisioner       = &kubernetesProvisioner{}
+	_ provision.MultiRegistryProvisioner   = &kubernetesProvisioner{}
+	_ provision.KillUnitProvisioner        = &kubernetesProvisioner{}
+	_ provision.JobProvisioner             = &kubernetesProvisioner{}
+	_ provision.CurrentReplicasProvisioner = &kubernetesProvisioner{}
 
 	mainKubernetesProvisioner *kubernetesProvisioner
 )

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -451,6 +451,12 @@ type InterAppProvisioner interface {
 	InternalAddresses(ctx context.Context, a App) ([]AppInternalAddress, error)
 }
 
+// CurrentReplicasGetter implements how to get the current (desired)
+// number of replicas (units) of an app.
+type CurrentReplicasGetter interface {
+	CurrentReplicas(ctx context.Context, a App, process string, version appTypes.AppVersion) (int32, error)
+}
+
 type AppInternalAddress struct {
 	Domain   string
 	Protocol string

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -454,7 +454,7 @@ type InterAppProvisioner interface {
 // CurrentReplicasGetter implements how to get the current (desired)
 // number of replicas (units) of an app.
 type CurrentReplicasGetter interface {
-	CurrentReplicas(ctx context.Context, a App, process string, version appTypes.AppVersion) (int32, error)
+	CurrentReplicas(ctx context.Context, a App, process string, version int) (int32, error)
 }
 
 type AppInternalAddress struct {

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -453,7 +453,7 @@ type InterAppProvisioner interface {
 
 // CurrentReplicasGetter implements how to get the current (desired)
 // number of replicas (units) of an app.
-type CurrentReplicasGetter interface {
+type CurrentReplicasProvisioner interface {
 	CurrentReplicas(ctx context.Context, a App, process string, version int) (int32, error)
 }
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1163,7 +1163,7 @@ func (p *FakeProvisioner) Units(ctx context.Context, apps ...provision.App) ([]p
 	return allUnits, nil
 }
 
-func (p *FakeProvisioner) CurrentReplicas(ctx context.Context, app provision.App, process string, version appTypes.AppVersion) (int32, error) {
+func (p *FakeProvisioner) CurrentReplicas(ctx context.Context, app provision.App, process string, version int) (int32, error) {
 	a, found := p.apps[app.GetName()]
 	if !found {
 		return 0, nil
@@ -1175,7 +1175,7 @@ func (p *FakeProvisioner) CurrentReplicas(ctx context.Context, app provision.App
 			continue
 		}
 
-		if version != nil && u.Version != version.Version() {
+		if u.Version != version {
 			continue
 		}
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -38,22 +38,22 @@ var (
 	errNotProvisioned         = &provision.Error{Reason: "App is not provisioned."}
 	uniqueIpCounter     int32 = 0
 
-	_ provision.Provisioner              = &FakeProvisioner{}
-	_ provision.NodeProvisioner          = &FakeProvisioner{}
-	_ provision.NodeContainerProvisioner = &FakeProvisioner{}
-	_ provision.InterAppProvisioner      = &FakeProvisioner{}
-	_ provision.UpdatableProvisioner     = &FakeProvisioner{}
-	_ provision.Provisioner              = &FakeProvisioner{}
-	_ provision.LogsProvisioner          = &FakeProvisioner{}
-	_ provision.MetricsProvisioner       = &FakeProvisioner{}
-	_ provision.VolumeProvisioner        = &FakeProvisioner{}
-	_ provision.SleepableProvisioner     = &FakeProvisioner{}
-	_ provision.AppFilterProvisioner     = &FakeProvisioner{}
-	_ provision.ExecutableProvisioner    = &FakeProvisioner{}
-	_ provision.NodeRebalanceProvisioner = &FakeProvisioner{}
-	_ provision.CurrentReplicasGetter    = &FakeProvisioner{}
-	_ provision.App                      = &FakeApp{}
-	_ bind.App                           = &FakeApp{}
+	_ provision.Provisioner                = &FakeProvisioner{}
+	_ provision.NodeProvisioner            = &FakeProvisioner{}
+	_ provision.NodeContainerProvisioner   = &FakeProvisioner{}
+	_ provision.InterAppProvisioner        = &FakeProvisioner{}
+	_ provision.UpdatableProvisioner       = &FakeProvisioner{}
+	_ provision.Provisioner                = &FakeProvisioner{}
+	_ provision.LogsProvisioner            = &FakeProvisioner{}
+	_ provision.MetricsProvisioner         = &FakeProvisioner{}
+	_ provision.VolumeProvisioner          = &FakeProvisioner{}
+	_ provision.SleepableProvisioner       = &FakeProvisioner{}
+	_ provision.AppFilterProvisioner       = &FakeProvisioner{}
+	_ provision.ExecutableProvisioner      = &FakeProvisioner{}
+	_ provision.NodeRebalanceProvisioner   = &FakeProvisioner{}
+	_ provision.CurrentReplicasProvisioner = &FakeProvisioner{}
+	_ provision.App                        = &FakeApp{}
+	_ bind.App                             = &FakeApp{}
 )
 
 func init() {

--- a/provision/servicecommon/state.go
+++ b/provision/servicecommon/state.go
@@ -12,12 +12,6 @@ import (
 	appTypes "github.com/tsuru/tsuru/types/app"
 )
 
-func patchWithPastUnits(process string, pastUnitsMap map[string]int, state *ProcessState) {
-	if replicas, ok := pastUnitsMap[process]; ok && (state.Start && !state.Restart) {
-		state.Increment = replicas
-	}
-}
-
 func ChangeAppState(ctx context.Context, manager ServiceManager, a provision.App, process string, state ProcessState, version appTypes.AppVersion) error {
 	var (
 		processes []string
@@ -37,7 +31,6 @@ func ChangeAppState(ctx context.Context, manager ServiceManager, a provision.App
 	}
 	spec := ProcessSpec{}
 	for _, procName := range processes {
-		patchWithPastUnits(procName, version.VersionInfo().PastUnits, &state)
 		spec[procName] = state
 	}
 	err = RunServicePipeline(ctx, manager, version.Version(), provision.DeployArgs{App: a, Version: version, PreserveVersions: true}, spec)


### PR DESCRIPTION
Prior to this PR, running consecutive app-stop and app-start could increase the number of replicas since we didn't check the status of the pods. This implementation delegates to the provisioner a new method to get the desired replicas number.