### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Dennis Nguyen <dnguy078@ucr.edu>
 Diego Araujo <diegoaraujo@usp.br>
 Diego Toral <diegotoral@gmail.com>
 Diogo Munaro Vieira <diogo.mvieira@gmail.com>
+Eng Zer Jun <engzerjun@gmail.com>
 Evandro Flores <eof@eof.com.br>
 Fares Rihani <anchepiece@gmail.com>
 Felipe Oliveira <felipeweb.programador@gmail.com>

--- a/builder/kubernetes/build_v2.go
+++ b/builder/kubernetes/build_v2.go
@@ -11,10 +11,10 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ghodss/yaml"
 	buildpb "github.com/tsuru/deploy-agent/pkg/build/grpc_build_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"sigs.k8s.io/yaml"
 
 	"github.com/tsuru/tsuru/app/image"
 	"github.com/tsuru/tsuru/app/version"
@@ -378,7 +378,7 @@ func tsuruYamlStringToCustomData(str string) (map[string]any, error) {
 	}
 
 	var tsuruYaml provisiontypes.TsuruYamlData
-	// NOTE(nettoclaudio): we must use the github.com/ghodss/yaml package to
+	// NOTE(nettoclaudio): we must use the "sigs.k8s.io/yaml" package to
 	// decode the YAML from app since we need some functions of JSON decoder
 	// as well - namely parse field names based on JSON struct tags.
 	if err := yaml.Unmarshal([]byte(str), &tsuruYaml); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tsuru/tsuru
 go 1.19
 
 require (
+	github.com/adhocore/gronx v1.1.2
 	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f
 	github.com/bradfitz/go-smtpd v0.0.0-20130623174436-5b56f4f917c7
 	github.com/codegangsta/negroni v0.0.0-20140611175843-a13766a8c257
@@ -12,13 +13,13 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2
 	github.com/felixge/fgprof v0.9.1
 	github.com/fsouza/go-dockerclient v1.7.4
-	github.com/ghodss/yaml v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/gops v0.0.0-20180311052415-160b358b10d6
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v0.0.0-20180716215031-270f2f71b1ee
+	github.com/imdario/mergo v0.3.12
 	github.com/kr/pretty v0.3.0
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/mattn/go-shellwords v1.0.12
@@ -56,18 +57,7 @@ require (
 	k8s.io/code-generator v0.20.6
 	k8s.io/ingress-gce v1.20.1
 	k8s.io/metrics v0.20.6
-)
-
-require (
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
-	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc v1.0.4 // indirect
-	github.com/lestrrat-go/iter v1.0.2 // indirect
-	github.com/lestrrat-go/option v1.0.1 // indirect
-	github.com/segmentio/asm v1.2.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	sigs.k8s.io/yaml v1.2.0
 )
 
 require (
@@ -76,13 +66,13 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/Microsoft/hcsshim v0.9.2 // indirect
 	github.com/RobotsAndPencils/go-saml v0.0.0-20150922030833-aa127de49a01 // indirect
-	github.com/adhocore/gronx v1.1.2
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containerd/containerd v1.6.3-0.20220401172941-5ff8fce1fcc6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -93,6 +83,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -102,10 +93,14 @@ require (
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/howeyc/fsnotify v0.9.0 // indirect
-	github.com/imdario/mergo v0.3.12
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kardianos/osext v0.0.0-20151124170342-10da29423eb9 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
+	github.com/lestrrat-go/httpcc v1.0.1 // indirect
+	github.com/lestrrat-go/httprc v1.0.4 // indirect
+	github.com/lestrrat-go/iter v1.0.2 // indirect
+	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -121,6 +116,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
@@ -133,13 +129,13 @@ require (
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20201113003025-83324d819ded // indirect
 	k8s.io/klog/v2 v2.50.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -368,7 +368,6 @@ github.com/fsouza/go-dockerclient v1.7.4/go.mod h1:het+LPt7NaTEVGgwXJAKxPn77RZrQ
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/builder"
@@ -43,6 +42,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	backendConfigClientSet "k8s.io/ingress-gce/pkg/backendconfig/client/clientset/versioned"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+	"sigs.k8s.io/yaml"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
@@ -26,6 +25,7 @@ import (
 	provisionTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/validation"
 	apiv1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
 var (

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -910,7 +910,7 @@ func (s *S) TestGetAffinity(c *check.C) {
 			pool:     Pool{Name: "pool1", Labels: map[string]string{affinityKey: `invalid affinity`}},
 			assertion: func(testName string, c *check.C, affinity *apiv1.Affinity, err error) {
 				c.Assert(affinity, check.IsNil)
-				c.Assert(err, check.ErrorMatches, "error unmarshaling JSON: json: cannot unmarshal string into Go value of type v1.Affinity")
+				c.Assert(err, check.ErrorMatches, "error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.Affinity")
 			},
 		},
 		{


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer being actively maintained. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, while `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. You can see the changes between the two versions here: [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), which mostly consists of bug fixes.