### PR TITLE
Extract apikey permission to allow to disable apikey generation for some users

### DIFF
--- a/permission/permitems.go
+++ b/permission/permitems.go
@@ -9,6 +9,9 @@ package permission
 
 var (
 	PermAll                              = PermissionRegistry.get("")                                    // [global]
+	PermApikey                           = PermissionRegistry.get("apikey")                              // [global user]
+	PermApikeyRead                       = PermissionRegistry.get("apikey.read")                         // [global user]
+	PermApikeyUpdate                     = PermissionRegistry.get("apikey.update")                       // [global user]
 	PermApp                              = PermissionRegistry.get("app")                                 // [global app team pool]
 	PermAppAdmin                         = PermissionRegistry.get("app.admin")                           // [global app team pool]
 	PermAppAdminQuota                    = PermissionRegistry.get("app.admin.quota")                     // [global app team pool]
@@ -209,7 +212,6 @@ var (
 	PermUserUpdatePassword               = PermissionRegistry.get("user.update.password")                // [global user]
 	PermUserUpdateQuota                  = PermissionRegistry.get("user.update.quota")                   // [global user]
 	PermUserUpdateReset                  = PermissionRegistry.get("user.update.reset")                   // [global user]
-	PermUserUpdateToken                  = PermissionRegistry.get("user.update.token")                   // [global user]
 	PermVolume                           = PermissionRegistry.get("volume")                              // [global volume team pool]
 	PermVolumeCreate                     = PermissionRegistry.get("volume.create")                       // [global team pool]
 	PermVolumeDelete                     = PermissionRegistry.get("volume.delete")                       // [global volume team pool]

--- a/permission/permlist.go
+++ b/permission/permlist.go
@@ -98,10 +98,14 @@ var PermissionRegistry = (&registry{}).addWithCtx(
 	"user.delete",
 	"user.read.events",
 	"user.read.quota",
-	"user.update.token",
 	"user.update.quota",
 	"user.update.password",
 	"user.update.reset",
+).addWithCtx(
+	"apikey", []permTypes.ContextType{permTypes.CtxUser},
+).add(
+	"apikey.read",
+	"apikey.update",
 ).addWithCtx(
 	"service", []permTypes.ContextType{permTypes.CtxService, permTypes.CtxTeam},
 ).addWithCtx(


### PR DESCRIPTION
APIkey is two-edged sword, this feature allow users to fast and simple configure CI and allow to authenticate on tsuru when identity provider is down, in other hand it is a token without expiration, causing a insecure access.

to solve this problem, we could disable apikey for major users, via role we could add permission to only admins use that in case of downtime of identity provider.

users can continue using team tokens that is a better manner to auth on CI