### PR TITLE
KEDA Prometheus Autoscale

### DIFF
--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -4720,12 +4720,19 @@ definitions:
         items:
           type: object
           $ref: "#/definitions/AutoScaleSchedule"
+      prometheus:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/AutoScalePrometheus"
       version:
         type: integer
   AutoScaleSchedule:
     description: Auto Scale schedules struct
     type: object
     properties:
+      name:
+        type: string
       minReplicas:
         type: integer
       start:
@@ -4733,6 +4740,22 @@ definitions:
       end:
         type: string
       timezone:
+        type: string
+  AutoScalePrometheus:
+    description: Auto Scale prometheus struct
+    type: object
+    properties:
+      name:
+        type: string
+      query:
+        type: string
+      threshold:
+        type: number
+        x-go-custom-type: "float64"
+      activationThreshold:
+        type: number
+        x-go-custom-type: "float64"
+      prometheusAddress:
         type: string
   AppCName:
     description: Application CNames

--- a/provision/kubernetes/autoscale.go
+++ b/provision/kubernetes/autoscale.go
@@ -5,13 +5,16 @@
 package kubernetes
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"html/template"
 	"strconv"
 	"strings"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/pkg/errors"
+	"github.com/tsuru/config"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/provision"
 	appsv1 "k8s.io/api/apps/v1"
