### PR TITLE
Migrate app package to types standard - part 1

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -179,26 +179,7 @@ func appDelete(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	return app.Delete(ctx, &a, evt, requestIDHeader(r))
 }
 
-// miniApp is a minimal representation of the app, created to make appList
-// faster and transmit less data.
-type miniApp struct {
-	Name        string               `json:"name"`
-	Pool        string               `json:"pool"`
-	TeamOwner   string               `json:"teamowner"`
-	Plan        appTypes.Plan        `json:"plan"`
-	Units       []provTypes.Unit     `json:"units"`
-	CName       []string             `json:"cname"`
-	IP          string               `json:"ip"`
-	Routers     []appTypes.AppRouter `json:"routers"`
-	Lock        appTypes.AppLock     `json:"lock"`
-	Tags        []string             `json:"tags"`
-	Error       string               `json:"error,omitempty"`
-	Platform    string               `json:"platform,omitempty"`
-	Description string               `json:"description,omitempty"`
-	Metadata    appTypes.Metadata    `json:"metadata,omitempty"`
-}
-
-func minifyApp(app app.App, unitData app.AppUnitsResponse, extended bool) (miniApp, error) {
+func minifyApp(app app.App, unitData app.AppUnitsResponse, extended bool) (appTypes.AppResume, error) {
 	var errorStr string
 	if unitData.Err != nil {
 		errorStr = unitData.Err.Error()
@@ -206,7 +187,7 @@ func minifyApp(app app.App, unitData app.AppUnitsResponse, extended bool) (miniA
 	if unitData.Units == nil {
 		unitData.Units = []provTypes.Unit{}
 	}
-	ma := miniApp{
+	ma := appTypes.AppResume{
 		Name:      app.Name,
 		Pool:      app.Pool,
 		Plan:      app.Plan,
@@ -304,7 +285,7 @@ func appList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	simple, _ := strconv.ParseBool(r.URL.Query().Get("simplified"))
 	extended, _ := strconv.ParseBool(r.URL.Query().Get("extended"))
 	w.Header().Set("Content-Type", "application/json")
-	miniApps := make([]miniApp, len(apps))
+	miniApps := make([]appTypes.AppResume, len(apps))
 	if simple {
 		for i, ap := range apps {
 			ur := app.AppUnitsResponse{Units: nil, Err: nil}

--- a/api/app.go
+++ b/api/app.go
@@ -348,8 +348,13 @@ func appInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if !canRead {
 		return permission.ErrUnauthorized
 	}
+
+	appInfo, err := app.AppInfo(&a)
+	if err != nil {
+		return err
+	}
 	w.Header().Set("Content-Type", "application/json")
-	return json.NewEncoder(w).Encode(&a)
+	return json.NewEncoder(w).Encode(&appInfo)
 }
 
 type inputApp struct {
@@ -542,7 +547,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	imageReset, _ := strconv.ParseBool(InputValue(r, "imageReset"))
 	updateData := app.App{
 		TeamOwner:      ia.TeamOwner,
-		Plan:           appTypes.Plan{Name: ia.Plan, Override: ia.PlanOverride},
+		Plan:           appTypes.Plan{Name: ia.Plan, Override: &ia.PlanOverride},
 		Pool:           ia.Pool,
 		Description:    ia.Description,
 		Router:         ia.Router,
@@ -574,7 +579,7 @@ func updateApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	if updateData.Plan.Name != "" {
 		wantedPerms = append(wantedPerms, permission.PermAppUpdatePlan)
 	}
-	if updateData.Plan.Override != (appTypes.PlanOverride{}) {
+	if updateData.Plan.Override != nil && *updateData.Plan.Override != (appTypes.PlanOverride{}) {
 		wantedPerms = append(wantedPerms, permission.PermAppUpdatePlanoverride)
 	}
 	if updateData.Pool != "" {

--- a/api/app.go
+++ b/api/app.go
@@ -39,6 +39,7 @@ import (
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	logTypes "github.com/tsuru/tsuru/types/log"
 	permTypes "github.com/tsuru/tsuru/types/permission"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	tagTypes "github.com/tsuru/tsuru/types/tag"
 )
@@ -185,7 +186,7 @@ type miniApp struct {
 	Pool        string               `json:"pool"`
 	TeamOwner   string               `json:"teamowner"`
 	Plan        appTypes.Plan        `json:"plan"`
-	Units       []provision.Unit     `json:"units"`
+	Units       []provTypes.Unit     `json:"units"`
 	CName       []string             `json:"cname"`
 	IP          string               `json:"ip"`
 	Routers     []appTypes.AppRouter `json:"routers"`
@@ -203,7 +204,7 @@ func minifyApp(app app.App, unitData app.AppUnitsResponse, extended bool) (miniA
 		errorStr = unitData.Err.Error()
 	}
 	if unitData.Units == nil {
-		unitData.Units = []provision.Unit{}
+		unitData.Units = []provTypes.Unit{}
 	}
 	ma := miniApp{
 		Name:      app.Name,

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/tsuru/tsuru/types/cache"
 	logTypes "github.com/tsuru/tsuru/types/log"
 	permTypes "github.com/tsuru/tsuru/types/permission"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	tagTypes "github.com/tsuru/tsuru/types/tag"
 	check "gopkg.in/check.v1"
@@ -675,14 +676,14 @@ func (s *S) TestAppListUnitsError(c *check.C) {
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
 	var apps []struct {
 		Name  string
-		Units []provision.Unit
+		Units []provTypes.Unit
 		Error string
 	}
 	err = json.Unmarshal(recorder.Body.Bytes(), &apps)
 	c.Assert(err, check.IsNil)
 	c.Assert(apps, check.HasLen, 1)
 	c.Assert(apps[0].Name, check.Equals, app1.Name)
-	c.Assert(apps[0].Units, check.DeepEquals, []provision.Unit{})
+	c.Assert(apps[0].Units, check.DeepEquals, []provTypes.Unit{})
 	c.Assert(apps[0].Error, check.Equals, "unable to list app units: some units error")
 }
 

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1812,6 +1812,7 @@ func (s *S) TestUpdateAppWithTagsOnly(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/x-json-stream")
+	c.Assert(recorder.Body.String(), check.Equals, "jaja")
 
 	var gotApp app.App
 	err = s.conn.Apps().Find(bson.M{"name": "myapp"}).One(&gotApp)

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -1812,7 +1812,6 @@ func (s *S) TestUpdateAppWithTagsOnly(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/x-json-stream")
-	c.Assert(recorder.Body.String(), check.Equals, "jaja")
 
 	var gotApp app.App
 	err = s.conn.Apps().Find(bson.M{"name": "myapp"}).One(&gotApp)

--- a/api/job.go
+++ b/api/job.go
@@ -223,7 +223,7 @@ func jobInfo(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		})
 	}
 
-	result := jobInfoResult{
+	result := jobTypes.JobInfo{
 		Job:                  j,
 		Units:                units,
 		ServiceInstanceBinds: binds,
@@ -298,14 +298,6 @@ func killJob(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}
 	return err
-}
-
-// TODO: after move of provision.Unit to types, leave this structure to types/job
-type jobInfoResult struct {
-	Cluster              string                          `json:"cluster,omitempty"`
-	Job                  *jobTypes.Job                   `json:"job,omitempty"`
-	Units                []provision.Unit                `json:"units,omitempty"`
-	ServiceInstanceBinds []bindTypes.ServiceInstanceBind `json:"serviceInstanceBinds,omitempty"`
 }
 
 // title: job update

--- a/api/job_test.go
+++ b/api/job_test.go
@@ -1209,7 +1209,7 @@ func (s *S) TestJobInfo(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var result jobInfoResult
+	var result jobTypes.JobInfo
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result.Cluster, check.Equals, "cluster1")

--- a/api/scale.go
+++ b/api/scale.go
@@ -10,6 +10,8 @@ import (
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
+
+	provTypes "github.com/tsuru/tsuru/types/provision"
 )
 
 // title: units autoscale info
@@ -66,7 +68,7 @@ func addAutoScaleUnits(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	var spec provision.AutoScaleSpec
+	var spec provTypes.AutoScaleSpec
 	err = ParseInput(r, &spec)
 	if err != nil {
 		return &errors.HTTP{
@@ -78,7 +80,7 @@ func addAutoScaleUnits(w http.ResponseWriter, r *http.Request, t auth.Token) (er
 	if err != nil {
 		return err
 	}
-	err = spec.Validate(quota.Limit, &a)
+	err = provision.ValidateAutoScaleSpec(&spec, quota.Limit, &a)
 	if err != nil {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,

--- a/api/scale_test.go
+++ b/api/scale_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	permTypes "github.com/tsuru/tsuru/types/permission"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	check "gopkg.in/check.v1"
 )
@@ -28,7 +29,7 @@ func (s *S) TestAutoScaleUnitsInfo(c *check.C) {
 	err := app.CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 
-	autoscaleSpec := provision.AutoScaleSpec{
+	autoscaleSpec := provTypes.AutoScaleSpec{
 		Process:    "p1",
 		AverageCPU: "300m",
 		MaxUnits:   10,
@@ -50,7 +51,7 @@ func (s *S) TestAutoScaleUnitsInfo(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
 
-	var autoscales []provision.AutoScaleSpec
+	var autoscales []provTypes.AutoScaleSpec
 	err = json.Unmarshal(recorder.Body.Bytes(), &autoscales)
 	c.Assert(err, check.IsNil)
 	c.Assert(autoscales, check.HasLen, 1)
@@ -89,7 +90,7 @@ func (s *S) TestAddAutoScaleUnits(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	spec, err := a.AutoScaleInfo()
 	c.Assert(err, check.IsNil)
-	c.Assert(spec, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(spec, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{Process: "p1", MinUnits: 2, MaxUnits: 10, AverageCPU: "600m"},
 	})
 	c.Assert(eventtest.EventDesc{
@@ -115,7 +116,7 @@ func (s *S) TestRemoveAutoScaleUnits(c *check.C) {
 	a := app.App{Name: "myapp", Platform: "zend", TeamOwner: s.team.Name}
 	err := app.CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
-	err = a.AutoScale(provision.AutoScaleSpec{
+	err = a.AutoScale(provTypes.AutoScaleSpec{
 		Process:    "p1",
 		AverageCPU: "300m",
 		MaxUnits:   10,

--- a/api/scale_test.go
+++ b/api/scale_test.go
@@ -83,6 +83,9 @@ func (s *S) TestAddAutoScaleUnits(c *check.C) {
 	request.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		c.Assert(recorder.Body.String(), check.Equals, "check err")
+	}
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	spec, err := a.AutoScaleInfo()
 	c.Assert(err, check.IsNil)

--- a/app/app.go
+++ b/app/app.go
@@ -2669,7 +2669,7 @@ buildResult:
 	return result
 }
 
-func (app *App) AutoScaleInfo() ([]provision.AutoScaleSpec, error) {
+func (app *App) AutoScaleInfo() ([]provTypes.AutoScaleSpec, error) {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return nil, err
@@ -2681,7 +2681,7 @@ func (app *App) AutoScaleInfo() ([]provision.AutoScaleSpec, error) {
 	return autoscaleProv.GetAutoScale(app.ctx, app)
 }
 
-func (app *App) VerticalAutoScaleRecommendations() ([]provision.RecommendedResources, error) {
+func (app *App) VerticalAutoScaleRecommendations() ([]provTypes.RecommendedResources, error) {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return nil, err
@@ -2705,7 +2705,7 @@ func (app *App) UnitsMetrics() ([]provTypes.UnitMetric, error) {
 	return metricsProv.UnitsMetrics(app.ctx, app)
 }
 
-func (app *App) AutoScale(spec provision.AutoScaleSpec) error {
+func (app *App) AutoScale(spec provTypes.AutoScaleSpec) error {
 	prov, err := app.getProvisioner()
 	if err != nil {
 		return err

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -43,6 +43,7 @@ import (
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	"github.com/tsuru/tsuru/types/cache"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	routerTypes "github.com/tsuru/tsuru/types/router"
 	volumeTypes "github.com/tsuru/tsuru/types/volume"
@@ -2165,7 +2166,7 @@ func (s *S) TestStop(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(units, check.HasLen, 2)
 	for _, u := range units {
-		c.Assert(u.Status, check.Equals, provision.StatusStopped)
+		c.Assert(u.Status, check.Equals, provTypes.UnitStatusStopped)
 	}
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2319,14 +2319,6 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 		TeamOwner:   "myteam",
 		Routers:     []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{"opt1": "val1"}}},
 		Tags:        []string{"tag a", "tag b"},
-		InternalAddresses: []provision.AppInternalAddress{
-			{
-				Domain:   "name-web.cluster.local",
-				Protocol: "TCP",
-				Port:     4000,
-				Process:  "web",
-			},
-		},
 	}
 	err = CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
@@ -2382,12 +2374,34 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 		"ip": "name.fakerouter.com",
 		"internalAddresses": []interface{}{
 			map[string]interface{}{
-				"Domain":   "name-web.cluster.local",
+				"Domain":   "name-web.fake-cluster.local",
 				"Protocol": "TCP",
-				"Port":     float64(4000),
+				"Port":     float64(80),
 				"Process":  "web",
 				"Version":  "",
-			}},
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs.fake-cluster.local",
+				"Protocol": "UDP",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs-v2.fake-cluster.local",
+				"Protocol": "UDP",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Version":  "2",
+			},
+			map[string]interface{}{
+				"Domain":   "name-web-v2.fake-cluster.local",
+				"Protocol": "TCP",
+				"Port":     float64(80),
+				"Process":  "web",
+				"Version":  "2",
+			},
+		},
 		"provisioner": "fake",
 		"cname":       []interface{}{"name.mycompany.com"},
 		"owner":       s.user.Email,
@@ -2469,14 +2483,6 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 		TeamOwner:   "myteam",
 		Routers:     []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{"opt1": "val1"}}},
 		Tags:        []string{"tag a", "tag b"},
-		InternalAddresses: []provision.AppInternalAddress{
-			{
-				Domain:   "name-web.cluster.local",
-				Protocol: "TCP",
-				Port:     4000,
-				Process:  "web",
-			},
-		},
 	}
 	err = app.AutoScale(provision.AutoScaleSpec{Process: "p1"})
 	c.Assert(err, check.IsNil)
@@ -2490,12 +2496,34 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 		"ip":       "name.fakerouter.com",
 		"internalAddresses": []interface{}{
 			map[string]interface{}{
-				"Domain":   "name-web.cluster.local",
-				"Protocol": "TCP",
-				"Port":     float64(4000),
-				"Version":  "",
+				"Domain":   "name-web.fake-cluster.local",
+				"Port":     float64(80),
 				"Process":  "web",
-			}},
+				"Protocol": "TCP",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs-v2.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "2",
+			},
+			map[string]interface{}{
+				"Domain":   "name-web-v2.fake-cluster.local",
+				"Port":     float64(80),
+				"Process":  "web",
+				"Protocol": "TCP",
+				"Version":  "2",
+			},
+		},
 		"provisioner": "fake",
 		"cname":       []interface{}{"name.mycompany.com"},
 		"owner":       "appOwner",
@@ -2560,14 +2588,6 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 	app := App{
 		Name:    "name",
 		Routers: []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{}}},
-		InternalAddresses: []provision.AppInternalAddress{
-			{
-				Domain:   "name-web.cluster.local",
-				Protocol: "TCP",
-				Port:     4000,
-				Process:  "web",
-			},
-		},
 	}
 	err := routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
@@ -2615,12 +2635,34 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 		},
 		"internalAddresses": []interface{}{
 			map[string]interface{}{
-				"Domain":   "name-web.cluster.local",
-				"Protocol": "TCP",
-				"Port":     float64(4000),
+				"Domain":   "name-web.fake-cluster.local",
+				"Port":     float64(80),
 				"Process":  "web",
+				"Protocol": "TCP",
 				"Version":  "",
-			}},
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs-v2.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "2",
+			},
+			map[string]interface{}{
+				"Domain":   "name-web-v2.fake-cluster.local",
+				"Port":     float64(80),
+				"Process":  "web",
+				"Protocol": "TCP",
+				"Version":  "2",
+			},
+		},
 		"serviceInstanceBinds": []interface{}{},
 	}
 	appInfo, err := AppInfo(&app)
@@ -2654,14 +2696,6 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 		Routers:         []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{"opt1": "val1"}}},
 		Tags:            []string{"tag a", "tag b"},
 		Metadata:        appTypes.Metadata{Labels: []appTypes.MetadataItem{{Name: "label", Value: "value"}}},
-		InternalAddresses: []provision.AppInternalAddress{
-			{
-				Domain:   "name-web.cluster.local",
-				Protocol: "TCP",
-				Port:     4000,
-				Process:  "web",
-			},
-		},
 	}
 	err = routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
@@ -2710,12 +2744,34 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 		"serviceInstanceBinds": []interface{}{},
 		"internalAddresses": []interface{}{
 			map[string]interface{}{
-				"Domain":   "name-web.cluster.local",
-				"Protocol": "TCP",
-				"Port":     float64(4000),
+				"Domain":   "name-web.fake-cluster.local",
+				"Port":     float64(80),
 				"Process":  "web",
+				"Protocol": "TCP",
 				"Version":  "",
-			}},
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "name-logs-v2.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "2",
+			},
+			map[string]interface{}{
+				"Domain":   "name-web-v2.fake-cluster.local",
+				"Port":     float64(80),
+				"Process":  "web",
+				"Protocol": "TCP",
+				"Version":  "2",
+			},
+		},
 	}
 	appInfo, err := AppInfo(&app)
 	c.Assert(err, check.IsNil)
@@ -2743,14 +2799,6 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 		Plan:            appTypes.Plan{Name: "small", CPUMilli: 1000, Memory: 128},
 		TeamOwner:       "team-one",
 		Routers:         []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{"opt1": "val1"}}},
-		InternalAddresses: []provision.AppInternalAddress{
-			{
-				Domain:   "name-web.cluster.local",
-				Protocol: "TCP",
-				Port:     4000,
-				Process:  "web",
-			},
-		},
 	}
 	err = routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
@@ -2809,12 +2857,34 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 		"serviceInstanceBinds": []interface{}{},
 		"internalAddresses": []interface{}{
 			map[string]interface{}{
-				"Domain":   "name-web.cluster.local",
-				"Protocol": "TCP",
-				"Port":     float64(4000),
+				"Domain":   "my-awesome-app-web.fake-cluster.local",
+				"Port":     float64(80),
 				"Process":  "web",
+				"Protocol": "TCP",
 				"Version":  "",
-			}},
+			},
+			map[string]interface{}{
+				"Domain":   "my-awesome-app-logs.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "",
+			},
+			map[string]interface{}{
+				"Domain":   "my-awesome-app-logs-v2.fake-cluster.local",
+				"Port":     float64(12201),
+				"Process":  "logs",
+				"Protocol": "UDP",
+				"Version":  "2",
+			},
+			map[string]interface{}{
+				"Domain":   "my-awesome-app-web-v2.fake-cluster.local",
+				"Port":     float64(80),
+				"Process":  "web",
+				"Protocol": "TCP",
+				"Version":  "2",
+			},
+		},
 	})
 
 }
@@ -3461,7 +3531,8 @@ func (s *S) TestListUsesCachedRouterAddrs(c *check.C) {
 			Routers: []appTypes.AppRouter{
 				{Name: "fake", Opts: map[string]string{}},
 			},
-			Quota: quota.UnlimitedQuota,
+			Processes: []appTypes.Process{},
+			Quota:     quota.UnlimitedQuota,
 		},
 		{
 			Name:      "app2",
@@ -3489,7 +3560,8 @@ func (s *S) TestListUsesCachedRouterAddrs(c *check.C) {
 			Routers: []appTypes.AppRouter{
 				{Name: "fake", Opts: map[string]string{}},
 			},
-			Quota: quota.UnlimitedQuota,
+			Processes: []appTypes.Process{},
+			Quota:     quota.UnlimitedQuota,
 		},
 	})
 	s.mockService.Cache.OnList = func(keys ...string) ([]cache.CacheEntry, error) {
@@ -3522,6 +3594,7 @@ func (s *S) TestListUsesCachedRouterAddrsWithLegacyRouter(c *check.C) {
 		TeamOwner: s.team.Name,
 		Teams:     []string{s.team.Name},
 		Router:    "fake",
+		ctx:       context.TODO(),
 	}
 	err := s.conn.Apps().Insert(a)
 	c.Assert(err, check.IsNil)
@@ -3545,6 +3618,7 @@ func (s *S) TestListUsesCachedRouterAddrsWithLegacyRouter(c *check.C) {
 				Labels:      []appTypes.MetadataItem{},
 				Annotations: []appTypes.MetadataItem{},
 			},
+			Processes: []appTypes.Process{},
 			Routers: []appTypes.AppRouter{
 				{Name: "fake", Opts: map[string]string{}},
 			},
@@ -5715,31 +5789,33 @@ func (s *S) TestGetUUID(c *check.C) {
 	c.Assert(storedApp.UUID, check.DeepEquals, uuid)
 }
 
-func (s *S) TestFillInternalAddresses(c *check.C) {
+func (s *S) TestInternalAddresses(c *check.C) {
 	app := App{Name: "test", TeamOwner: s.team.Name, Pool: s.Pool}
-	err := app.fillInternalAddresses()
+
+	addresses, err := internalAddresses(&app)
 	c.Assert(err, check.IsNil)
-	c.Assert(app.InternalAddresses, check.HasLen, 4)
-	c.Assert(app.InternalAddresses[0], check.DeepEquals, provision.AppInternalAddress{
+
+	c.Assert(addresses, check.HasLen, 4)
+	c.Assert(addresses[0], check.DeepEquals, appTypes.AppInternalAddress{
 		Domain:   "test-web.fake-cluster.local",
 		Protocol: "TCP",
 		Process:  "web",
 		Port:     80,
 	})
-	c.Assert(app.InternalAddresses[1], check.DeepEquals, provision.AppInternalAddress{
+	c.Assert(addresses[1], check.DeepEquals, appTypes.AppInternalAddress{
 		Domain:   "test-logs.fake-cluster.local",
 		Protocol: "UDP",
 		Process:  "logs",
 		Port:     12201,
 	})
-	c.Assert(app.InternalAddresses[2], check.DeepEquals, provision.AppInternalAddress{
+	c.Assert(addresses[2], check.DeepEquals, appTypes.AppInternalAddress{
 		Domain:   "test-logs-v2.fake-cluster.local",
 		Protocol: "UDP",
 		Process:  "logs",
 		Version:  "2",
 		Port:     12201,
 	})
-	c.Assert(app.InternalAddresses[3], check.DeepEquals, provision.AppInternalAddress{
+	c.Assert(addresses[3], check.DeepEquals, appTypes.AppInternalAddress{
 		Domain:   "test-web-v2.fake-cluster.local",
 		Protocol: "TCP",
 		Process:  "web",
@@ -5794,8 +5870,9 @@ func (s *S) TestAutoscaleWithAutoscaleProvisioner(c *check.C) {
 	oldProvisioner := provision.DefaultProvisioner
 	defer func() { provision.DefaultProvisioner = oldProvisioner }()
 	provision.DefaultProvisioner = "autoscaleProv"
+	autoScaleProv := &provisiontest.AutoScaleProvisioner{FakeProvisioner: provisiontest.ProvisionerInstance}
 	provision.Register("autoscaleProv", func() (provision.Provisioner, error) {
-		return &provisiontest.AutoScaleProvisioner{FakeProvisioner: provisiontest.ProvisionerInstance}, nil
+		return autoScaleProv, nil
 	})
 	defer provision.Unregister("autoscaleProv")
 	a := App{Name: "my-test-app", TeamOwner: s.team.Name}
@@ -5819,7 +5896,7 @@ func (s *S) TestAutoscaleWithAutoscaleProvisioner(c *check.C) {
 }
 
 func (s *S) TestGetInternalBindableAddresses(c *check.C) {
-	app := App{Name: "myapp", Platform: "go", TeamOwner: s.team.Name, provisioner: s.provisioner}
+	app := App{Name: "myapp", Platform: "go", TeamOwner: s.team.Name}
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
 	addresses, err := app.GetInternalBindableAddresses()

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2485,7 +2485,7 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 		Routers:     []appTypes.AppRouter{{Name: "fake", Opts: map[string]string{"opt1": "val1"}}},
 		Tags:        []string{"tag a", "tag b"},
 	}
-	err = app.AutoScale(provision.AutoScaleSpec{Process: "p1"})
+	err = app.AutoScale(provTypes.AutoScaleSpec{Process: "p1"})
 	c.Assert(err, check.IsNil)
 	err = routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
@@ -4065,7 +4065,7 @@ func (s *S) TestAppUnitsWithAutoscaler(c *check.C) {
 	err := CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 
-	err = provisioner.SetAutoScale(context.TODO(), &a, provision.AutoScaleSpec{
+	err = provisioner.SetAutoScale(context.TODO(), &a, provTypes.AutoScaleSpec{
 		Process:    "web",
 		Version:    1,
 		MinUnits:   1,
@@ -5877,13 +5877,13 @@ func (s *S) TestAutoscaleWithAutoscaleProvisioner(c *check.C) {
 	})
 	defer provision.Unregister("autoscaleProv")
 	a := App{Name: "my-test-app", TeamOwner: s.team.Name}
-	err := a.AutoScale(provision.AutoScaleSpec{Process: "p1"})
+	err := a.AutoScale(provTypes.AutoScaleSpec{Process: "p1"})
 	c.Assert(err, check.IsNil)
-	err = a.AutoScale(provision.AutoScaleSpec{Process: "p2"})
+	err = a.AutoScale(provTypes.AutoScaleSpec{Process: "p2"})
 	c.Assert(err, check.IsNil)
 	scales, err := a.AutoScaleInfo()
 	c.Assert(err, check.IsNil)
-	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(scales, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{Process: "p1"},
 		{Process: "p2"},
 	})
@@ -5891,7 +5891,7 @@ func (s *S) TestAutoscaleWithAutoscaleProvisioner(c *check.C) {
 	c.Assert(err, check.IsNil)
 	scales, err = a.AutoScaleInfo()
 	c.Assert(err, check.IsNil)
-	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(scales, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{Process: "p2"},
 	})
 }

--- a/job/job.go
+++ b/job/job.go
@@ -30,7 +30,7 @@ import (
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	jobTypes "github.com/tsuru/tsuru/types/job"
-	provisionTypes "github.com/tsuru/tsuru/types/provision"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -52,10 +52,10 @@ func getProvisioner(ctx context.Context, job *jobTypes.Job) (provision.JobProvis
 }
 
 // Units returns the list of units.
-func Units(ctx context.Context, job *jobTypes.Job) ([]provision.Unit, error) {
+func Units(ctx context.Context, job *jobTypes.Job) ([]provTypes.Unit, error) {
 	prov, err := getProvisioner(ctx, job)
 	if err != nil {
-		return []provision.Unit{}, err
+		return []provTypes.Unit{}, err
 	}
 	return prov.JobUnits(context.TODO(), job)
 }
@@ -203,7 +203,7 @@ func ensureDeployOptions(j *jobTypes.Job) error {
 	// TODO: remove this when we remove the old deploy kind from the client side
 	if j.Spec.Container.OriginalImageSrc != "" {
 		j.DeployOptions = &jobTypes.DeployOptions{
-			Kind:  provisionTypes.DeployImage,
+			Kind:  provTypes.DeployImage,
 			Image: j.Spec.Container.OriginalImageSrc,
 		}
 		return nil

--- a/provision/kubernetes/autoscale_test.go
+++ b/provision/kubernetes/autoscale_test.go
@@ -13,8 +13,8 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kr/pretty"
 	"github.com/tsuru/config"
-	"github.com/tsuru/tsuru/provision"
 	appTypes "github.com/tsuru/tsuru/types/app"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -97,7 +97,7 @@ func testHPAWithTarget(tg autoscalingv2.MetricTarget) *autoscalingv2.HorizontalP
 	}
 }
 
-func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs []provision.AutoScaleSchedule, prometheusSpecs []provision.AutoScalePrometheus, ns string) *kedav1alpha1.ScaledObject {
+func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs []provTypes.AutoScaleSchedule, prometheusSpecs []provTypes.AutoScalePrometheus, ns string) *kedav1alpha1.ScaledObject {
 	triggers := []kedav1alpha1.ScaleTriggers{}
 
 	if cpuTrigger != nil {
@@ -236,7 +236,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 	}{
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -250,7 +250,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50%",
@@ -264,7 +264,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50",
@@ -280,7 +280,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 			scenario: func() {
 				a.MilliCPU = 700
 				defer func() { a.MilliCPU = 0 }()
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -296,7 +296,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 			scenario: func() {
 				a.MilliCPU = 700
 				defer func() { a.MilliCPU = 0 }()
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50%",
@@ -312,7 +312,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 			scenario: func() {
 				a.MilliCPU = 700
 				defer func() { a.MilliCPU = 0 }()
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50",
@@ -349,7 +349,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	schedulesList := []provision.AutoScaleSchedule{
+	schedulesList := []provTypes.AutoScaleSchedule{
 		{
 			MinReplicas: 2,
 			Start:       "0 6 * * *",
@@ -373,11 +373,11 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 	tests := []struct {
 		scenario      func()
 		cpuTrigger    *kedav1alpha1.ScaleTriggers
-		scheduleSpecs []provision.AutoScaleSchedule
+		scheduleSpecs []provTypes.AutoScaleSchedule
 	}{
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -396,7 +396,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50%",
@@ -415,7 +415,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50",
@@ -435,7 +435,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 		{
 			scenario: func() {
 				a.MilliCPU = 700
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -454,7 +454,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:  1,
 					MaxUnits:  2,
 					Schedules: schedulesList[:1],
@@ -472,7 +472,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 		c.Assert(err, check.IsNil)
 		scaledObject, err := s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Get(context.TODO(), "myapp-web", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
-		expected := testKEDAScaledObject(tt.cpuTrigger, tt.scheduleSpecs, []provision.AutoScalePrometheus{}, "default")
+		expected := testKEDAScaledObject(tt.cpuTrigger, tt.scheduleSpecs, []provTypes.AutoScalePrometheus{}, "default")
 		c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
 	}
 }
@@ -493,7 +493,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	prometheusList := []provision.AutoScalePrometheus{
+	prometheusList := []provTypes.AutoScalePrometheus{
 		{
 			Name:      "prometheus_metric_1",
 			Query:     "some_query_1",
@@ -516,11 +516,11 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 	tests := []struct {
 		scenario        func()
 		cpuTrigger      *kedav1alpha1.ScaleTriggers
-		prometheusSpecs []provision.AutoScalePrometheus
+		prometheusSpecs []provTypes.AutoScalePrometheus
 	}{
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -539,7 +539,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50%",
@@ -558,7 +558,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "50",
@@ -578,7 +578,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 		{
 			scenario: func() {
 				a.MilliCPU = 700
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					AverageCPU: "500m",
@@ -597,7 +597,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 		},
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					Prometheus: prometheusList[:1],
@@ -615,7 +615,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 		c.Assert(err, check.IsNil)
 		scaledObject, err := s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Get(context.TODO(), "myapp-web", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
-		expected := testKEDAScaledObject(tt.cpuTrigger, []provision.AutoScaleSchedule{}, tt.prometheusSpecs, "default")
+		expected := testKEDAScaledObject(tt.cpuTrigger, []provTypes.AutoScaleSchedule{}, tt.prometheusSpecs, "default")
 		c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
 	}
 }
@@ -633,7 +633,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScaleWithoutTemplateConfig(c *ch
 	c.Assert(err, check.IsNil)
 	wait()
 
-	prometheusList := []provision.AutoScalePrometheus{
+	prometheusList := []provTypes.AutoScalePrometheus{
 		{
 			Name:              "prometheus_metric_1",
 			Query:             "some_query_1",
@@ -649,12 +649,12 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScaleWithoutTemplateConfig(c *ch
 
 	tests := []struct {
 		scenario        func()
-		prometheusSpecs []provision.AutoScalePrometheus
+		prometheusSpecs []provTypes.AutoScalePrometheus
 		assertion       func(error, *kedav1alpha1.ScaledObject)
 	}{
 		{
 			scenario: func() {
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					Prometheus: prometheusList[:1],
@@ -664,14 +664,14 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScaleWithoutTemplateConfig(c *ch
 			prometheusSpecs: prometheusList[:1],
 			assertion: func(err error, scaledObject *kedav1alpha1.ScaledObject) {
 				c.Assert(err, check.IsNil)
-				expected := testKEDAScaledObject(nil, []provision.AutoScaleSchedule{}, prometheusList[:1], "default")
+				expected := testKEDAScaledObject(nil, []provTypes.AutoScaleSchedule{}, prometheusList[:1], "default")
 				c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
 			},
 		},
 		{
 			scenario: func() {
 				config.Unset("kubernetes:keda:prometheus-address-template")
-				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+				err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 					MinUnits:   1,
 					MaxUnits:   2,
 					Prometheus: prometheusList[1:],
@@ -713,7 +713,7 @@ func (s *S) TestProvisionerSetAutoScaleMultipleVersions(c *check.C) {
 	err := s.p.AddUnits(context.TODO(), a, 1, "web", versions[0], nil)
 	c.Assert(err, check.IsNil)
 	wait()
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   1,
 		MaxUnits:   2,
 		AverageCPU: "500m",
@@ -823,11 +823,11 @@ func (s *S) TestProvisionerSetKEDAAutoScaleMultipleVersions(c *check.C) {
 	err := s.p.AddUnits(context.TODO(), a, 1, "web", versions[0], nil)
 	c.Assert(err, check.IsNil)
 	wait()
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   1,
 		MaxUnits:   2,
 		AverageCPU: "500m",
-		Schedules: []provision.AutoScaleSchedule{
+		Schedules: []provTypes.AutoScaleSchedule{
 			{
 				MinReplicas: 2,
 				Start:       "0 6 * * *",
@@ -835,7 +835,7 @@ func (s *S) TestProvisionerSetKEDAAutoScaleMultipleVersions(c *check.C) {
 				Timezone:    "UTC",
 			},
 		},
-		Prometheus: []provision.AutoScalePrometheus{
+		Prometheus: []provTypes.AutoScalePrometheus{
 			{
 				Name:              "prometheus_metric",
 				Query:             "sum(some_metric{app='app_test'})",
@@ -946,7 +946,7 @@ func (s *S) TestProvisionerRemoveAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   5,
 		MaxUnits:   20,
 		AverageCPU: "500m",
@@ -1024,11 +1024,11 @@ func (s *S) TestProvisionerRemoveKEDAAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   5,
 		MaxUnits:   20,
 		AverageCPU: "500m",
-		Schedules: []provision.AutoScaleSchedule{
+		Schedules: []provTypes.AutoScaleSchedule{
 			{
 				MinReplicas: 2,
 				Start:       "0 6 * * *",
@@ -1036,7 +1036,7 @@ func (s *S) TestProvisionerRemoveKEDAAutoScale(c *check.C) {
 				Timezone:    "UTC",
 			},
 		},
-		Prometheus: []provision.AutoScalePrometheus{
+		Prometheus: []provTypes.AutoScalePrometheus{
 			{
 				Name:              "prometheus_metric",
 				Query:             "sum(some_metric{app='app_test'})",
@@ -1074,7 +1074,7 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   1,
 		MaxUnits:   2,
 		AverageCPU: "500m",
@@ -1082,7 +1082,7 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   2,
 		MaxUnits:   4,
 		AverageCPU: "200m",
@@ -1095,7 +1095,7 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 	sort.Slice(scales, func(i, j int) bool {
 		return scales[i].Process < scales[j].Process
 	})
-	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(scales, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{
 			MinUnits:   1,
 			MaxUnits:   2,
@@ -1129,12 +1129,12 @@ func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   1,
 		MaxUnits:   2,
 		AverageCPU: "500m",
 		Process:    "web",
-		Schedules: []provision.AutoScaleSchedule{
+		Schedules: []provTypes.AutoScaleSchedule{
 			{
 				MinReplicas: 2,
 				Start:       "0 6 * * *",
@@ -1145,12 +1145,12 @@ func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   2,
 		MaxUnits:   4,
 		AverageCPU: "200m",
 		Process:    "worker",
-		Schedules: []provision.AutoScaleSchedule{
+		Schedules: []provTypes.AutoScaleSchedule{
 			{
 				MinReplicas: 4,
 				Start:       "0 12 * * *",
@@ -1175,14 +1175,14 @@ func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 	sort.Slice(scales, func(i, j int) bool {
 		return scales[i].Process < scales[j].Process
 	})
-	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(scales, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{
 			MinUnits:   1,
 			MaxUnits:   2,
 			AverageCPU: "500m",
 			Version:    1,
 			Process:    "web",
-			Schedules: []provision.AutoScaleSchedule{
+			Schedules: []provTypes.AutoScaleSchedule{
 				{
 					MinReplicas: 2,
 					Start:       "0 6 * * *",
@@ -1197,7 +1197,7 @@ func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 			AverageCPU: "200m",
 			Version:    1,
 			Process:    "worker",
-			Schedules: []provision.AutoScaleSchedule{
+			Schedules: []provTypes.AutoScaleSchedule{
 				{
 					MinReplicas: 4,
 					Start:       "0 12 * * *",
@@ -1229,12 +1229,12 @@ func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   1,
 		MaxUnits:   2,
 		AverageCPU: "500m",
 		Process:    "web",
-		Prometheus: []provision.AutoScalePrometheus{
+		Prometheus: []provTypes.AutoScalePrometheus{
 			{
 				Name:              "prometheus_metric_1",
 				Query:             "some_query_1",
@@ -1245,12 +1245,12 @@ func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
 		MinUnits:   2,
 		MaxUnits:   4,
 		AverageCPU: "200m",
 		Process:    "worker",
-		Prometheus: []provision.AutoScalePrometheus{
+		Prometheus: []provTypes.AutoScalePrometheus{
 			{
 				Name:      "prometheus_metric_2",
 				Query:     "some_query_2",
@@ -1280,14 +1280,14 @@ func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
 	sort.Slice(scales, func(i, j int) bool {
 		return scales[i].Process < scales[j].Process
 	})
-	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+	c.Assert(scales, check.DeepEquals, []provTypes.AutoScaleSpec{
 		{
 			MinUnits:   1,
 			MaxUnits:   2,
 			AverageCPU: "500m",
 			Version:    1,
 			Process:    "web",
-			Prometheus: []provision.AutoScalePrometheus{
+			Prometheus: []provTypes.AutoScalePrometheus{
 				{
 					Name:              "prometheus_metric_1",
 					Query:             "some_query_1",
@@ -1302,7 +1302,7 @@ func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
 			AverageCPU: "200m",
 			Version:    1,
 			Process:    "worker",
-			Prometheus: []provision.AutoScalePrometheus{
+			Prometheus: []provTypes.AutoScalePrometheus{
 				{
 					Name:              "prometheus_metric_2",
 					Query:             "some_query_2",
@@ -1479,10 +1479,10 @@ func (s *S) TestGetVerticalAutoScaleRecommendations(c *check.C) {
 
 	rec, err = s.p.GetVerticalAutoScaleRecommendations(context.TODO(), a)
 	c.Assert(err, check.IsNil)
-	c.Assert(rec, check.DeepEquals, []provision.RecommendedResources{
+	c.Assert(rec, check.DeepEquals, []provTypes.RecommendedResources{
 		{
 			Process: "web",
-			Recommendations: []provision.RecommendedProcessResources{
+			Recommendations: []provTypes.RecommendedProcessResources{
 				{Type: "target", CPU: "100m", Memory: "99Mi"},
 				{Type: "uncappedTarget", CPU: "101m", Memory: "98Mi"},
 				{Type: "lowerBound", CPU: "102m", Memory: "97Mi"},

--- a/provision/kubernetes/metrics.go
+++ b/provision/kubernetes/metrics.go
@@ -11,9 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	provTypes "github.com/tsuru/tsuru/types/provision"
 )
 
-func (p *kubernetesProvisioner) UnitsMetrics(ctx context.Context, a provision.App) ([]provision.UnitMetric, error) {
+func (p *kubernetesProvisioner) UnitsMetrics(ctx context.Context, a provision.App) ([]provTypes.UnitMetric, error) {
 	clusterClient, err := clusterForPool(ctx, a.GetPool())
 	if err != nil {
 		return nil, err
@@ -44,7 +46,7 @@ func (p *kubernetesProvisioner) UnitsMetrics(ctx context.Context, a provision.Ap
 		return nil, err
 	}
 
-	unitMetrics := []provision.UnitMetric{}
+	unitMetrics := []provTypes.UnitMetric{}
 	for _, metric := range metricList.Items {
 		totalCPUUsage := resource.NewQuantity(0, resource.DecimalSI)
 		totalMemoryUsage := resource.NewQuantity(0, resource.BinarySI)
@@ -65,7 +67,7 @@ func (p *kubernetesProvisioner) UnitsMetrics(ctx context.Context, a provision.Ap
 			totalMemoryUsage.Add(memoryUsage)
 		}
 
-		unitMetrics = append(unitMetrics, provision.UnitMetric{
+		unitMetrics = append(unitMetrics, provTypes.UnitMetric{
 			ID:     metric.ObjectMeta.Name,
 			CPU:    totalCPUUsage.String(),
 			Memory: totalMemoryUsage.String(),

--- a/provision/kubernetes/metrics_test.go
+++ b/provision/kubernetes/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -78,7 +79,7 @@ func (s *S) Test_MetricsProvisioner_UnitsMetrics(c *check.C) {
 	metrics, err := s.p.UnitsMetrics(context.TODO(), a)
 	c.Assert(err, check.IsNil)
 	c.Assert(metrics, check.HasLen, 1)
-	c.Assert(metrics, check.DeepEquals, []provision.UnitMetric{
+	c.Assert(metrics, check.DeepEquals, []provTypes.UnitMetric{
 		{
 			ID:     "myapp-123",
 			CPU:    "2200m",

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -991,7 +991,7 @@ func (p *kubernetesProvisioner) addressesForApp(ctx context.Context, client *Clu
 	return addrs, nil
 }
 
-func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]provision.AppInternalAddress, error) {
+func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]appTypes.AppInternalAddress, error) {
 	client, err := clusterForPool(ctx, a.GetPool())
 	if err != nil {
 		return nil, err
@@ -1037,14 +1037,14 @@ func (p *kubernetesProvisioner) InternalAddresses(ctx context.Context, a provisi
 		return iProcess < jProcess
 	})
 
-	addresses := []provision.AppInternalAddress{}
+	addresses := []appTypes.AppInternalAddress{}
 	for _, service := range svcs {
 		// we can't show headless services
 		if service.Spec.ClusterIP == "None" {
 			continue
 		}
 		for _, port := range service.Spec.Ports {
-			addresses = append(addresses, provision.AppInternalAddress{
+			addresses = append(addresses, appTypes.AppInternalAddress{
 				Domain:   fmt.Sprintf("%s.%s.svc.cluster.local", service.Name, ns),
 				Protocol: string(port.Protocol),
 				Port:     port.Port,

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1295,7 +1295,7 @@ func (s *S) TestInternalAddresses(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait()
 
-	c.Assert(addrs, check.DeepEquals, []provision.AppInternalAddress{
+	c.Assert(addrs, check.DeepEquals, []appTypes.AppInternalAddress{
 		{Domain: "myapp-web.default.svc.cluster.local", Protocol: "TCP", Port: 80, Process: "web"},
 		{Domain: "myapp-web.default.svc.cluster.local", Protocol: "TCP", Port: 443, Process: "web"},
 		{Domain: "myapp-jobs.default.svc.cluster.local", Protocol: "UDP", Port: 12201, Process: "jobs"},

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -183,7 +183,7 @@ func (s *S) TestUnits(c *check.C) {
 	}
 	restarts := int32(0)
 	ready := false
-	c.Assert(units, check.DeepEquals, []provision.Unit{
+	c.Assert(units, check.DeepEquals, []provTypes.Unit{
 		{
 			AppName:     "myapp",
 			ProcessName: "web",
@@ -281,7 +281,7 @@ func (s *S) TestUnitsMultipleAppsNodes(c *check.C) {
 	})
 	restarts := int32(0)
 	ready := false
-	c.Assert(units, check.DeepEquals, []provision.Unit{
+	c.Assert(units, check.DeepEquals, []provTypes.Unit{
 		{
 			ID:          "myapp-1",
 			Name:        "myapp-1",
@@ -463,7 +463,7 @@ func (s *S) TestUnitsStarting(c *check.C) {
 	units, err := s.p.Units(context.TODO(), a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
-	c.Assert(units[0].Status, check.DeepEquals, provision.StatusStarting)
+	c.Assert(units[0].Status, check.DeepEquals, provTypes.UnitStatusStarting)
 }
 
 func (s *S) TestUnitsStartingError(c *check.C) {
@@ -513,7 +513,7 @@ func (s *S) TestUnitsStartingError(c *check.C) {
 	units, err := s.p.Units(context.TODO(), a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
-	c.Assert(units[0].Status, check.DeepEquals, provision.StatusError)
+	c.Assert(units[0].Status, check.DeepEquals, provTypes.UnitStatusError)
 	c.Assert(units[0].StatusReason, check.DeepEquals, "OOMKilled")
 
 }
@@ -570,7 +570,7 @@ func (s *S) TestUnitsCrashLoopBackOff(c *check.C) {
 	units, err := s.p.Units(context.TODO(), a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
-	c.Assert(units[0].Status, check.DeepEquals, provision.StatusError)
+	c.Assert(units[0].Status, check.DeepEquals, provTypes.UnitStatusError)
 	c.Assert(units[0].StatusReason, check.DeepEquals, "OOMKilled")
 
 }
@@ -628,7 +628,7 @@ func (s *S) TestUnitsCrashLoopBackOffWithExitCode(c *check.C) {
 	units, err := s.p.Units(context.TODO(), a)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(units), check.Equals, 1)
-	c.Assert(units[0].Status, check.DeepEquals, provision.StatusError)
+	c.Assert(units[0].Status, check.DeepEquals, provTypes.UnitStatusError)
 	c.Assert(units[0].StatusReason, check.DeepEquals, "exitCode: 1")
 
 }

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -380,15 +380,7 @@ type UpdatableProvisioner interface {
 // InterAppProvisioner is a provisioner that allows an app to comunicate with each other
 // using internal dns and own load balancers provided by provisioner.
 type InterAppProvisioner interface {
-	InternalAddresses(ctx context.Context, a App) ([]AppInternalAddress, error)
-}
-
-type AppInternalAddress struct {
-	Domain   string
-	Protocol string
-	Port     int32
-	Version  string
-	Process  string
+	InternalAddresses(ctx context.Context, a App) ([]appTypes.AppInternalAddress, error)
 }
 
 // MessageProvisioner is a provisioner that provides a welcome message for

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -130,59 +130,59 @@ func (ProvisionSuite) TestUnitNotFoundError(c *check.C) {
 
 func (ProvisionSuite) TestValidate(c *check.C) {
 	var tests = []struct {
-		input    AutoScaleSpec
+		input    provTypes.AutoScaleSpec
 		expected string
 	}{
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 0,
 				MaxUnits: 10,
 			},
 			"minimum units must be greater than 0",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 11,
 				MaxUnits: 10,
 			},
 			"maximum units must be greater than minimum units",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 10,
 				MaxUnits: 10,
 			},
 			"maximum units must be greater than minimum units",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 10,
 				MaxUnits: 20,
 			},
 			"maximum units cannot be greater than quota limit",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 1,
 				MaxUnits: 2,
 			},
 			"you have to configure at least one trigger between cpu, schedule and prometheus",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 1,
 				MaxUnits: 2,
-				Prometheus: []AutoScalePrometheus{{
+				Prometheus: []provTypes.AutoScalePrometheus{{
 					Name: "Invalid-Name",
 				}},
 			},
 			"\"Invalid-Name\" is an invalid name, it must contain only lower case letters, numbers or dashes and starts with a letter",
 		},
 		{
-			AutoScaleSpec{
+			provTypes.AutoScaleSpec{
 				MinUnits: 1,
 				MaxUnits: 2,
-				Prometheus: []AutoScalePrometheus{{
+				Prometheus: []provTypes.AutoScalePrometheus{{
 					Name: "valid-name",
 				}, {
 					Name: "another$invalid",
@@ -193,7 +193,7 @@ func (ProvisionSuite) TestValidate(c *check.C) {
 	}
 
 	for _, test := range tests {
-		err := test.input.Validate(10, nil)
+		err := ValidateAutoScaleSpec(&test.input, 10, nil)
 		c.Assert(err, check.NotNil)
 		c.Assert(err.Error(), check.Equals, test.expected)
 	}

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
 )
 
@@ -65,36 +66,36 @@ func (ProvisionSuite) TestErrorImplementsError(c *check.C) {
 }
 
 func (ProvisionSuite) TestStatusString(c *check.C) {
-	var s Status = "pending"
+	var s provTypes.UnitStatus = "pending"
 	c.Assert(s.String(), check.Equals, "pending")
 }
 
 func (ProvisionSuite) TestStatuses(c *check.C) {
-	c.Check(StatusCreated.String(), check.Equals, "created")
-	c.Check(StatusBuilding.String(), check.Equals, "building")
-	c.Check(StatusError.String(), check.Equals, "error")
-	c.Check(StatusStarted.String(), check.Equals, "started")
-	c.Check(StatusStopped.String(), check.Equals, "stopped")
-	c.Check(StatusStarting.String(), check.Equals, "starting")
+	c.Check(provTypes.UnitStatusCreated.String(), check.Equals, "created")
+	c.Check(provTypes.UnitStatusBuilding.String(), check.Equals, "building")
+	c.Check(provTypes.UnitStatusError.String(), check.Equals, "error")
+	c.Check(provTypes.UnitStatusStarted.String(), check.Equals, "started")
+	c.Check(provTypes.UnitStatusStopped.String(), check.Equals, "stopped")
+	c.Check(provTypes.UnitStatusStarting.String(), check.Equals, "starting")
 }
 
 func (ProvisionSuite) TestParseStatus(c *check.C) {
 	var tests = []struct {
 		input  string
-		output Status
+		output provTypes.UnitStatus
 		err    error
 	}{
-		{"created", StatusCreated, nil},
-		{"building", StatusBuilding, nil},
-		{"error", StatusError, nil},
-		{"started", StatusStarted, nil},
-		{"stopped", StatusStopped, nil},
-		{"starting", StatusStarting, nil},
-		{"something", Status(""), ErrInvalidStatus},
-		{"otherthing", Status(""), ErrInvalidStatus},
+		{"created", provTypes.UnitStatusCreated, nil},
+		{"building", provTypes.UnitStatusBuilding, nil},
+		{"error", provTypes.UnitStatusError, nil},
+		{"started", provTypes.UnitStatusStarted, nil},
+		{"stopped", provTypes.UnitStatusStopped, nil},
+		{"starting", provTypes.UnitStatusStarting, nil},
+		{"something", provTypes.UnitStatus(""), provTypes.ErrInvalidUnitStatus},
+		{"otherthing", provTypes.UnitStatus(""), provTypes.ErrInvalidUnitStatus},
 	}
 	for _, t := range tests {
-		got, err := ParseStatus(t.input)
+		got, err := provTypes.ParseUnitStatus(t.input)
 		c.Check(got, check.Equals, t.output)
 		c.Check(err, check.Equals, t.err)
 	}
@@ -102,23 +103,23 @@ func (ProvisionSuite) TestParseStatus(c *check.C) {
 
 func (ProvisionSuite) TestUnitAvailable(c *check.C) {
 	var tests = []struct {
-		input    Status
+		input    provTypes.UnitStatus
 		expected bool
 	}{
-		{StatusCreated, false},
-		{StatusStarting, true},
-		{StatusStarted, true},
-		{StatusBuilding, false},
-		{StatusError, true},
+		{provTypes.UnitStatusCreated, false},
+		{provTypes.UnitStatusStarting, true},
+		{provTypes.UnitStatusStarted, true},
+		{provTypes.UnitStatusBuilding, false},
+		{provTypes.UnitStatusError, true},
 	}
 	for _, test := range tests {
-		u := Unit{Status: test.input}
+		u := provTypes.Unit{Status: test.input}
 		c.Check(u.Available(), check.Equals, test.expected)
 	}
 }
 
 func (ProvisionSuite) TestUnitGetIp(c *check.C) {
-	u := Unit{IP: "10.3.3.1"}
+	u := provTypes.Unit{IP: "10.3.3.1"}
 	c.Assert(u.IP, check.Equals, u.GetIp())
 }
 

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -1026,30 +1026,30 @@ type provisionedJob struct {
 
 type AutoScaleProvisioner struct {
 	*FakeProvisioner
-	autoscales map[string][]provision.AutoScaleSpec
+	autoscales map[string][]provTypes.AutoScaleSpec
 }
 
 var _ provision.AutoScaleProvisioner = &AutoScaleProvisioner{}
 
-func (p *AutoScaleProvisioner) GetAutoScale(ctx context.Context, app provision.App) ([]provision.AutoScaleSpec, error) {
+func (p *AutoScaleProvisioner) GetAutoScale(ctx context.Context, app provision.App) ([]provTypes.AutoScaleSpec, error) {
 	if p.autoscales == nil {
 		return nil, nil
 	}
 	return p.autoscales[app.GetName()], nil
 }
 
-func (p *AutoScaleProvisioner) GetVerticalAutoScaleRecommendations(ctx context.Context, app provision.App) ([]provision.RecommendedResources, error) {
+func (p *AutoScaleProvisioner) GetVerticalAutoScaleRecommendations(ctx context.Context, app provision.App) ([]provTypes.RecommendedResources, error) {
 	if p.autoscales == nil {
 		return nil, nil
 	}
-	return []provision.RecommendedResources{
-		{Process: "p1", Recommendations: []provision.RecommendedProcessResources{{Type: "target", CPU: "100m", Memory: "100MiB"}}},
+	return []provTypes.RecommendedResources{
+		{Process: "p1", Recommendations: []provTypes.RecommendedProcessResources{{Type: "target", CPU: "100m", Memory: "100MiB"}}},
 	}, nil
 }
 
-func (p *AutoScaleProvisioner) SetAutoScale(ctx context.Context, app provision.App, spec provision.AutoScaleSpec) error {
+func (p *AutoScaleProvisioner) SetAutoScale(ctx context.Context, app provision.App, spec provTypes.AutoScaleSpec) error {
 	if p.autoscales == nil {
-		p.autoscales = make(map[string][]provision.AutoScaleSpec)
+		p.autoscales = make(map[string][]provTypes.AutoScaleSpec)
 	}
 	p.autoscales[app.GetName()] = append(p.autoscales[app.GetName()], spec)
 	return nil

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -81,7 +81,7 @@ type FakeApp struct {
 	Teams             []string
 	Tags              []string
 	Metadata          appTypes.Metadata
-	InternalAddresses []provision.AppInternalAddress
+	InternalAddresses []appTypes.AppInternalAddress
 }
 
 func NewFakeJob(name, pool, teamOwner string) *jobTypes.Job {
@@ -900,8 +900,8 @@ func (p *FakeProvisioner) UpdateApp(ctx context.Context, old, new provision.App,
 	return nil
 }
 
-func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]provision.AppInternalAddress, error) {
-	return []provision.AppInternalAddress{
+func (p *FakeProvisioner) InternalAddresses(ctx context.Context, a provision.App) ([]appTypes.AppInternalAddress, error) {
+	return []appTypes.AppInternalAddress{
 		{
 			Domain:   fmt.Sprintf("%s-web.fake-cluster.local", a.GetName()),
 			Port:     80,

--- a/provision/provisiontest/fake_provisioner_test.go
+++ b/provision/provisiontest/fake_provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tsuru/tsuru/router/routertest"
 	servicemock "github.com/tsuru/tsuru/servicemanager/mock"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
 )
 
@@ -50,7 +51,7 @@ func (s *S) SetUpTest(c *check.C) {
 
 func (s *S) TestFakeAppAddUnit(c *check.C) {
 	app := NewFakeApp("jean", "mj", 0)
-	app.AddUnit(provision.Unit{ID: "jean-0"})
+	app.AddUnit(provTypes.Unit{ID: "jean-0"})
 	c.Assert(app.units, check.HasLen, 1)
 }
 
@@ -318,9 +319,9 @@ func (s *S) TestStops(c *check.C) {
 }
 
 func (s *S) TestGetUnits(c *check.C) {
-	list := []provision.Unit{
-		{ID: "chain-lighting-0", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.10", Status: provision.StatusStarted},
-		{ID: "chain-lighting-1", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.15", Status: provision.StatusStarted},
+	list := []provTypes.Unit{
+		{ID: "chain-lighting-0", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.10", Status: provTypes.UnitStatusStarted},
+		{ID: "chain-lighting-1", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.15", Status: provTypes.UnitStatusStarted},
 	}
 	app := NewFakeApp("chain-lighting", "rush", 1)
 	p := NewFakeProvisioner()
@@ -742,7 +743,7 @@ func (s *S) TestFakeProvisionerAddUnit(c *check.C) {
 	p := NewFakeProvisioner()
 	err := p.Provision(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	p.AddUnit(app, provision.Unit{ID: "red-sector/1"})
+	p.AddUnit(app, provTypes.Unit{ID: "red-sector/1"})
 	units, err := p.Units(context.TODO(), app)
 	c.Assert(err, check.IsNil)
 	c.Assert(units, check.HasLen, 1)
@@ -754,7 +755,7 @@ func (s *S) TestFakeProvisionerUnits(c *check.C) {
 	p := NewFakeProvisioner()
 	err := p.Provision(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	p.AddUnit(app, provision.Unit{ID: "red-sector/1"})
+	p.AddUnit(app, provTypes.Unit{ID: "red-sector/1"})
 	units, err := p.Units(context.TODO(), app)
 	c.Assert(err, check.IsNil)
 	c.Assert(units, check.HasLen, 1)
@@ -769,8 +770,8 @@ func (s *S) TestFakeProvisionerUnitsAppNotFound(c *check.C) {
 }
 
 func (s *S) TestGetAppFromUnitID(c *check.C) {
-	list := []provision.Unit{
-		{ID: "chain-lighting-0", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.10", Status: provision.StatusStarted},
+	list := []provTypes.Unit{
+		{ID: "chain-lighting-0", AppName: "chain-lighting", ProcessName: "web", Type: "django", IP: "10.10.10.10", Status: provTypes.UnitStatusStarted},
 	}
 	app := NewFakeApp("chain-lighting", "rush", 1)
 	p := NewFakeProvisioner()

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -19,10 +19,11 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
-	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	"github.com/tsuru/tsuru/servicemanager"
+	appTypes "github.com/tsuru/tsuru/types/app"
 	provTypes "github.com/tsuru/tsuru/types/provision"
+
 	check "gopkg.in/check.v1"
 )
 
@@ -395,7 +396,7 @@ func (s *S) TestBindAppWithParams(c *check.C) {
 	}
 	instance := ServiceInstance{Name: "her-redis", ServiceName: "redis"}
 	a := provisiontest.NewFakeAppWithPool("her-app", "python", "her-pool", 1)
-	a.InternalAddresses = []provision.AppInternalAddress{
+	a.InternalAddresses = []appTypes.AppInternalAddress{
 		{
 			Protocol: "TCP",
 			Domain:   "aclfromhell-web.tsuru.svc.cluster.local",

--- a/storage/mongodb/plan.go
+++ b/storage/mongodb/plan.go
@@ -24,9 +24,9 @@ type planOnMongoDB struct {
 	Name     string `bson:"_id"`
 	Memory   int64
 	CPUMilli int
-	CPUBurst app.CPUBurst
+	CPUBurst *app.CPUBurst
 	Default  bool
-	Override app.PlanOverride `bson:"-"`
+	Override *app.PlanOverride `bson:"-"`
 }
 
 func plansCollection(conn *db.Storage) *dbStorage.Collection {

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -76,11 +76,11 @@ type AppInfo struct {
 	Tags        []string `json:"tags"`
 	Metadata    Metadata `json:"metadata"`
 
-	Units                   any `json:"units,omitempty"`                   // TODO: convert to typed field
-	InternalAddresses       any `json:"internalAddresses,omitempty"`       // TODO: convert to typed field
-	Autoscale               any `json:"autoscale,omitempty"`               // TODO: convert to typed field
-	UnitsMetrics            any `json:"unitsMetrics,omitempty"`            // TODO: convert to typed field
-	AutoscaleRecommendation any `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
+	Units                   any                  `json:"units,omitempty"` // TODO: convert to typed field
+	InternalAddresses       []AppInternalAddress `json:"internalAddresses,omitempty"`
+	Autoscale               any                  `json:"autoscale,omitempty"`               // TODO: convert to typed field
+	UnitsMetrics            any                  `json:"unitsMetrics,omitempty"`            // TODO: convert to typed field
+	AutoscaleRecommendation any                  `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
 
 	Provisioner          string                     `json:"provisioner,omitempty"`
 	Cluster              string                     `json:"cluster,omitempty"`
@@ -94,4 +94,12 @@ type AppInfo struct {
 	RouterOpts map[string]string `json:"routeropts"`
 	Quota      *quota.Quota      `json:"quota,omitempty"`
 	Error      string            `json:"error,omitempty"`
+}
+
+type AppInternalAddress struct {
+	Domain   string
+	Protocol string
+	Port     int32
+	Version  string
+	Process  string
 }

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -9,6 +9,9 @@ import (
 	"net/url"
 
 	"github.com/tsuru/tsuru/types/app/image"
+	"github.com/tsuru/tsuru/types/bind"
+	"github.com/tsuru/tsuru/types/quota"
+	"github.com/tsuru/tsuru/types/volume"
 )
 
 type App interface {
@@ -56,4 +59,39 @@ type Filter struct {
 type AppService interface {
 	GetByName(ctx context.Context, name string) (App, error)
 	List(ctx context.Context, filter *Filter) ([]App, error)
+}
+
+type AppInfo struct {
+	Name        string   `json:"name"`
+	Platform    string   `json:"platform"`
+	Teams       []string `json:"teams"`
+	Plan        *Plan    `json:"plan"`
+	CName       []string `json:"cname"`
+	Owner       string   `json:"owner"` // we may move this to createdBy
+	Pool        string   `json:"pool"`
+	Description string   `json:"description"`
+	Deploys     uint     `json:"deploys"`
+	TeamOwner   string   `json:"teamowner"`
+	Lock        AppLock  `json:"lock"`
+	Tags        []string `json:"tags"`
+	Metadata    Metadata `json:"metadata"`
+
+	Units                   any `json:"units,omitempty"`                   // TODO: convert to typed field
+	InternalAddresses       any `json:"internalAddresses,omitempty"`       // TODO: convert to typed field
+	Autoscale               any `json:"autoscale,omitempty"`               // TODO: convert to typed field
+	UnitsMetrics            any `json:"unitsMetrics,omitempty"`            // TODO: convert to typed field
+	AutoscaleRecommendation any `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
+
+	Provisioner          string                     `json:"provisioner,omitempty"`
+	Cluster              string                     `json:"cluster,omitempty"`
+	Processes            []Process                  `json:"processes,omitempty"`
+	Routers              []AppRouter                `json:"routers"`
+	VolumeBinds          []volume.VolumeBind        `json:"volumeBinds,omitempty"`
+	ServiceInstanceBinds []bind.ServiceInstanceBind `json:"serviceInstanceBinds"`
+
+	IP         string            `json:"ip,omitempty"`
+	Router     string            `json:"router,omitempty"`
+	RouterOpts map[string]string `json:"routeropts"`
+	Quota      *quota.Quota      `json:"quota,omitempty"`
+	Error      string            `json:"error,omitempty"`
 }

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tsuru/tsuru/types/app/image"
 	"github.com/tsuru/tsuru/types/bind"
+	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	"github.com/tsuru/tsuru/types/volume"
 )
@@ -76,11 +77,11 @@ type AppInfo struct {
 	Tags        []string `json:"tags"`
 	Metadata    Metadata `json:"metadata"`
 
-	Units                   any                  `json:"units,omitempty"` // TODO: convert to typed field
-	InternalAddresses       []AppInternalAddress `json:"internalAddresses,omitempty"`
-	Autoscale               any                  `json:"autoscale,omitempty"`               // TODO: convert to typed field
-	UnitsMetrics            any                  `json:"unitsMetrics,omitempty"`            // TODO: convert to typed field
-	AutoscaleRecommendation any                  `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
+	Units                   []provision.Unit       `json:"units"`
+	InternalAddresses       []AppInternalAddress   `json:"internalAddresses,omitempty"`
+	Autoscale               any                    `json:"autoscale,omitempty"` // TODO: convert to typed field
+	UnitsMetrics            []provision.UnitMetric `json:"unitsMetrics,omitempty"`
+	AutoscaleRecommendation any                    `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
 
 	Provisioner          string                     `json:"provisioner,omitempty"`
 	Cluster              string                     `json:"cluster,omitempty"`

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -104,3 +104,22 @@ type AppInternalAddress struct {
 	Version  string
 	Process  string
 }
+
+// AppResume is a minimal representation of the app, created to make appList
+// faster and transmit less data.
+type AppResume struct {
+	Name        string           `json:"name"`
+	Pool        string           `json:"pool"`
+	TeamOwner   string           `json:"teamowner"`
+	Plan        Plan             `json:"plan"`
+	Units       []provision.Unit `json:"units"`
+	CName       []string         `json:"cname"`
+	IP          string           `json:"ip"`
+	Routers     []AppRouter      `json:"routers"`
+	Lock        AppLock          `json:"lock"`
+	Tags        []string         `json:"tags"`
+	Error       string           `json:"error,omitempty"`
+	Platform    string           `json:"platform,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Metadata    Metadata         `json:"metadata,omitempty"`
+}

--- a/types/app/app.go
+++ b/types/app/app.go
@@ -77,11 +77,11 @@ type AppInfo struct {
 	Tags        []string `json:"tags"`
 	Metadata    Metadata `json:"metadata"`
 
-	Units                   []provision.Unit       `json:"units"`
-	InternalAddresses       []AppInternalAddress   `json:"internalAddresses,omitempty"`
-	Autoscale               any                    `json:"autoscale,omitempty"` // TODO: convert to typed field
-	UnitsMetrics            []provision.UnitMetric `json:"unitsMetrics,omitempty"`
-	AutoscaleRecommendation any                    `json:"autoscaleRecommendation,omitempty"` // TODO: convert to typed field or deprecate
+	Units                   []provision.Unit                 `json:"units"`
+	InternalAddresses       []AppInternalAddress             `json:"internalAddresses,omitempty"`
+	Autoscale               []provision.AutoScaleSpec        `json:"autoscale,omitempty"`
+	UnitsMetrics            []provision.UnitMetric           `json:"unitsMetrics,omitempty"`
+	AutoscaleRecommendation []provision.RecommendedResources `json:"autoscaleRecommendation,omitempty"`
 
 	Provisioner          string                     `json:"provisioner,omitempty"`
 	Cluster              string                     `json:"cluster,omitempty"`

--- a/types/app/plan.go
+++ b/types/app/plan.go
@@ -7,12 +7,12 @@ package app
 import "context"
 
 type Plan struct {
-	Name     string       `json:"name"`
-	Memory   int64        `json:"memory"`
-	CPUMilli int          `json:"cpumilli"`
-	CPUBurst CPUBurst     `json:"cpuBurst,omitempty"`
-	Default  bool         `json:"default,omitempty"`
-	Override PlanOverride `json:"override,omitempty"`
+	Name     string        `json:"name"`
+	Memory   int64         `json:"memory"`
+	CPUMilli int           `json:"cpumilli"`
+	CPUBurst *CPUBurst     `json:"cpuBurst,omitempty"`
+	Default  bool          `json:"default,omitempty"`
+	Override *PlanOverride `json:"override,omitempty"`
 }
 
 type PlanOverride struct {
@@ -27,28 +27,35 @@ type CPUBurst struct {
 }
 
 func (p *Plan) MergeOverride(po PlanOverride) {
+
+	newOverride := p.Override
+	if newOverride == nil {
+		newOverride = &PlanOverride{}
+	}
 	if po.Memory != nil {
 		if *po.Memory == 0 {
-			p.Override.Memory = nil
+			newOverride.Memory = nil
 		} else {
-			p.Override.Memory = po.Memory
+			newOverride.Memory = po.Memory
 		}
 	}
 	if po.CPUMilli != nil {
 		if *po.CPUMilli == 0 {
-			p.Override.CPUMilli = nil
+			newOverride.CPUMilli = nil
 		} else {
-			p.Override.CPUMilli = po.CPUMilli
+			newOverride.CPUMilli = po.CPUMilli
 		}
 	}
 
 	if po.CPUBurst != nil {
 		if *po.CPUBurst == 0 {
-			p.Override.CPUBurst = nil
+			newOverride.CPUBurst = nil
 		} else {
-			p.Override.CPUBurst = po.CPUBurst
+			newOverride.CPUBurst = po.CPUBurst
 		}
 	}
+
+	p.Override = newOverride
 }
 
 func (p Plan) GetMemory() int64 {

--- a/types/app/plan.go
+++ b/types/app/plan.go
@@ -55,28 +55,36 @@ func (p *Plan) MergeOverride(po PlanOverride) {
 		}
 	}
 
-	p.Override = newOverride
+	if (*newOverride == PlanOverride{}) {
+		p.Override = nil
+	} else {
+		p.Override = newOverride
+	}
 }
 
 func (p Plan) GetMemory() int64 {
-	if p.Override.Memory != nil {
+	if p.Override != nil && p.Override.Memory != nil {
 		return *p.Override.Memory
 	}
 	return p.Memory
 }
 
 func (p Plan) GetMilliCPU() int {
-	if p.Override.CPUMilli != nil {
+	if p.Override != nil && p.Override.CPUMilli != nil {
 		return *p.Override.CPUMilli
 	}
 	return p.CPUMilli
 }
 
 func (p Plan) GetCPUBurst() float64 {
-	if p.Override.CPUBurst != nil {
+	if p.Override != nil && p.Override.CPUBurst != nil {
 		return *p.Override.CPUBurst
 	}
-	return p.CPUBurst.Default
+	if p.CPUBurst != nil {
+		return p.CPUBurst.Default
+	}
+
+	return 0
 }
 
 type PlanService interface {

--- a/types/job/job.go
+++ b/types/job/job.go
@@ -10,7 +10,9 @@ import (
 
 	appTypes "github.com/tsuru/tsuru/types/app"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	"github.com/tsuru/tsuru/types/bind"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
+	"github.com/tsuru/tsuru/types/provision"
 	provisionTypes "github.com/tsuru/tsuru/types/provision"
 )
 
@@ -99,4 +101,11 @@ type JobService interface {
 	GetEnvs(ctx context.Context, job *Job) map[string]bindTypes.EnvVar
 	BaseImageName(ctx context.Context, job *Job) (string, error)
 	KillUnit(ctx context.Context, job *Job, unitName string, force bool) error
+}
+
+type JobInfo struct {
+	Cluster              string                     `json:"cluster,omitempty"`
+	Job                  *Job                       `json:"job,omitempty"`
+	Units                []provision.Unit           `json:"units,omitempty"`
+	ServiceInstanceBinds []bind.ServiceInstanceBind `json:"serviceInstanceBinds,omitempty"`
 }

--- a/types/provision/autoscale.go
+++ b/types/provision/autoscale.go
@@ -1,0 +1,45 @@
+// Copyright 2012 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package provision provides interfaces that need to be satisfied in order to
+// implement a new provisioner on tsuru.
+
+package provision
+
+type AutoScaleSpec struct {
+	Process    string                `json:"process"`
+	MinUnits   uint                  `json:"minUnits"`
+	MaxUnits   uint                  `json:"maxUnits"`
+	AverageCPU string                `json:"averageCPU,omitempty"`
+	Schedules  []AutoScaleSchedule   `json:"schedules,omitempty"`
+	Prometheus []AutoScalePrometheus `json:"prometheus,omitempty"`
+	Version    int                   `json:"version"`
+}
+
+type AutoScalePrometheus struct {
+	Name                string  `json:"name"`
+	Query               string  `json:"query"`
+	Threshold           float64 `json:"threshold"`
+	ActivationThreshold float64 `json:"activationThreshold,omitempty"`
+	PrometheusAddress   string  `json:"prometheusAddress,omitempty"`
+}
+
+type AutoScaleSchedule struct {
+	Name        string `json:"name,omitempty"`
+	MinReplicas int    `json:"minReplicas"`
+	Start       string `json:"start"`
+	End         string `json:"end"`
+	Timezone    string `json:"timezone,omitempty"`
+}
+
+type RecommendedResources struct {
+	Process         string                        `json:"process"`
+	Recommendations []RecommendedProcessResources `json:"recommendations"`
+}
+
+type RecommendedProcessResources struct {
+	Type   string `json:"type"`
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+}

--- a/types/provision/unit.go
+++ b/types/provision/unit.go
@@ -1,0 +1,153 @@
+// Copyright 2018 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package provision
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/url"
+	"time"
+)
+
+var (
+	ErrInvalidUnitStatus = errors.New("invalid status")
+)
+
+// Status represents the status of a unit in tsuru.
+type UnitStatus string
+
+func (s UnitStatus) String() string {
+	return string(s)
+}
+
+// Unit represents a provision unit. Can be a machine, container or anything
+// IP-addressable.
+type Unit struct {
+	ID           string
+	Name         string
+	AppName      string
+	ProcessName  string
+	Type         string
+	IP           string
+	InternalIP   string
+	Status       UnitStatus
+	StatusReason string
+	Address      *url.URL  // TODO: deprecate after drop docker provisioner
+	Addresses    []url.URL // TODO: deprecate after drop docker provisioner
+	Version      int
+	Routable     bool
+	Restarts     *int32
+	CreatedAt    *time.Time
+	Ready        *bool
+}
+
+// GetName returns the name of the unit.
+func (u *Unit) GetID() string {
+	return u.ID
+}
+
+// GetIp returns the Unit.IP.
+func (u *Unit) GetIp() string {
+	return u.IP
+}
+
+func (u *Unit) MarshalJSON() ([]byte, error) {
+	type UnitForMarshal Unit
+	var host, port string
+	if u.Address != nil {
+		host, port, _ = net.SplitHostPort(u.Address.Host)
+	}
+	// New fields added for compatibility with old routes returning containers.
+	return json.Marshal(&struct {
+		*UnitForMarshal
+		HostAddr string
+		HostPort string
+		IP       string
+	}{
+		UnitForMarshal: (*UnitForMarshal)(u),
+		HostAddr:       host,
+		HostPort:       port,
+		IP:             u.IP,
+	})
+}
+
+// Available returns true if the unit is available. It will return true
+// whenever the unit itself is available, even when the application process is
+// not.
+func (u *Unit) Available() bool {
+	return u.Status == UnitStatusStarted ||
+		u.Status == UnitStatusStarting ||
+		u.Status == UnitStatusError
+}
+
+func ParseUnitStatus(status string) (UnitStatus, error) {
+	switch status {
+	case "created":
+		return UnitStatusCreated, nil
+	case "building":
+		return UnitStatusBuilding, nil
+	case "error":
+		return UnitStatusError, nil
+	case "started":
+		return UnitStatusStarted, nil
+	case "starting":
+		return UnitStatusStarting, nil
+	case "stopped":
+		return UnitStatusStopped, nil
+	case "success":
+		return UnitStatusSucceeded, nil
+	}
+	return UnitStatus(""), ErrInvalidUnitStatus
+}
+
+// Flow:
+
+// +---------+             +----------+                 +---------+
+// | Created | +---------> | Starting | +-------------> | Started |
+// +---------+             +----------+                 +---------+
+//
+//	^                         + +
+//	|                         | |
+//	|                         | |
+//	|                         | |
+//	v                         | |
+//	+-------+                 | |
+//	| Error | +---------------+ |
+//	+-------+ ------------------+
+const (
+	// UnitStatusCreated is the initial status of a unit in the database,
+	// it should transition shortly to a more specific status
+	UnitStatusCreated = UnitStatus("created")
+
+	// UnitStatusBuilding is the status for units being provisioned by the
+	// provisioner, like in the deployment.
+	UnitStatusBuilding = UnitStatus("building")
+
+	// UnitStatusError is the status for units that failed to start, because of
+	// an application error.
+	UnitStatusError = UnitStatus("error")
+
+	// UnitStatusStarting is set when the container is started in docker.
+	UnitStatusStarting = UnitStatus("starting")
+
+	// StatusStarted is for cases where the unit is up and running, and bound
+	// to the proper status, it's set by RegisterUnit and SetUnitStatus.
+	UnitStatusStarted = UnitStatus("started")
+
+	// UnitStatusStopped is for cases where the unit has been stopped.
+	UnitStatusStopped = UnitStatus("stopped")
+
+	// UnitStatusSucceeded is for alternete cases where the unit has been
+	// stopped with succeeded end.
+	UnitStatusSucceeded = UnitStatus("succeeded")
+)
+
+// UnitMetric represents a a related metrics for an unit.
+type UnitMetric struct {
+	ID     string
+	CPU    string
+	Memory string
+}


### PR DESCRIPTION
types standard provides more reusable pattern and simplify dependecy of structs that are wide used.

the app package is the major one that is no migrated.

working to standardize the project.