### PR TITLE
docs: Fix typo in Installing Tsuru in a local Kubernetes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,6 +61,7 @@ Guilherme Bruzzi <guibruzzi@gmail.com>
 Guilherme Garnier <guilherme.garnier@gmail.com>
 Guilherme Paixão <guiferpa@gmail.com>
 Guilherme Rezende <guilhermebr@gmail.com>
+Guilherme Vicentin <gvicentin@ciandt.com>
 Gustavo Henrique <gustavo@gustavohenrique.net>
 Hugo Seixas Antunes <hugo.santunes@gmail.com>
 Igor Fernandes <igor.fernandes@corp.globo.com>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,9 +254,8 @@ texinfo_documents = [
 # tsuru releases
 try:
     import releases
-except:
-    pass
-else:
     html_context = {
         'releases': releases.RELEASES,
     }
+except:
+    pass

--- a/docs/installing/installing-minikube.rst
+++ b/docs/installing/installing-minikube.rst
@@ -87,7 +87,7 @@ Add the localhost to tsuru target and log in:
 
 ::
 
-   $ tsuru target-add default https://localhost:8080 -s
+   $ tsuru target-add default http://localhost:8080 -s
    $ tsuru login
 
 Create one team:

--- a/docs/installing/installing-tsuru-components.rst
+++ b/docs/installing/installing-tsuru-components.rst
@@ -18,6 +18,5 @@ ride.
 
 .. toctree::
 
-    api
     adding-nodes
     dashboard

--- a/docs/releases/tsr/0.11.0.rst
+++ b/docs/releases/tsr/0.11.0.rst
@@ -165,8 +165,8 @@ Other improvements
       </using/quickstart>` page (thanks Felippe Raposo).
     - improve documentation for the :doc:`contributing </contributing/index>`
       page (thanks Lucas Weiblen).
-    - fix user creation instruction in the :doc:`installing
-      </installing/api>` page (thanks Samuel Roze).
+    - fix user creation instruction in the `installing` page 
+      (thanks Samuel Roze).
     - fix wording and spelling in the `Gandalf install` page
       (thanks Martin Jackson).
 

--- a/docs/releases/tsurud/0.13.0.rst
+++ b/docs/releases/tsurud/0.13.0.rst
@@ -119,9 +119,8 @@ Other improvements
 * Improvements in the installing and management docs, reflecting the daemon
   rename (thanks Giuseppe Ciotta).
 
-* Fix instructions on the :doc:`Hipache installing
-  </installing/hipache-router>` page so it doesn't use a deprecated
-  configuration flag (thanks Giuseppe Ciotta).
+* Fix instructions on the `Hipache installing` page so it doesn't use a 
+  deprecated configuration flag (thanks Giuseppe Ciotta).
 
 * Improve database connection management in the application locking procedure,
   avoiding database connections leakage.

--- a/docs/services/build.rst
+++ b/docs/services/build.rst
@@ -407,6 +407,8 @@ _`submit your service`: `Submitting your service API`_
 Submiting your service API
 ==========================
 
+.. _Submitting your service API:
+
 To submit your service, you can run:
 
 .. highlight:: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ Sphinx==1.7.4
 sphinx-rtd-theme==0.3.1
 sphinx-tabs==1.1.13
 tsuru-sphinx==0.1.5
+sphinxcontrib-httpdomain==1.8.0
 sphinxcontrib-openapi==0.3.2
 pyrsistent==0.16.0
+docutils==0.12


### PR DESCRIPTION
When following the doc **Installing Tsuru in a local Kubernetes cluster with Helm** there is an extra `s` in [Configuring Tsuru](https://docs.tsuru.io/main/installing/installing-minikube.html#configuring-tsuru) that will make `tsuru cli` not find the API.

In order to generate the docs for validation I had to do the following:
1. Create a virtual environment with Python 2.7
2. Pin a couple of Python's dependencies so Sphinx can start properly.
3. Move `releases RELEASES` to the try block for running locally without problems.
4. Fix some old reference targets in the docs