@@ -189,7 +192,8 @@ func scaledObjectToSpec(scaledObject kedav1alpha1.ScaledObject) provision.AutoSc
 	}
 
 	for _, metric := range scaledObject.Spec.Triggers {
-		if metric.Type == "cron" {
+		switch metric.Type {
+		case "cron":
 			minReplicas, _ := strconv.Atoi(metric.Metadata["desiredReplicas"])
 
 			spec.Schedules = append(spec.Schedules, provision.AutoScaleSchedule{
@@ -197,9 +201,22 @@ func scaledObjectToSpec(scaledObject kedav1alpha1.ScaledObject) provision.AutoSc
 				Start:       metric.Metadata["start"],
 				End:         metric.Metadata["end"],
 				Timezone:    metric.Metadata["timezone"],
+				Name:        metric.Metadata["scheduleName"],
 			})
-		}
-		if metric.Type == "cpu" {
+
+		case "prometheus":
+			thresholdValue, _ := strconv.ParseFloat(metric.Metadata["threshold"], 64)
+			activationThresholdValue, _ := strconv.ParseFloat(metric.Metadata["activationThreshold"], 64)
+
+			spec.Prometheus = append(spec.Prometheus, provision.AutoScalePrometheus{
+				Name:                metric.Metadata["prometheusMetricName"],
+				Query:               metric.Metadata["query"],
+				Threshold:           thresholdValue,
+				ActivationThreshold: activationThresholdValue,
+				PrometheusAddress:   metric.Metadata["serverAddress"],
+			})
+
+		case "cpu":
 			cpuValue := metric.Metadata["value"]
 			if metric.MetricType == autoscalingv2.UtilizationMetricType {
 				//percentage based, so multiple by 10
@@ -345,7 +362,7 @@ func setAutoScale(ctx context.Context, client *ClusterClient, a provision.App, s
 	labels = labels.WithoutIsolated().WithoutRoutable()
 	hpaName := hpaNameForApp(a, depInfo.process)
 
-	if len(spec.Schedules) > 0 {
+	if len(spec.Schedules) > 0 || len(spec.Prometheus) > 0 {
 		err = setKEDAAutoscale(ctx, client, spec, a, depInfo, hpaName, labels)
 		if err != nil {
 			return errors.WithStack(err)
@@ -502,12 +519,22 @@ func newKEDAScaledObject(ctx context.Context, spec provision.AutoScaleSpec, a pr
 		kedaTriggers = append(kedaTriggers, kedav1alpha1.ScaleTriggers{
 			Type: "cron",
 			Metadata: map[string]string{
+				"scheduleName":    schedule.Name,
 				"desiredReplicas": strconv.Itoa(schedule.MinReplicas),
 				"start":           schedule.Start,
 				"end":             schedule.End,
 				"timezone":        timezone,
 			},
 		})
+	}
+
+	for _, prometheus := range spec.Prometheus {
+		prometheusTrigger, err := buildPrometheusTrigger(ns, prometheus)
+		if err != nil {
+			return nil, err
+		}
+
+		kedaTriggers = append(kedaTriggers, *prometheusTrigger)
 	}
 
 	return &kedav1alpha1.ScaledObject{
@@ -532,6 +559,51 @@ func newKEDAScaledObject(ctx context.Context, spec provision.AutoScaleSpec, a pr
 			},
 		},
 	}, nil
+}
+
+func buildPrometheusTrigger(ns string, prometheus provision.AutoScalePrometheus) (*kedav1alpha1.ScaleTriggers, error) {
+	if prometheus.PrometheusAddress == "" {
+		defaultPrometheusAddress, err := buildDefaultPrometheusAddress(ns)
+		if err != nil {
+			return nil, err
+		}
+
+		prometheus.PrometheusAddress = defaultPrometheusAddress
+	}
+
+	return &kedav1alpha1.ScaleTriggers{
+		Type: "prometheus",
+		Metadata: map[string]string{
+			"serverAddress":        prometheus.PrometheusAddress,
+			"query":                prometheus.Query,
+			"threshold":            strconv.FormatFloat(prometheus.Threshold, 'f', -1, 64),
+			"activationThreshold":  strconv.FormatFloat(prometheus.ActivationThreshold, 'f', -1, 64),
+			"prometheusMetricName": prometheus.Name,
+		},
+	}, nil
+}
+
+func buildDefaultPrometheusAddress(ns string) (string, error) {
+	prometheusAddressTemplate, err := config.GetString("kubernetes:keda:prometheus-address-template")
+	if err != nil {
+		return "", err
+	}
+
+	tmpl, err := template.New("prometheusAddress").Parse(prometheusAddressTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+
+	err = tmpl.Execute(&buf, map[string]string{
+		"namespace": ns,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }
 
 func buildHPABehavior() *autoscalingv2.HorizontalPodAutoscalerBehavior {

--- a/provision/kubernetes/autoscale_test.go
+++ b/provision/kubernetes/autoscale_test.go
@@ -12,6 +12,7 @@ import (
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kr/pretty"
+	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/provision"
 	appTypes "github.com/tsuru/tsuru/types/app"
 	check "gopkg.in/check.v1"
@@ -99,7 +100,7 @@ func testHPAWithTarget(tg autoscalingv2.MetricTarget) *autoscalingv2.HorizontalP
 	}
 }
 
-func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs []provision.AutoScaleSchedule) *kedav1alpha1.ScaledObject {
+func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs []provision.AutoScaleSchedule, prometheusSpecs []provision.AutoScalePrometheus, ns string) *kedav1alpha1.ScaledObject {
 	triggers := []kedav1alpha1.ScaleTriggers{}
 
 	if cpuTrigger != nil {
@@ -110,6 +111,7 @@ func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs 
 		scheduleTrigger := kedav1alpha1.ScaleTriggers{
 			Type: "cron",
 			Metadata: map[string]string{
+				"scheduleName":    schedule.Name,
 				"desiredReplicas": strconv.Itoa(schedule.MinReplicas),
 				"start":           schedule.Start,
 				"end":             schedule.End,
@@ -118,6 +120,16 @@ func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs 
 		}
 		triggers = append(triggers, scheduleTrigger)
 	}
+
+	for _, prometheus := range prometheusSpecs {
+		prometheusTrigger, err := buildPrometheusTrigger(ns, prometheus)
+		if err != nil {
+			return nil
+		}
+
+		triggers = append(triggers, *prometheusTrigger)
+	}
+
 	policyMin := autoscalingv2.MinChangePolicySelect
 
 	return &kedav1alpha1.ScaledObject{
@@ -334,7 +346,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 	}
 }
 
-func (s *S) TestProvisionerSetKEDAAutoScale(c *check.C) {
+func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string]interface{}{
@@ -469,8 +481,228 @@ func (s *S) TestProvisionerSetKEDAAutoScale(c *check.C) {
 		c.Assert(err, check.IsNil)
 		scaledObject, err := s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Get(context.TODO(), "myapp-web", metav1.GetOptions{})
 		c.Assert(err, check.IsNil)
-		expected := testKEDAScaledObject(tt.cpuTrigger, tt.scheduleSpecs)
+		expected := testKEDAScaledObject(tt.cpuTrigger, tt.scheduleSpecs, []provision.AutoScalePrometheus{}, "default")
 		c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
+	}
+}
+
+func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	config.Set("kubernetes:keda:prometheus-address-template", "http://prometheus-address-test.{{.namespace}}")
+	defer config.Unset("kubernetes:keda:prometheus-address-template")
+
+	version := newSuccessfulVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "python myapp.py",
+		},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	c.Assert(err, check.IsNil)
+	wait()
+
+	prometheusList := []provision.AutoScalePrometheus{
+		{
+			Name:      "prometheus_metric_1",
+			Query:     "some_query_1",
+			Threshold: 10.0,
+		},
+		{
+			Name:                "prometheus_metric_2",
+			Query:               "some_query_2",
+			Threshold:           10.0,
+			ActivationThreshold: 2.0,
+		},
+		{
+			Name:              "prometheus_metric_3",
+			Query:             "some_query_3",
+			PrometheusAddress: "test.prometheus.address.exemple",
+			Threshold:         30.0,
+		},
+	}
+
+	tests := []struct {
+		scenario        func()
+		cpuTrigger      *kedav1alpha1.ScaleTriggers
+		prometheusSpecs []provision.AutoScalePrometheus
+	}{
+		{
+			scenario: func() {
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					AverageCPU: "500m",
+					Prometheus: prometheusList[:1],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			cpuTrigger: &kedav1alpha1.ScaleTriggers{
+				Type:       "cpu",
+				MetricType: autoscalingv2.AverageValueMetricType,
+				Metadata: map[string]string{
+					"value": strconv.Itoa(500),
+				},
+			},
+			prometheusSpecs: prometheusList[:1],
+		},
+		{
+			scenario: func() {
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					AverageCPU: "50%",
+					Prometheus: prometheusList[:2],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			cpuTrigger: &kedav1alpha1.ScaleTriggers{
+				Type:       "cpu",
+				MetricType: autoscalingv2.AverageValueMetricType,
+				Metadata: map[string]string{
+					"value": strconv.Itoa(500),
+				},
+			},
+			prometheusSpecs: prometheusList[:2],
+		},
+		{
+			scenario: func() {
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					AverageCPU: "50",
+					Prometheus: prometheusList[:3],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			cpuTrigger: &kedav1alpha1.ScaleTriggers{
+				Type:       "cpu",
+				MetricType: autoscalingv2.AverageValueMetricType,
+				Metadata: map[string]string{
+					"value": strconv.Itoa(500),
+				},
+			},
+			prometheusSpecs: prometheusList[:3],
+		},
+		{
+			scenario: func() {
+				a.MilliCPU = 700
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					AverageCPU: "500m",
+					Prometheus: prometheusList[:3],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			cpuTrigger: &kedav1alpha1.ScaleTriggers{
+				Type:       "cpu",
+				MetricType: autoscalingv2.UtilizationMetricType,
+				Metadata: map[string]string{
+					"value": strconv.Itoa(50),
+				},
+			},
+			prometheusSpecs: prometheusList[:3],
+		},
+		{
+			scenario: func() {
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					Prometheus: prometheusList[:1],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			cpuTrigger:      nil,
+			prometheusSpecs: prometheusList[:1],
+		},
+	}
+	for _, tt := range tests {
+		tt.scenario()
+
+		ns, err := s.client.AppNamespace(context.TODO(), a)
+		c.Assert(err, check.IsNil)
+		scaledObject, err := s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Get(context.TODO(), "myapp-web", metav1.GetOptions{})
+		c.Assert(err, check.IsNil)
+		expected := testKEDAScaledObject(tt.cpuTrigger, []provision.AutoScaleSchedule{}, tt.prometheusSpecs, "default")
+		c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
+	}
+}
+
+func (s *S) TestProvisionerSetPrometheusKEDAAutoScaleWithoutTemplateConfig(c *check.C) {
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	version := newSuccessfulVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "python myapp.py",
+		},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	c.Assert(err, check.IsNil)
+	wait()
+
+	prometheusList := []provision.AutoScalePrometheus{
+		{
+			Name:              "prometheus_metric_1",
+			Query:             "some_query_1",
+			PrometheusAddress: "test.prometheus.address.exemple",
+			Threshold:         10.0,
+		},
+		{
+			Name:      "prometheus_metric_2",
+			Query:     "some_query_2",
+			Threshold: 10.0,
+		},
+	}
+
+	tests := []struct {
+		scenario        func()
+		prometheusSpecs []provision.AutoScalePrometheus
+		assertion       func(error, *kedav1alpha1.ScaledObject)
+	}{
+		{
+			scenario: func() {
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					Prometheus: prometheusList[:1],
+				})
+				c.Assert(err, check.IsNil)
+			},
+			prometheusSpecs: prometheusList[:1],
+			assertion: func(err error, scaledObject *kedav1alpha1.ScaledObject) {
+				c.Assert(err, check.IsNil)
+				expected := testKEDAScaledObject(nil, []provision.AutoScaleSchedule{}, prometheusList[:1], "default")
+				c.Assert(scaledObject, check.DeepEquals, expected, check.Commentf("diff: %v", pretty.Diff(scaledObject, expected)))
+			},
+		},
+		{
+			scenario: func() {
+				config.Unset("kubernetes:keda:prometheus-address-template")
+				err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+					MinUnits:   1,
+					MaxUnits:   2,
+					Prometheus: prometheusList[1:],
+				})
+				expectedError := config.ErrKeyNotFound{Key: "kubernetes:keda:prometheus-address-template"}
+				c.Assert(err.Error(), check.Equals, expectedError.Error())
+			},
+			prometheusSpecs: prometheusList[:1],
+			assertion: func(err error, scaledObject *kedav1alpha1.ScaledObject) {
+				c.Assert(err.Error(), check.Equals, "scaledobjects.keda \"myapp-web\" not found")
+				c.Assert(scaledObject, check.IsNil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.scenario()
+
+		ns, err := s.client.AppNamespace(context.TODO(), a)
+		c.Assert(err, check.IsNil)
+		scaledObject, err := s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Get(context.TODO(), "myapp-web", metav1.GetOptions{})
+		tt.assertion(err, scaledObject)
+		s.client.KEDAClientForConfig.KedaV1alpha1().ScaledObjects(ns).Delete(context.TODO(), "myapp-web", metav1.DeleteOptions{})
 	}
 }
 
@@ -597,7 +829,6 @@ func (s *S) TestProvisionerSetKEDAAutoScaleMultipleVersions(c *check.C) {
 			},
 		})
 	}
-
 	err := s.p.AddUnits(context.TODO(), a, 1, "web", versions[0], nil)
 	c.Assert(err, check.IsNil)
 	wait()
@@ -611,6 +842,14 @@ func (s *S) TestProvisionerSetKEDAAutoScaleMultipleVersions(c *check.C) {
 				Start:       "0 6 * * *",
 				End:         "0 18 * * *",
 				Timezone:    "UTC",
+			},
+		},
+		Prometheus: []provision.AutoScalePrometheus{
+			{
+				Name:              "prometheus_metric",
+				Query:             "sum(some_metric{app='app_test'})",
+				PrometheusAddress: "test.prometheus.address.exemple",
+				Threshold:         10.0,
 			},
 		},
 	})
@@ -808,6 +1047,14 @@ func (s *S) TestProvisionerRemoveKEDAAutoScale(c *check.C) {
 				Timezone:    "UTC",
 			},
 		},
+		Prometheus: []provision.AutoScalePrometheus{
+			{
+				Name:              "prometheus_metric",
+				Query:             "sum(some_metric{app='app_test'})",
+				PrometheusAddress: "test.prometheus.address.exemple",
+				Threshold:         10.0,
+			},
+		},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -877,7 +1124,7 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 	})
 }
 
