### PR TITLE
fix login on windows (WSL)

### DIFF
--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -119,7 +119,7 @@ func (c *login) oauthLogin(context *Context, client *Client) error {
 	if err != nil {
 		return err
 	}
-	redirectURL := fmt.Sprintf("http://127.0.0.1:%s", port)
+	redirectURL := fmt.Sprintf("http://localhost:%s", port)
 	authURL := strings.Replace(schemeData["authorizeUrl"], "__redirect_url__", redirectURL, 1)
 	http.HandleFunc("/", callback(redirectURL, finish))
 	server := &http.Server{}


### PR DESCRIPTION
use `localhost` instead of `127.0.0.1` (for compatibility with windows)

closes: https://github.com/tsuru/tsuru/issues/2622
