### PR TITLE
Drop TSURU_APP_TOKEN

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -1076,14 +1076,13 @@ func getAppEnv(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
-	if !t.IsAppToken() {
-		allowed := permission.Check(t, permission.PermAppReadEnv,
-			contextsForApp(&a)...,
-		)
-		if !allowed {
-			return permission.ErrUnauthorized
-		}
+	allowed := permission.Check(t, permission.PermAppReadEnv,
+		contextsForApp(&a)...,
+	)
+	if !allowed {
+		return permission.ErrUnauthorized
 	}
+
 	return writeEnvVars(w, &a, variables...)
 }
 
@@ -1765,14 +1764,13 @@ func addLog(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
-	if t.GetAppName() != app.InternalAppName {
-		allowed := permission.Check(t, permission.PermAppUpdateLog,
-			contextsForApp(a)...,
-		)
-		if !allowed {
-			return permission.ErrUnauthorized
-		}
+	allowed := permission.Check(t, permission.PermAppUpdateLog,
+		contextsForApp(a)...,
+	)
+	if !allowed {
+		return permission.ErrUnauthorized
 	}
+
 	logs, _ := InputValues(r, "message")
 	source := InputValue(r, "source")
 	if source == "" {

--- a/api/log.go
+++ b/api/log.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/api/context"
-	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
 	appTypes "github.com/tsuru/tsuru/types/app"
@@ -32,10 +31,6 @@ func addLogs(ws *websocket.Conn) {
 	t := context.GetAuthToken(req)
 	if t == nil {
 		err = errors.Errorf("wslogs: no token")
-		return
-	}
-	if t.GetAppName() != app.InternalAppName {
-		err = errors.Errorf("wslogs: invalid token app name: %q", t.GetAppName())
 		return
 	}
 	err = scanLogs(ws)

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -154,8 +154,6 @@ func (s *S) TestSetVersionHeadersMiddleware(c *check.C) {
 	setVersionHeadersMiddleware(recorder, request, h)
 	c.Assert(log.called, check.Equals, true)
 	c.Assert(recorder.Header().Get("Supported-Tsuru"), check.Equals, tsuruMin)
-	c.Assert(recorder.Header().Get("Supported-Crane"), check.Equals, craneMin)
-	c.Assert(recorder.Header().Get("Supported-Tsuru-Admin"), check.Equals, tsuruAdminMin)
 }
 
 func (s *S) TestErrorHandlingMiddlewareWithoutError(c *check.C) {
@@ -297,7 +295,6 @@ func (s *S) TestAuthTokenMiddlewareWithTeamToken(c *check.C) {
 	t := context.GetAuthToken(request)
 	c.Assert(t, check.NotNil)
 	c.Assert(t.GetValue(), check.Equals, token.Token)
-	c.Assert(t.GetAppName(), check.Equals, "")
 	mockSpan := span.(*mocktracer.MockSpan)
 	c.Check(mockSpan.Tag("user.name"), check.Equals, token.TokenID)
 	c.Check(mockSpan.Tag("app.name"), check.Equals, nil)

--- a/app/app.go
+++ b/app/app.go
@@ -89,11 +89,6 @@ func init() {
 }
 
 const (
-	// InternalAppName is a reserved name used for token generation. For
-	// backward compatibility and historical purpose, the value remained
-	// "tsr" when the name of the daemon changed to "tsurud".
-	InternalAppName = "tsr"
-
 	defaultAppDir = "/home/application/current"
 
 	routerNone = "none"
@@ -413,7 +408,6 @@ func CreateApp(ctx context.Context, app *App, user *auth.User) error {
 		&reserveTeamApp,
 		&reserveUserApp,
 		&insertApp,
-		&createAppToken,
 		&exportEnvironmentsAction,
 		&provisionApp,
 		&addRouterBackend,
@@ -811,11 +805,6 @@ func Delete(ctx context.Context, app *App, evt *event.Event, requestID string) e
 	if err != nil {
 		logErr("Unable to unbind volumes", err)
 	}
-	token := app.Env["TSURU_APP_TOKEN"].Value
-	err = auth.GetAppScheme().AppLogout(ctx, token)
-	if err != nil {
-		logErr("Unable to remove app token in destroy", err)
-	}
 	owner, err := auth.GetUserByEmail(app.Owner)
 	if err == nil {
 		err = servicemanager.UserQuota.Inc(ctx, owner, -1)
@@ -1168,7 +1157,7 @@ func (app *App) getEnv(name string) (bindTypes.EnvVar, error) {
 
 // validateNew checks app name format, pool and plan
 func (app *App) validateNew(ctx context.Context) error {
-	if app.Name == InternalAppName || !validation.ValidateName(app.Name) {
+	if !validation.ValidateName(app.Name) {
 		msg := "Invalid app name, your app should have at most 40 " +
 			"characters, containing only lower case letters, numbers or dashes, " +
 			"starting with a letter."

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2287,7 +2287,6 @@ func (s *S) TestIsValid(c *check.C) {
 		{"-myapp", s.team.Name, "pool1", "fake", "default-plan", errMsg},
 		{"my_app", s.team.Name, "pool1", "fake", "default-plan", errMsg},
 		{"b", s.team.Name, "pool1", "fake", "default-plan", ""},
-		{InternalAppName, s.team.Name, "pool1", "fake", "default-plan", errMsg},
 		{"myapp", "invalidteam", "pool1", "fake", "default-plan", "team not found"},
 		{"myapp", s.team.Name, "pool1", "faketls", "default-plan", "router \"faketls\" is not available for pool \"pool1\". Available routers are: \"fake, fake-hc, fake-tls, fake-v2\""},
 		{"myapp", "noaccessteam", "pool1", "fake", "default-plan", "App team owner \"noaccessteam\" has no access to pool \"pool1\""},

--- a/auth/api_token.go
+++ b/auth/api_token.go
@@ -27,16 +27,8 @@ func (t *APIToken) User() (*authTypes.User, error) {
 	return ConvertOldUser(GetUserByEmail(t.UserEmail))
 }
 
-func (t *APIToken) IsAppToken() bool {
-	return false
-}
-
 func (t *APIToken) GetUserName() string {
 	return t.UserEmail
-}
-
-func (t *APIToken) GetAppName() string {
-	return ""
 }
 
 func (t *APIToken) Engine() string {

--- a/auth/multi/multi_test.go
+++ b/auth/multi/multi_test.go
@@ -631,16 +631,8 @@ func (t fakeToken) User() (*authTypes.User, error) {
 	return &authTypes.User{}, nil
 }
 
-func (t fakeToken) IsAppToken() bool {
-	return false
-}
-
 func (t fakeToken) GetUserName() string {
 	return "faketoken"
-}
-
-func (t fakeToken) GetAppName() string {
-	return ""
 }
 
 func (t fakeToken) Engine() string {

--- a/auth/native/native.go
+++ b/auth/native/native.go
@@ -32,7 +32,6 @@ func init() {
 var (
 	_ auth.Scheme        = &NativeScheme{}
 	_ auth.UserScheme    = &NativeScheme{}
-	_ auth.AppScheme     = &NativeScheme{}
 	_ auth.ManagedScheme = &NativeScheme{}
 )
 
@@ -62,14 +61,6 @@ func (s NativeScheme) Auth(ctx context.Context, token string) (auth.Token, error
 
 func (s NativeScheme) Logout(ctx context.Context, token string) error {
 	return deleteToken(token)
-}
-
-func (s NativeScheme) AppLogin(ctx context.Context, appName string) (auth.Token, error) {
-	return createApplicationToken(appName)
-}
-
-func (s NativeScheme) AppLogout(ctx context.Context, token string) error {
-	return s.Logout(ctx, token)
 }
 
 func (s NativeScheme) Create(ctx context.Context, user *auth.User) (*auth.User, error) {

--- a/auth/native/native_test.go
+++ b/auth/native/native_test.go
@@ -41,9 +41,7 @@ func (s *S) TestNativeLogin(c *check.C) {
 	params["password"] = "123456"
 	token, err := scheme.Login(context.TODO(), params)
 	c.Assert(err, check.IsNil)
-	c.Assert(token.GetAppName(), check.Equals, "")
 	c.Assert(token.GetValue(), check.Not(check.Equals), "")
-	c.Assert(token.IsAppToken(), check.Equals, false)
 	u, err := token.User()
 	c.Assert(err, check.IsNil)
 	c.Assert(u.Email, check.Equals, "timeredbull@globo.com")
@@ -261,12 +259,4 @@ func (s *S) TestNativeRemove(c *check.C) {
 	c.Assert(tokens, check.HasLen, 0)
 	_, err = auth.GetUserByEmail("timeredbull@globo.com")
 	c.Assert(err, check.Equals, authTypes.ErrUserNotFound)
-}
-
-func (s *S) TestAppLogin(c *check.C) {
-	scheme := NativeScheme{}
-	token, err := scheme.AppLogin(context.TODO(), "myApp")
-	c.Assert(err, check.IsNil)
-	c.Assert(token.IsAppToken(), check.Equals, true)
-	c.Assert(token.GetAppName(), check.Equals, "myApp")
 }

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -47,7 +47,6 @@ func (s *S) TestOAuthLogin(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(token.GetValue(), check.Equals, "my_token")
 	c.Assert(token.GetUserName(), check.Equals, "rand@althor.com")
-	c.Assert(token.IsAppToken(), check.Equals, false)
 	u, err := token.User()
 	c.Assert(err, check.IsNil)
 	c.Assert(u.Email, check.Equals, "rand@althor.com")

--- a/auth/oauth/token.go
+++ b/auth/oauth/token.go
@@ -32,16 +32,8 @@ func (t *tokenWrapper) User() (*authTypes.User, error) {
 	return auth.ConvertOldUser(auth.GetUserByEmail(t.UserEmail))
 }
 
-func (t *tokenWrapper) IsAppToken() bool {
-	return false
-}
-
 func (t *tokenWrapper) GetUserName() string {
 	return t.UserEmail
-}
-
-func (t *tokenWrapper) GetAppName() string {
-	return ""
 }
 
 func (t *tokenWrapper) Engine() string {

--- a/auth/oidc/token.go
+++ b/auth/oidc/token.go
@@ -63,16 +63,8 @@ func (t *jwtToken) User() (*authTypes.User, error) {
 	return t.AuthUser, nil
 }
 
-func (t *jwtToken) IsAppToken() bool {
-	return false
-}
-
 func (t *jwtToken) GetUserName() string {
 	return t.AuthUser.Email
-}
-
-func (t *jwtToken) GetAppName() string {
-	return ""
 }
 
 func (t *jwtToken) Engine() string {

--- a/auth/peer/peer.go
+++ b/auth/peer/peer.go
@@ -43,16 +43,8 @@ func (t *Token) User() (*authTypes.User, error) {
 	return nil, errors.New("no token user")
 }
 
-func (t *Token) IsAppToken() bool {
-	return false
-}
-
 func (t *Token) GetUserName() string {
 	return "peer"
-}
-
-func (t *Token) GetAppName() string {
-	return ""
 }
 
 func (t *Token) Engine() string {

--- a/auth/scheme.go
+++ b/auth/scheme.go
@@ -29,12 +29,6 @@ type UserScheme interface {
 	Remove(ctx context.Context, user *User) error
 }
 
-type AppScheme interface {
-	UserScheme
-	AppLogin(ctx context.Context, appName string) (Token, error)
-	AppLogout(ctx context.Context, token string) error
-}
-
 type ManagedScheme interface {
 	UserScheme
 	StartPasswordReset(ctx context.Context, user *User) error
@@ -69,14 +63,4 @@ func GetScheme(name string) (Scheme, error) {
 		return nil, errors.Errorf("Unknown auth scheme: %q.", name)
 	}
 	return scheme, nil
-}
-
-func GetAppScheme() AppScheme {
-	scheme, err := GetScheme("native")
-
-	if err != nil {
-		panic("native scheme is not linked")
-	}
-
-	return scheme.(AppScheme)
 }

--- a/auth/team_token.go
+++ b/auth/team_token.go
@@ -51,20 +51,12 @@ func (t *teamToken) User() (*authTypes.User, error) {
 	}, nil
 }
 
-func (t *teamToken) IsAppToken() bool {
-	return false
-}
-
 func (t *teamToken) GetUserName() string {
 	return t.GetTokenName()
 }
 
 func (t *teamToken) GetTokenName() string {
 	return t.TokenID
-}
-
-func (t *teamToken) GetAppName() string {
-	return ""
 }
 
 func (t *teamToken) Engine() string {

--- a/auth/team_token_test.go
+++ b/auth/team_token_test.go
@@ -28,9 +28,7 @@ type userToken struct {
 func (t *userToken) GetValue() string {
 	return ""
 }
-func (t *userToken) GetAppName() string {
-	return ""
-}
+
 func (t *userToken) GetUserName() string {
 	return ""
 }
@@ -39,9 +37,6 @@ func (t *userToken) Engine() string {
 	return "user"
 }
 
-func (t *userToken) IsAppToken() bool {
-	return false
-}
 func (t *userToken) User() (*authTypes.User, error) {
 	return ConvertOldUser(t.user, nil)
 }
@@ -116,8 +111,6 @@ func (s *S) Test_TeamTokenService_Authenticate(c *check.C) {
 	t, err := servicemanager.TeamToken.Authenticate(context.TODO(), "bearer "+token.Token)
 	c.Assert(err, check.IsNil)
 	c.Assert(t.GetValue(), check.Equals, token.Token)
-	c.Assert(t.IsAppToken(), check.Equals, false)
-	c.Assert(t.GetAppName(), check.Equals, "")
 	c.Assert(t.GetUserName(), check.Equals, fmt.Sprintf("cobrateam-%s", token.Token[:5]))
 	namedToken, ok := t.(authTypes.NamedToken)
 	c.Assert(ok, check.Equals, true)

--- a/auth/token.go
+++ b/auth/token.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/permission"
 	authTypes "github.com/tsuru/tsuru/types/auth"
-	permTypes "github.com/tsuru/tsuru/types/permission"
 )
 
 // Token type alias exists to ease refactoring while we move auth types to
@@ -54,33 +53,6 @@ func ParseToken(header string) (string, error) {
 }
 
 func BaseTokenPermission(t Token) ([]permission.Permission, error) {
-	if t.IsAppToken() {
-		// TODO(cezarsa): Improve handling of app tokens. These permissions
-		// listed here are the ones required by deploy-agent and legacy tsuru-
-		// unit-agent.
-		return []permission.Permission{
-			{
-				Scheme:  permission.PermAppUpdateUnitRegister,
-				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
-			},
-			{
-				Scheme:  permission.PermAppUpdateLog,
-				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
-			},
-			{
-				Scheme:  permission.PermAppUpdateUnitStatus,
-				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
-			},
-			{
-				Scheme:  permission.PermAppReadDeploy,
-				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
-			},
-			{
-				Scheme:  permission.PermAppReadLog,
-				Context: permission.Context(permTypes.CtxApp, t.GetAppName()),
-			},
-		}, nil
-	}
 	u, err := ConvertNewUser(t.User())
 	if err != nil {
 		return nil, err

--- a/cmd/tsurud/command_test.go
+++ b/cmd/tsurud/command_test.go
@@ -39,22 +39,22 @@ func (s *S) TestTsrCommandFlagged(c *check.C) {
 	c.Assert(cmd.file.String(), check.Equals, "testdata/tsuru.conf")
 }
 
-func (s *S) TestTsrCommandNotFlagged(c *check.C) {
-	var originalCmd tokenCmd
-	cmd := tsurudCommand{Command: originalCmd}
-	flags := cmd.Flags()
-	err := flags.Parse(true, []string{"--config", "testdata/tsuru.conf"})
-	c.Assert(err, check.IsNil)
-	c.Assert(cmd.file.String(), check.Equals, "testdata/tsuru.conf")
-	cmd = tsurudCommand{Command: originalCmd}
-	flags.Parse(true, []string{"-c", "testdata/tsuru.conf"})
-	c.Assert(cmd.file.String(), check.Equals, "testdata/tsuru.conf")
-}
-
 type fakeCommand struct {
-	tokenCmd
 	name string
 	fs   *gnuflag.FlagSet
+}
+
+func (f *fakeCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "fake",
+		Usage:   "fake",
+		Desc:    `Fake`,
+		MinArgs: 1,
+	}
+}
+
+func (f *fakeCommand) Run(*cmd.Context) error {
+	return nil
 }
 
 func (f *fakeCommand) Flags() *gnuflag.FlagSet {

--- a/cmd/tsurud/main.go
+++ b/cmd/tsurud/main.go
@@ -24,7 +24,6 @@ var configPath = defaultConfigPath
 func buildManager() *cmd.Manager {
 	m := cmd.NewManager("tsurud", os.Stdout, os.Stderr, os.Stdin, nil)
 	m.Register(&tsurudCommand{Command: &apiCmd{}})
-	m.Register(&tsurudCommand{Command: tokenCmd{}})
 	m.Register(&tsurudCommand{Command: &migrateCmd{}})
 	m.Register(&tsurudCommand{Command: createRootUserCmd{}})
 	m.Register(&tsurudCommand{Command: &migrationListCmd{}})

--- a/cmd/tsurud/main_test.go
+++ b/cmd/tsurud/main_test.go
@@ -39,15 +39,6 @@ func (s *S) TestAPICmdIsRegistered(c *check.C) {
 	c.Assert(tsurudApi.Command, check.FitsTypeOf, &apiCmd{})
 }
 
-func (s *S) TestTokenCmdIsRegistered(c *check.C) {
-	manager := buildManager()
-	token, ok := manager.Commands["token"]
-	c.Assert(ok, check.Equals, true)
-	tsurudToken, ok := token.(*tsurudCommand)
-	c.Assert(ok, check.Equals, true)
-	c.Assert(tsurudToken.Command, check.FitsTypeOf, tokenCmd{})
-}
-
 func (s *S) TestMigrateCmdIsRegistered(c *check.C) {
 	manager := buildManager()
 	cmd, ok := manager.Commands["migrate"]

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -109,31 +109,3 @@ roles are properly created and assigned.`,
 		MinArgs: 1,
 	}
 }
-
-type tokenCmd struct{}
-
-func (tokenCmd) Run(context *cmd.Context) error {
-	scheme, err := config.GetString("auth:scheme")
-	if err != nil {
-		scheme = nativeSchemeName
-	}
-	app.AuthScheme, err = auth.GetScheme(scheme)
-	if err != nil {
-		return err
-	}
-	t, err := auth.GetAppScheme().AppLogin(stdContext.TODO(), app.InternalAppName)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(context.Stdout, t.GetValue())
-	return nil
-}
-
-func (tokenCmd) Info() *cmd.Info {
-	return &cmd.Info{
-		Name:    "token",
-		Usage:   "token",
-		Desc:    "Generates a tsuru token.",
-		MinArgs: 0,
-	}
-}

--- a/cmd/tsurud/token_test.go
+++ b/cmd/tsurud/token_test.go
@@ -14,33 +14,6 @@ import (
 	check "gopkg.in/check.v1"
 )
 
-func (s *S) TestTokenCmdInfo(c *check.C) {
-	expected := &cmd.Info{
-		Name:    "token",
-		Usage:   "token",
-		Desc:    "Generates a tsuru token.",
-		MinArgs: 0,
-	}
-	c.Assert(tokenCmd{}.Info(), check.DeepEquals, expected)
-}
-
-func (s *S) TestTokenCmdIsACommand(c *check.C) {
-	var _ cmd.Command = &tokenCmd{}
-}
-
-func (s *S) TestTokenRun(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	context := cmd.Context{
-		Args:   []string{},
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-	command := tokenCmd{}
-	err := command.Run(&context)
-	c.Assert(err, check.IsNil)
-	c.Assert(stdout.String(), check.Not(check.Equals), "")
-}
-
 func (s *S) TestCreateRootUserCmdInfo(c *check.C) {
 	c.Assert((&createRootUserCmd{}).Info(), check.NotNil)
 }

--- a/event/event.go
+++ b/event/event.go
@@ -911,9 +911,6 @@ func newEvtOnce(opts *Opts) (evt *Event, err error) {
 		if token, ok := opts.Owner.(authTypes.NamedToken); ok {
 			o.Type = OwnerTypeToken
 			o.Name = token.GetTokenName()
-		} else if opts.Owner.IsAppToken() {
-			o.Type = OwnerTypeApp
-			o.Name = opts.Owner.GetAppName()
 		} else {
 			o.Type = OwnerTypeUser
 			o.Name = opts.Owner.GetUserName()

--- a/types/auth/token.go
+++ b/types/auth/token.go
@@ -8,9 +8,7 @@ import "github.com/tsuru/tsuru/permission"
 
 type Token interface {
 	GetValue() string
-	GetAppName() string
 	GetUserName() string
-	IsAppToken() bool
 	User() (*User, error)
 	Engine() string
 	Permissions() ([]permission.Permission, error)


### PR DESCRIPTION
TSURU_APP_TOKEN were used before when containers of applications was responsible to report logs, status and query application's metadata via directly trough tsuru API. nowadays, after the surge of kubernetes, all these mechanisms is replaced by watchers that report cluster objects to TSURU API, after that all these kind of requests became unneeded. Removing this code in favor of tsuru API becomes more lean.