### PR TITLE
service instance proxy V2

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -249,6 +249,7 @@ func RunServer(dry bool) http.Handler {
 	m.Add("1.0", http.MethodDelete, "/services/{service}/instances/permission/{instance}/{team}", AuthorizationRequiredHandler(serviceInstanceRevokeTeam))
 
 	m.AddAll("1.0", "/services/{service}/proxy/{instance}", AuthorizationRequiredHandler(serviceInstanceProxy))
+	m.AddAll("1.20", "/services/{service}/resources/{instance}/{path:.*}", AuthorizationRequiredHandler(serviceInstanceProxyV2))
 	m.AddAll("1.0", "/services/proxy/service/{service}", AuthorizationRequiredHandler(serviceProxy))
 
 	m.Add("1.0", http.MethodGet, "/services", AuthorizationRequiredHandler(serviceList))

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -725,6 +725,13 @@ func serviceInstanceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) 
 	return service.ProxyInstance(ctx, serviceInstance, path, evt, requestIDHeader(r), w, r)
 }
 
+// title: service instance proxy V2
+// path: /services/{service}/resources/{instance}/{path:*}
+// method: "*"
+// responses:
+//
+//	401: Unauthorized
+//	404: Instance not found
 func serviceInstanceProxyV2(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 	ctx := r.Context()
 	serviceName := r.URL.Query().Get(":service")

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -725,6 +725,47 @@ func serviceInstanceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) 
 	return service.ProxyInstance(ctx, serviceInstance, path, evt, requestIDHeader(r), w, r)
 }
 
+func serviceInstanceProxyV2(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
+	ctx := r.Context()
+	serviceName := r.URL.Query().Get(":service")
+	instanceName := r.URL.Query().Get(":instance")
+	queryPath := r.URL.Query().Get(":path")
+
+	serviceInstance, err := getServiceInstanceOrError(ctx, serviceName, instanceName)
+	if err != nil {
+		return err
+	}
+	allowed := permission.Check(t, permission.PermServiceInstanceUpdateProxy,
+		contextsForServiceInstance(serviceInstance, serviceName)...,
+	)
+	if !allowed {
+		return permission.ErrUnauthorized
+	}
+
+	path := "/resources/" + serviceInstance.GetIdentifier() + "/" + queryPath
+
+	var evt *event.Event
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		evt, err = event.New(&event.Opts{
+			Target:     serviceInstanceTarget(serviceName, instanceName),
+			Kind:       permission.PermServiceInstanceUpdateProxy,
+			Owner:      t,
+			RemoteAddr: r.RemoteAddr,
+			CustomData: append(event.FormToCustomData(InputFields(r)), map[string]interface{}{
+				"name":  "method",
+				"value": r.Method,
+			}),
+			Allowed: event.Allowed(permission.PermServiceInstanceReadEvents,
+				contextsForServiceInstance(serviceInstance, serviceName)...),
+		})
+		if err != nil {
+			return err
+		}
+		defer func() { evt.Done(err) }()
+	}
+	return service.ProxyInstance(ctx, serviceInstance, path, evt, requestIDHeader(r), w, r)
+}
+
 // title: grant access to service instance
 // path: /services/{service}/instances/permission/{instance}/{team}
 // consume: application/x-www-form-urlencoded

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -413,6 +413,8 @@ func (c *endpointClient) Proxy(ctx context.Context, opts *ProxyOpts) error {
 	delete(q, "callback")
 	delete(q, ":service")           // injected as named param by DelayedRouter
 	delete(q, ":instance")          // injected as named param by DelayedRouter
+	delete(q, ":path")              // injected as named param by DelayedRouter
+	delete(q, ":version")           // injected as named param by DelayedRouter
 	delete(q, ":mux-route-name")    // injected as named param by DelayedRouter
 	delete(q, ":mux-path-template") // injected as named param by DelayedRouter
 	qstring := q.Encode()


### PR DESCRIPTION
The Tsuru has a way to proxy requests to a backend of service instance, nowadays is:

```
/services/<SERVICE>/proxy/<INSTANCE>?callback=%2Fresources%2F<INSTANCE>%2F<CUSTOM_PATH>
```

why evolve to a new model?
* repeat <INSTANCE> on callback querystring is a little redundant
* user could escape to a instance that does not have permission, i. e: `/services/<SERVICE>/proxy/instance-a?callback=%2Fresources%2Finstance-b%2Finfo`
* simplify clients codebase.

proposal:
new proxy API with same permission model, but with a syntax sugar:

```
/1.20/services/<SERVICE>/resources/<INSTANCE>/<CUSTOM_PATH>
```

this model ensure easy way to interoperate trough tsuru api and directly access.

ex:

* trough tsuru api: http://mytsuru.com/1.20/services/myservice/resources/instance/info
* direct access: http://myservicebackend.com/resources/instance/info
