### PR TITLE
revert: min units 0

### DIFF
--- a/provision/provision.go
+++ b/provision/provision.go
@@ -519,6 +519,9 @@ func (s AutoScaleSpec) ToCPUValue(a App) (int, error) {
 }
 
 func (s AutoScaleSpec) Validate(quotaLimit int, a App) error {
+	if s.MinUnits == 0 {
+		return errors.New("minimum units must be greater than 0")
+	}
 	if s.MaxUnits <= s.MinUnits {
 		return errors.New("maximum units must be greater than minimum units")
 	}

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -134,6 +134,13 @@ func (ProvisionSuite) TestValidate(c *check.C) {
 	}{
 		{
 			AutoScaleSpec{
+				MinUnits: 0,
+				MaxUnits: 10,
+			},
+			"minimum units must be greater than 0",
+		},
+		{
+			AutoScaleSpec{
 				MinUnits: 11,
 				MaxUnits: 10,
 			},


### PR DESCRIPTION
Autoscales uses deployment to check for a few informations, so allowing scaling a process to 0 currently makes you unable to change/delete that autoscale.