-func (s *S) TestProvisionerGetKEDAAutoScale(c *check.C) {
+func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string]interface{}{
@@ -967,6 +1214,117 @@ func (s *S) TestProvisionerGetKEDAAutoScale(c *check.C) {
 					Start:       "0 12 * * *",
 					End:         "0 15 * * *",
 					Timezone:    "UTC",
+				},
+			},
+		},
+	})
+}
+
+func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	config.Set("kubernetes:keda:prometheus-address-template", "http://prometheus-address-test.{{.namespace}}")
+	defer config.Unset("kubernetes:keda:prometheus-address-template")
+
+	version := newSuccessfulVersion(c, a, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web":    "python myapp.py",
+			"worker": "python worker.py",
+		},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	c.Assert(err, check.IsNil)
+	wait()
+	err = s.p.AddUnits(context.TODO(), a, 1, "worker", version, nil)
+	c.Assert(err, check.IsNil)
+	wait()
+
+	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+		MinUnits:   1,
+		MaxUnits:   2,
+		AverageCPU: "500m",
+		Process:    "web",
+		Prometheus: []provision.AutoScalePrometheus{
+			{
+				Name:              "prometheus_metric_1",
+				Query:             "some_query_1",
+				PrometheusAddress: "test.prometheus.address.exemple",
+				Threshold:         10.0,
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	err = s.p.SetAutoScale(context.TODO(), a, provision.AutoScaleSpec{
+		MinUnits:   2,
+		MaxUnits:   4,
+		AverageCPU: "200m",
+		Process:    "worker",
+		Prometheus: []provision.AutoScalePrometheus{
+			{
+				Name:      "prometheus_metric_2",
+				Query:     "some_query_2",
+				Threshold: 20.0,
+			},
+			{
+				Name:              "prometheus_metric_3",
+				Query:             "some_query_3",
+				PrometheusAddress: "test.prometheus.address3.exemple",
+				Threshold:         30.0,
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+
+	_, err = s.client.AutoscalingV2().HorizontalPodAutoscalers(ns).Create(context.TODO(), testKEDAHPA("myapp-web"), metav1.CreateOptions{})
+	c.Assert(err, check.IsNil)
+
+	_, err = s.client.AutoscalingV2().HorizontalPodAutoscalers(ns).Create(context.TODO(), testKEDAHPA("myapp-worker"), metav1.CreateOptions{})
+	c.Assert(err, check.IsNil)
+
+	scales, err := s.p.GetAutoScale(context.TODO(), a)
+	c.Assert(err, check.IsNil)
+	sort.Slice(scales, func(i, j int) bool {
+		return scales[i].Process < scales[j].Process
+	})
+	c.Assert(scales, check.DeepEquals, []provision.AutoScaleSpec{
+		{
+			MinUnits:   1,
+			MaxUnits:   2,
+			AverageCPU: "500m",
+			Version:    1,
+			Process:    "web",
+			Prometheus: []provision.AutoScalePrometheus{
+				{
+					Name:              "prometheus_metric_1",
+					Query:             "some_query_1",
+					PrometheusAddress: "test.prometheus.address.exemple",
+					Threshold:         10.0,
+				},
+			},
+		},
+		{
+			MinUnits:   2,
+			MaxUnits:   4,
+			AverageCPU: "200m",
+			Version:    1,
+			Process:    "worker",
+			Prometheus: []provision.AutoScalePrometheus{
+				{
+					Name:              "prometheus_metric_2",
+					Query:             "some_query_2",
+					PrometheusAddress: "http://prometheus-address-test.default",
+					Threshold:         20.0,
+				},
+				{
+					Name:              "prometheus_metric_3",
+					Query:             "some_query_3",
+					PrometheusAddress: "test.prometheus.address3.exemple",
+					Threshold:         30.0,
 				},
 			},
 		},

--- a/provision/provision.go
+++ b/provision/provision.go
@@ -461,15 +461,25 @@ type VolumeProvisioner interface {
 }
 
 type AutoScaleSpec struct {
-	Process    string              `json:"process"`
-	MinUnits   uint                `json:"minUnits"`
-	MaxUnits   uint                `json:"maxUnits"`
-	AverageCPU string              `json:"averageCPU,omitempty"`
-	Schedules  []AutoScaleSchedule `json:"schedules,omitempty"`
-	Version    int                 `json:"version"`
+	Process    string                `json:"process"`
+	MinUnits   uint                  `json:"minUnits"`
+	MaxUnits   uint                  `json:"maxUnits"`
+	AverageCPU string                `json:"averageCPU,omitempty"`
+	Schedules  []AutoScaleSchedule   `json:"schedules,omitempty"`
+	Prometheus []AutoScalePrometheus `json:"prometheus,omitempty"`
+	Version    int                   `json:"version"`
+}
+
+type AutoScalePrometheus struct {
+	Name                string  `json:"name"`
+	Query               string  `json:"query"`
+	Threshold           float64 `json:"threshold"`
+	ActivationThreshold float64 `json:"activationThreshold,omitempty"`
+	PrometheusAddress   string  `json:"prometheusAddress,omitempty"`
 }
 
 type AutoScaleSchedule struct {
+	Name        string `json:"name,omitempty"`
 	MinReplicas int    `json:"minReplicas"`
 	Start       string `json:"start"`
 	End         string `json:"end"`
@@ -527,8 +537,8 @@ func (s AutoScaleSpec) Validate(quotaLimit int, a App) error {
 	if quotaLimit > 0 && s.MaxUnits > uint(quotaLimit) {
 		return errors.New("maximum units cannot be greater than quota limit")
 	}
-	if s.AverageCPU == "" && len(s.Schedules) == 0 {
-		return errors.New("you have to configure at least one trigger between cpu and schedule")
+	if s.AverageCPU == "" && len(s.Schedules) == 0 && len(s.Prometheus) == 0 {
+		return errors.New("you have to configure at least one trigger between cpu, schedule and prometheus")
 	}
 	if s.AverageCPU != "" {
 		_, err := s.ToCPUValue(a)

--- a/provision/provision_test.go
+++ b/provision/provision_test.go
@@ -160,6 +160,13 @@ func (ProvisionSuite) TestValidate(c *check.C) {
 			},
 			"maximum units cannot be greater than quota limit",
 		},
+		{
+			AutoScaleSpec{
+				MinUnits: 1,
+				MaxUnits: 2,
+			},
+			"you have to configure at least one trigger between cpu, schedule and prometheus",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Adds support to KEDA Prometheus Autoscale

Uses template to define default Prometheus URL
- Template config should be defined on `kubernetes:keda:prometheus-address-template`
