### PR TITLE
Migrate MGO to Official Mongo Driver - part 4

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -423,7 +423,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	if !canCreate {
 		return permission.ErrUnauthorized
 	}
-	u, err := auth.ConvertNewUser(t.User())
+	u, err := auth.ConvertNewUser(t.User(ctx))
 	if err != nil {
 		return err
 	}

--- a/api/auth.go
+++ b/api/auth.go
@@ -246,7 +246,7 @@ func resetPassword(w http.ResponseWriter, r *http.Request) (err error) {
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	u, err := auth.GetUserByEmail(email)
+	u, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		if err == authTypes.ErrUserNotFound {
 			return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
@@ -318,7 +318,7 @@ func updateTeam(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if changeRequest.NewName == "" {
 		return servicemanager.Team.Update(ctx, name, changeRequest.Tags)
 	}
-	u, err := t.User()
+	u, err := t.User(ctx)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func createTeam(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	u, err := t.User()
+	u, err := t.User(ctx)
 	if err != nil {
 		return err
 	}
@@ -530,7 +530,7 @@ func teamInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}
-	users, err := auth.ListUsers()
+	users, err := auth.ListUsers(ctx)
 	if err != nil {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}
@@ -604,7 +604,7 @@ func removeUser(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	u, err := auth.GetUserByEmail(email)
+	u, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}
@@ -693,11 +693,11 @@ func regenerateAPIToken(w http.ResponseWriter, r *http.Request, t auth.Token) (e
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	u, err := auth.GetUserByEmail(email)
+	u, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}
-	apiKey, err := u.RegenerateAPIKey()
+	apiKey, err := u.RegenerateAPIKey(ctx)
 	if err != nil {
 		return err
 	}
@@ -716,7 +716,7 @@ func regenerateAPIToken(w http.ResponseWriter, r *http.Request, t auth.Token) (e
 //	404: User not found
 func showAPIToken(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	ctx := r.Context()
-	u, err := auth.ConvertNewUser(t.User())
+	u, err := auth.ConvertNewUser(t.User(ctx))
 	if err != nil {
 		return err
 	}
@@ -733,12 +733,12 @@ func showAPIToken(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	}
 
 	if email != "" {
-		u, err = auth.GetUserByEmail(email)
+		u, err = auth.GetUserByEmail(ctx, email)
 		if err != nil {
 			return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 		}
 	}
-	apiKey, err := u.ShowAPIKey()
+	apiKey, err := u.ShowAPIKey(ctx)
 	if err != nil {
 		return err
 	}
@@ -858,7 +858,7 @@ func listUsers(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	userEmail := r.URL.Query().Get("userEmail")
 	roleName := r.URL.Query().Get("role")
 	contextValue := r.URL.Query().Get("context")
-	users, err := auth.ListUsers()
+	users, err := auth.ListUsers(ctx)
 	if err != nil {
 		return err
 	}
@@ -902,7 +902,7 @@ func listUsers(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		if contextValue != "" {
 			return &errors.HTTP{Code: http.StatusNotFound, Message: "Wrong context being passed."}
 		}
-		user, err := auth.ConvertNewUser(t.User())
+		user, err := auth.ConvertNewUser(t.User(ctx))
 		if err != nil {
 			return err
 		}
@@ -930,7 +930,7 @@ func listUsers(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 //	401: Unauthorized
 func userInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	ctx := r.Context()
-	user, err := auth.ConvertNewUser(t.User())
+	user, err := auth.ConvertNewUser(t.User(ctx))
 	if err != nil {
 		return err
 	}
@@ -987,7 +987,7 @@ func teamUserList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		}
 	}
 
-	users, err := auth.ListUsersWithRolesAndContext(teamRoles, teamName)
+	users, err := auth.ListUsersWithRolesAndContext(ctx, teamRoles, teamName)
 	if err != nil {
 		return err
 	}

--- a/api/build_test.go
+++ b/api/build_test.go
@@ -108,7 +108,7 @@ func (s *BuildSuite) SetUpTest(c *check.C) {
 	opts := pool.AddPoolOptions{Name: "pool1", Default: true}
 	err = pool.AddPool(context.TODO(), opts)
 	c.Assert(err, check.IsNil)
-	s.user, err = auth.ConvertNewUser(s.token.User())
+	s.user, err = auth.ConvertNewUser(s.token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	config.Set("docker:router", "fake")
 	servicemock.SetMockService(&s.mockService)

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -70,7 +70,7 @@ func (s *DeploySuite) createUserAndTeam(c *check.C) {
 		Scheme:  permission.PermAppDeploy,
 		Context: permission.Context(permTypes.CtxTeam, s.team.Name),
 	})
-	s.user, err = auth.ConvertNewUser(s.token.User())
+	s.user, err = auth.ConvertNewUser(s.token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 }
 

--- a/api/handler_test.go
+++ b/api/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/errors"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	"golang.org/x/crypto/bcrypt"
@@ -34,13 +35,15 @@ func (s *HandlerSuite) SetUpSuite(c *check.C) {
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "tsuru_api_handler_test")
 	config.Set("auth:hash-cost", bcrypt.MinCost)
+
+	storagev2.Reset()
 }
 
 func (s *HandlerSuite) SetUpTest(c *check.C) {
 	var err error
 	s.conn, err = db.Conn()
 	c.Assert(err, check.IsNil)
-	dbtest.ClearAllCollections(s.conn.Apps().Database)
+	storagev2.ClearAllCollections(nil)
 	user := &auth.User{Email: "whydidifall@thewho.com", Password: "123456"}
 	_, err = nativeScheme.Create(context.TODO(), user)
 	c.Assert(err, check.IsNil)

--- a/api/job.go
+++ b/api/job.go
@@ -334,7 +334,7 @@ func updateJob(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	if !canUpdate {
 		return permission.ErrUnauthorized
 	}
-	user, err := t.User()
+	user, err := t.User(ctx)
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func createJob(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	if !canCreate {
 		return permission.ErrUnauthorized
 	}
-	u, err := t.User()
+	u, err := t.User(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/job_test.go
+++ b/api/job_test.go
@@ -1030,7 +1030,7 @@ func (s *S) TestJobListFilterByOwner(c *check.C) {
 		Scheme:  permission.PermAppRead,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	u, _ := token.User()
+	u, _ := token.User(context.TODO())
 	oldProvisioner := provision.DefaultProvisioner
 	defer func() { provision.DefaultProvisioner = oldProvisioner }()
 	provision.DefaultProvisioner = "jobProv"

--- a/api/job_test.go
+++ b/api/job_test.go
@@ -257,6 +257,8 @@ func (s *S) TestCreateFullyFeaturedCronjob(c *check.C) {
 			Schedule:              "* * * * *",
 			ActiveDeadlineSeconds: func() *int64 { v := int64(0); return &v }(),
 			ConcurrencyPolicy:     func() *string { s := "Allow"; return &s }(),
+			ServiceEnvs:           []bindTypes.ServiceEnvVar{},
+			Envs:                  []bindTypes.EnvVar{},
 		},
 	}
 	c.Assert(gotJob, check.DeepEquals, expectedJob)
@@ -329,6 +331,10 @@ func (s *S) TestCreateManualJob(c *check.C) {
 			Kind:  provTypes.DeployImage,
 			Image: "busybox:1.28",
 		},
+		Metadata: appTypes.Metadata{
+			Labels:      []appTypes.MetadataItem{},
+			Annotations: []appTypes.MetadataItem{},
+		},
 		Spec: jobTypes.JobSpec{
 			Container: jobTypes.ContainerInfo{
 				OriginalImageSrc: "busybox:1.28",
@@ -340,6 +346,9 @@ func (s *S) TestCreateManualJob(c *check.C) {
 				v := int64(0)
 				return &v
 			}(),
+
+			ServiceEnvs: []bindTypes.ServiceEnvVar{},
+			Envs:        []bindTypes.EnvVar{},
 		},
 	}
 	c.Assert(gotJob, check.DeepEquals, expectedJob)
@@ -425,6 +434,7 @@ func (s *S) TestUpdateCronjob(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(gotJob.Spec.Container, check.DeepEquals, jobTypes.ContainerInfo{
 		OriginalImageSrc: "busybox:1.28",
+		Command:          []string{},
 	})
 	c.Assert(gotJob.Spec.Schedule, check.DeepEquals, "* * * * *")
 	ij := inputJob{
@@ -505,6 +515,8 @@ func (s *S) TestUpdateCronjob(c *check.C) {
 				v := int64(0)
 				return &v
 			}(),
+			ServiceEnvs: []bindTypes.ServiceEnvVar{},
+			Envs:        []bindTypes.EnvVar{},
 		},
 		DeployOptions: &jobTypes.DeployOptions{
 			Kind:  provTypes.DeployImage,
@@ -540,7 +552,7 @@ func (s *S) TestKillJob(c *check.C) {
 	c.Assert(err, check.IsNil)
 	gotJob, err := servicemanager.Job.GetByName(context.TODO(), j1.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(gotJob.Spec.Container, check.DeepEquals, jobTypes.ContainerInfo{OriginalImageSrc: "busybox:1.28"})
+	c.Assert(gotJob.Spec.Container, check.DeepEquals, jobTypes.ContainerInfo{OriginalImageSrc: "busybox:1.28", Command: []string{}})
 	c.Assert(gotJob.Spec.Schedule, check.DeepEquals, "* * * * *")
 	var buffer bytes.Buffer
 	request, err := http.NewRequest("DELETE", "/jobs/job1/units/unit2", &buffer)
@@ -577,7 +589,7 @@ func (s *S) TestKillJobUnitNotFound(c *check.C) {
 	c.Assert(err, check.IsNil)
 	gotJob, err := servicemanager.Job.GetByName(context.TODO(), j1.Name)
 	c.Assert(err, check.IsNil)
-	c.Assert(gotJob.Spec.Container, check.DeepEquals, jobTypes.ContainerInfo{OriginalImageSrc: "busybox:1.28"})
+	c.Assert(gotJob.Spec.Container, check.DeepEquals, jobTypes.ContainerInfo{OriginalImageSrc: "busybox:1.28", Command: []string{}})
 	c.Assert(gotJob.Spec.Schedule, check.DeepEquals, "* * * * *")
 	var buffer bytes.Buffer
 	request, err := http.NewRequest("DELETE", "/jobs/job1/units/unit1", &buffer)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -93,7 +93,7 @@ func tokenByAllAuthEngines(ctx stdContext.Context, token string) (auth.Token, er
 		return t, nil
 	}
 
-	t, err = auth.APIAuth(token)
+	t, err = auth.APIAuth(ctx, token)
 	if err == nil {
 		return t, nil
 	}

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tsuru/tsuru/api/context"
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/db/storagev2"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/io"
 	"github.com/tsuru/tsuru/servicemanager"
@@ -257,7 +258,11 @@ func (s *S) TestAuthTokenMiddlewareWithToken(c *check.C) {
 
 func (s *S) TestAuthTokenMiddlewareWithAPIToken(c *check.C) {
 	user := auth.User{Email: "para@xmen.com", APIKey: "347r3487rh3489hr34897rh487hr0377rg308rg32"}
-	err := s.conn.Users().Insert(&user)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.InsertOne(stdContext.TODO(), &user)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest("GET", "/", nil)
@@ -314,7 +319,11 @@ func (s *S) TestAuthTokenMiddlewareWithInvalidToken(c *check.C) {
 
 func (s *S) TestAuthTokenMiddlewareWithInvalidAPIToken(c *check.C) {
 	user := auth.User{Email: "para@xmen.com", APIKey: "347r3487rh3489hr34897rh487hr0377rg308rg32"}
-	err := s.conn.Users().Insert(&user)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.InsertOne(stdContext.TODO(), &user)
 	c.Assert(err, check.IsNil)
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest("GET", "/", nil)

--- a/api/permission.go
+++ b/api/permission.go
@@ -105,7 +105,7 @@ func removeRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	usersWithRole, err := auth.ListUsersWithRole(roleName)
+	usersWithRole, err := auth.ListUsersWithRole(ctx, roleName)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func assignRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	defer func() { evt.Done(ctx, err) }()
 	email := InputValue(r, "email")
 	contextValue := InputValue(r, "context")
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		return err
 	}
@@ -396,7 +396,7 @@ func dissociateRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 	defer func() { evt.Done(ctx, err) }()
 	email := r.URL.Query().Get(":email")
 	contextValue := r.URL.Query().Get("context")
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		return err
 	}
@@ -410,7 +410,7 @@ func dissociateRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err e
 		return err
 	}
 
-	return user.RemoveRole(roleName, contextValue)
+	return user.RemoveRole(ctx, roleName, contextValue)
 }
 
 type permissionSchemeData struct {
@@ -658,7 +658,7 @@ func validateContextValue(ctx context.Context, role permission.Role, contextValu
 			return &errors.ValidationError{Message: err.Error()}
 		}
 	case permTypes.CtxUser:
-		if _, err := auth.GetUserByEmail(contextValue); err != nil {
+		if _, err := auth.GetUserByEmail(ctx, contextValue); err != nil {
 			return &errors.ValidationError{Message: err.Error()}
 		}
 	case permTypes.CtxPool:

--- a/api/permission.go
+++ b/api/permission.go
@@ -59,7 +59,7 @@ func addRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
-	_, err = permission.NewRole(roleName, InputValue(r, "context"), InputValue(r, "description"))
+	_, err = permission.NewRole(ctx, roleName, InputValue(r, "context"), InputValue(r, "description"))
 	if err == permTypes.ErrInvalidRoleName {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,
@@ -112,7 +112,7 @@ func removeRole(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	if len(usersWithRole) != 0 {
 		return &errors.HTTP{Code: http.StatusPreconditionFailed, Message: permTypes.ErrRemoveRoleWithUsers.Error()}
 	}
-	err = permission.DestroyRole(roleName)
+	err = permission.DestroyRole(ctx, roleName)
 	if err == permTypes.ErrRoleNotFound {
 		return &errors.HTTP{Code: http.StatusNotFound, Message: err.Error()}
 	}

--- a/api/permission_test.go
+++ b/api/permission_test.go
@@ -173,7 +173,7 @@ func (s *S) TestRemoveRoleWithUsers(c *check.C) {
 		Scheme:  permission.PermRoleDelete,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	user, err := auth.ConvertNewUser(token.User())
+	user, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	err = user.AddRole(ctx, "test", "app")
 	c.Assert(err, check.IsNil)
@@ -187,7 +187,7 @@ func (s *S) TestRemoveRoleWithUsers(c *check.C) {
 	roles, err := permission.ListRoles(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(roles, check.HasLen, 2)
-	user, err = auth.ConvertNewUser(token.User())
+	user, err = auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	c.Assert(user.Roles, check.HasLen, 2)
 }
@@ -438,7 +438,7 @@ func (s *S) TestAssignRole(c *check.C) {
 	server := RunServer(true)
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	emptyUser, err := emptyToken.User()
+	emptyUser, err := emptyToken.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(emptyUser.Roles, check.HasLen, 1)
 	c.Assert(eventtest.EventDesc{
@@ -879,7 +879,7 @@ func (s *S) TestAssignRoleNotAuthorized(c *check.C) {
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusForbidden)
 	c.Assert(recorder.Body.String(), check.Equals, "User not authorized to use permission app.create(team myteam)\n")
-	emptyUser, err := emptyToken.User()
+	emptyUser, err := emptyToken.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(emptyUser.Roles, check.HasLen, 0)
 }
@@ -910,7 +910,7 @@ func (s *S) TestDissociateRole(c *check.C) {
 	err = role.AddPermissions(context.TODO(), "app.create")
 	c.Assert(err, check.IsNil)
 	_, otherToken := permissiontest.CustomUserWithPermission(c, nativeScheme, "user2")
-	otherUser, err := auth.ConvertNewUser(otherToken.User())
+	otherUser, err := auth.ConvertNewUser(otherToken.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	err = otherUser.AddRole(context.TODO(), role.Name, "myteam")
 	c.Assert(err, check.IsNil)
@@ -930,7 +930,7 @@ func (s *S) TestDissociateRole(c *check.C) {
 	server := RunServer(true)
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	otherUser, err = auth.ConvertNewUser(otherToken.User())
+	otherUser, err = auth.ConvertNewUser(otherToken.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	c.Assert(otherUser.Roles, check.HasLen, 0)
 	c.Assert(eventtest.EventDesc{
@@ -950,7 +950,7 @@ func (s *S) TestDissociateRoleNotAuthorized(c *check.C) {
 	err = role.AddPermissions(context.TODO(), "app.create")
 	c.Assert(err, check.IsNil)
 	_, otherToken := permissiontest.CustomUserWithPermission(c, nativeScheme, "user2")
-	otherUser, err := auth.ConvertNewUser(otherToken.User())
+	otherUser, err := auth.ConvertNewUser(otherToken.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	err = otherUser.AddRole(context.TODO(), role.Name, "myteam")
 	c.Assert(err, check.IsNil)
@@ -971,7 +971,7 @@ func (s *S) TestDissociateRoleNotAuthorized(c *check.C) {
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusForbidden)
 	c.Assert(recorder.Body.String(), check.Equals, "User not authorized to use permission app.create(team myteam)\n")
-	otherUser, err = auth.ConvertNewUser(otherToken.User())
+	otherUser, err = auth.ConvertNewUser(otherToken.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	c.Assert(otherUser.Roles, check.HasLen, 1)
 }
@@ -1130,7 +1130,7 @@ func (s *S) TestRoleUpdateDestroysAndCreatesNewRole(c *check.C) {
 		Scheme:  permission.PermRoleUpdate,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	user, err := auth.ConvertNewUser(token.User())
+	user, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	_, err = permission.NewRole(context.TODO(), "r1", "app", "")
 	c.Assert(err, check.IsNil)
@@ -1160,7 +1160,7 @@ func (s *S) TestRoleUpdateDestroysAndCreatesNewRole(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(string(r.ContextType), check.Equals, "team")
 	c.Assert(string(r.Description), check.Equals, "new desc")
-	users, err := auth.ListUsersWithRole("r2")
+	users, err := auth.ListUsersWithRole(context.TODO(), "r2")
 	c.Assert(err, check.IsNil)
 	c.Assert(users, check.HasLen, 1)
 }
@@ -1199,7 +1199,7 @@ func (s *S) TestRoleUpdateIncorrectContext(c *check.C) {
 		Scheme:  permission.PermRoleUpdate,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	user, err := auth.ConvertNewUser(token.User())
+	user, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	_, err = permission.NewRole(context.TODO(), "r1", "app", "")
 	c.Assert(err, check.IsNil)
@@ -1222,7 +1222,7 @@ func (s *S) TestRoleUpdateSingleField(c *check.C) {
 		Scheme:  permission.PermRoleUpdate,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	user, err := auth.ConvertNewUser(token.User())
+	user, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	_, err = permission.NewRole(context.TODO(), "r1", "app", "Syncopy")
 	c.Assert(err, check.IsNil)
@@ -1252,7 +1252,7 @@ func (s *S) TestRoleUpdateSingleField(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(string(r.ContextType), check.Equals, "team")
 	c.Assert(string(r.Description), check.Equals, "Syncopy")
-	users, err := auth.ListUsersWithRole("r1")
+	users, err := auth.ListUsersWithRole(context.TODO(), "r1")
 	c.Assert(err, check.IsNil)
 	c.Assert(users, check.HasLen, 1)
 }

--- a/api/permission_test.go
+++ b/api/permission_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/event/eventtest"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/permission/permissiontest"
@@ -28,11 +29,19 @@ import (
 	permTypes "github.com/tsuru/tsuru/types/permission"
 	routerTypes "github.com/tsuru/tsuru/types/router"
 	"github.com/tsuru/tsuru/types/volume"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	check "gopkg.in/check.v1"
 )
 
 func (s *S) TestAddRole(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
+
 	role := bytes.NewBufferString("name=test&context=global")
 	req, err := http.NewRequest(http.MethodPost, "/roles", role)
 	c.Assert(err, check.IsNil)
@@ -91,9 +100,10 @@ func (s *S) TestAddRoleInvalidName(c *check.C) {
 }
 
 func (s *S) TestAddRoleNameAlreadyExists(c *check.C) {
-	_, err := permission.NewRole("ble", "global", "desc")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "ble", "global", "desc")
 	c.Assert(err, check.IsNil)
-	defer permission.DestroyRole("ble")
+	defer permission.DestroyRole(ctx, "ble")
 	b := bytes.NewBufferString("name=ble&context=global")
 	req, err := http.NewRequest(http.MethodPost, "/roles", b)
 	c.Assert(err, check.IsNil)
@@ -111,8 +121,15 @@ func (s *S) TestAddRoleNameAlreadyExists(c *check.C) {
 }
 
 func (s *S) TestRemoveRole(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
-	_, err := permission.NewRole("test", "app", "")
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
+
+	_, err = permission.NewRole(ctx, "test", "app", "")
 	c.Assert(err, check.IsNil)
 	req, err := http.NewRequest(http.MethodDelete, "/roles/test", nil)
 	c.Assert(err, check.IsNil)
@@ -126,7 +143,7 @@ func (s *S) TestRemoveRole(c *check.C) {
 	server := RunServer(true)
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	roles, err := permission.ListRoles(context.TODO())
+	roles, err := permission.ListRoles(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(roles, check.HasLen, 1)
 	c.Assert(eventtest.EventDesc{
@@ -140,8 +157,15 @@ func (s *S) TestRemoveRole(c *check.C) {
 }
 
 func (s *S) TestRemoveRoleWithUsers(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
-	_, err := permission.NewRole("test", "app", "")
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
+
+	_, err = permission.NewRole(ctx, "test", "app", "")
 	c.Assert(err, check.IsNil)
 	req, err := http.NewRequest(http.MethodDelete, "/roles/test", nil)
 	c.Assert(err, check.IsNil)
@@ -151,7 +175,7 @@ func (s *S) TestRemoveRoleWithUsers(c *check.C) {
 	})
 	user, err := auth.ConvertNewUser(token.User())
 	c.Assert(err, check.IsNil)
-	err = user.AddRole(context.TODO(), "test", "app")
+	err = user.AddRole(ctx, "test", "app")
 	c.Assert(err, check.IsNil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Authorization", "bearer "+token.GetValue())
@@ -160,7 +184,7 @@ func (s *S) TestRemoveRoleWithUsers(c *check.C) {
 	server.ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, check.Equals, http.StatusPreconditionFailed)
 	c.Assert(recorder.Body.String(), check.Equals, permTypes.ErrRemoveRoleWithUsers.Error()+"\n")
-	roles, err := permission.ListRoles(context.TODO())
+	roles, err := permission.ListRoles(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(roles, check.HasLen, 2)
 	user, err = auth.ConvertNewUser(token.User())
@@ -169,7 +193,8 @@ func (s *S) TestRemoveRoleWithUsers(c *check.C) {
 }
 
 func (s *S) TestRemoveRoleUnauthorized(c *check.C) {
-	_, err := permission.NewRole("test", "app", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "app", "")
 	c.Assert(err, check.IsNil)
 	req, err := http.NewRequest(http.MethodDelete, "/roles/test", nil)
 	c.Assert(err, check.IsNil)
@@ -183,7 +208,14 @@ func (s *S) TestRemoveRoleUnauthorized(c *check.C) {
 }
 
 func (s *S) TestListRoles(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
+
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, "/roles", nil)
 	c.Assert(err, check.IsNil)
@@ -200,7 +232,13 @@ func (s *S) TestListRoles(c *check.C) {
 }
 
 func (s *S) TestRoleInfoNotFound(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, "/roles/xpto.update", nil)
 	c.Assert(err, check.IsNil)
@@ -215,7 +253,13 @@ func (s *S) TestRoleInfoNotFound(c *check.C) {
 }
 
 func (s *S) TestRoleInfo(c *check.C) {
-	s.conn.Roles().RemoveAll(nil)
+	ctx := context.TODO()
+
+	rolesCollection, err := storagev2.RolesCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = rolesCollection.DeleteMany(ctx, mongoBSON.M{})
+	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, "/roles/majortomrole.update", nil)
 	c.Assert(err, check.IsNil)
@@ -232,7 +276,8 @@ func (s *S) TestRoleInfo(c *check.C) {
 }
 
 func (s *S) TestAddPermissionsToARole(c *check.C) {
-	_, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	b := bytes.NewBufferString(`permission=app.update&permission=app.deploy`)
@@ -247,7 +292,7 @@ func (s *S) TestAddPermissionsToARole(c *check.C) {
 	server := RunServer(true)
 	server.ServeHTTP(rec, req)
 	c.Assert(rec.Code, check.Equals, http.StatusOK)
-	r, err := permission.FindRole(context.TODO(), "test")
+	r, err := permission.FindRole(ctx, "test")
 	c.Assert(err, check.IsNil)
 	sort.Strings(r.SchemeNames)
 	c.Assert(r.SchemeNames, check.DeepEquals, []string{"app.deploy", "app.update"})
@@ -262,7 +307,8 @@ func (s *S) TestAddPermissionsToARole(c *check.C) {
 }
 
 func (s *S) TestAddPermissionsToARolePermissionNotFound(c *check.C) {
-	_, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	b := bytes.NewBufferString(`permission=does.not.exists&permission=app.deploy`)
@@ -281,7 +327,8 @@ func (s *S) TestAddPermissionsToARolePermissionNotFound(c *check.C) {
 }
 
 func (s *S) TestAddPermissionsToARoleInvalidName(c *check.C) {
-	_, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	b := bytes.NewBufferString(`permission=&permission=app.deploy`)
@@ -300,7 +347,8 @@ func (s *S) TestAddPermissionsToARoleInvalidName(c *check.C) {
 }
 
 func (s *S) TestAddPermissionsToARolePermissionNotAllowed(c *check.C) {
-	_, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	b := bytes.NewBufferString(`permission=pool.create`)
@@ -333,9 +381,11 @@ func (s *S) TestRemovePermissionsRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestRemovePermissionsFromRole(c *check.C) {
-	r, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+
+	r, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
-	defer permission.DestroyRole(r.Name)
+	defer permission.DestroyRole(ctx, r.Name)
 	err = r.AddPermissions(context.TODO(), "app.update")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
@@ -365,9 +415,11 @@ func (s *S) TestRemovePermissionsFromRole(c *check.C) {
 }
 
 func (s *S) TestAssignRole(c *check.C) {
-	role, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+
+	role, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
-	err = role.AddPermissions(context.TODO(), "app.create")
+	err = role.AddPermissions(ctx, "app.create")
 	c.Assert(err, check.IsNil)
 	_, emptyToken := permissiontest.CustomUserWithPermission(c, nativeScheme, "user2")
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=myteam", emptyToken.GetUserName()))
@@ -421,7 +473,9 @@ func (s *S) TestAssignRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestRoleAssignEmptyContextValueAndGlobalContextType(c *check.C) {
-	_, err := permission.NewRole("test", "global", "")
+	ctx := context.TODO()
+
+	_, err := permission.NewRole(ctx, "test", "global", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermRoleUpdateAssign,
@@ -442,7 +496,8 @@ func (s *S) TestRoleAssignEmptyContextValueAndGlobalContextType(c *check.C) {
 }
 
 func (s *S) TestRoleAssignEmptyContextValueWithoutGlobalContextType(c *check.C) {
-	_, err := permission.NewRole("test", "team", "")
+	ctx := context.TODO()
+	_, err := permission.NewRole(ctx, "test", "team", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermRoleUpdateAssign,
@@ -463,8 +518,9 @@ func (s *S) TestRoleAssignEmptyContextValueWithoutGlobalContextType(c *check.C) 
 }
 
 func (s *S) TestRoleAssignValidateCtxAppNotFound(c *check.C) {
+	ctx := context.TODO()
 	appName := "myapp"
-	_, err := permission.NewRole("test", "app", "")
+	_, err := permission.NewRole(ctx, "test", "app", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermAll,
@@ -482,8 +538,9 @@ func (s *S) TestRoleAssignValidateCtxAppNotFound(c *check.C) {
 }
 
 func (s *S) TestRoleAssignValidateCtxAppFound(c *check.C) {
+	ctx := context.TODO()
 	appName := "myapp"
-	_, err := permission.NewRole("test", "app", "")
+	_, err := permission.NewRole(ctx, "test", "app", "")
 	c.Assert(err, check.IsNil)
 	user, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermAll,
@@ -508,7 +565,7 @@ func (s *S) TestRoleAssignValidateCtxTeamNotFound(c *check.C) {
 		return nil, errors.New("not found")
 	}
 	team := "myteam"
-	_, err := permission.NewRole("test", "team", "")
+	_, err := permission.NewRole(context.TODO(), "test", "team", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermAll,
@@ -527,7 +584,7 @@ func (s *S) TestRoleAssignValidateCtxTeamNotFound(c *check.C) {
 
 func (s *S) TestRoleAssignValidateCtxTeamFound(c *check.C) {
 	team := "myteam"
-	_, err := permission.NewRole("test", "team", "")
+	_, err := permission.NewRole(context.TODO(), "test", "team", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermAll,
@@ -546,7 +603,7 @@ func (s *S) TestRoleAssignValidateCtxTeamFound(c *check.C) {
 
 func (s *S) TestRoleAssignValidateCtxUserNotFound(c *check.C) {
 	user := "someuser@validemail.com"
-	_, err := permission.NewRole("test", "user", "")
+	_, err := permission.NewRole(context.TODO(), "test", "user", "")
 	c.Assert(err, check.IsNil)
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "user1", permission.Permission{
 		Scheme:  permission.PermAll,
@@ -568,7 +625,7 @@ func (s *S) TestRoleAssignValidateCtxUserFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "user", "")
+	_, err := permission.NewRole(context.TODO(), "test", "user", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), user.Email))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -586,7 +643,7 @@ func (s *S) TestRoleAssignValidateCtxPoolNotFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "pool", "")
+	_, err := permission.NewRole(context.TODO(), "test", "pool", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), "somepool"))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -604,7 +661,7 @@ func (s *S) TestRoleAssignValidateCtxPoolFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "pool", "")
+	_, err := permission.NewRole(context.TODO(), "test", "pool", "")
 	c.Assert(err, check.IsNil)
 	poolName := "somepool"
 	opts := pool.AddPoolOptions{Name: poolName, Public: true}
@@ -626,7 +683,7 @@ func (s *S) TestRoleAssignValidateCtxServiceNotFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "service", "")
+	_, err := permission.NewRole(context.TODO(), "test", "service", "")
 	c.Assert(err, check.IsNil)
 	serviceName := "someservice"
 	c.Assert(err, check.IsNil)
@@ -646,7 +703,7 @@ func (s *S) TestRoleAssignValidateCtxServiceFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "service", "")
+	_, err := permission.NewRole(context.TODO(), "test", "service", "")
 	c.Assert(err, check.IsNil)
 	serviceName := "someservice"
 	srv := service.Service{
@@ -673,7 +730,7 @@ func (s *S) TestRoleAssignValidateCtxServiceInstanceNotFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "service-instance", "")
+	_, err := permission.NewRole(context.TODO(), "test", "service-instance", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), "my-instance"))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -702,7 +759,7 @@ func (s *S) TestRoleAssignValidateCtxServiceInstanceFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err = permission.NewRole("test", "service-instance", "")
+	_, err = permission.NewRole(context.TODO(), "test", "service-instance", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), siName))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -723,7 +780,7 @@ func (s *S) TestRoleAssignValidateCtxVolumeNotFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "volume", "")
+	_, err := permission.NewRole(context.TODO(), "test", "volume", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), "my-volume"))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -741,7 +798,7 @@ func (s *S) TestRoleAssignValidateCtxVolumeFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "volume", "")
+	_, err := permission.NewRole(context.TODO(), "test", "volume", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), "my-volume"))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -759,7 +816,7 @@ func (s *S) TestRoleAssignValidateCtxRouterNotFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "router", "")
+	_, err := permission.NewRole(context.TODO(), "test", "router", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), "my-router"))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -786,7 +843,7 @@ func (s *S) TestRoleAssignValidateCtxRouterFound(c *check.C) {
 		Scheme:  permission.PermAll,
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
-	_, err := permission.NewRole("test", "router", "")
+	_, err := permission.NewRole(context.TODO(), "test", "router", "")
 	c.Assert(err, check.IsNil)
 	roleBody := bytes.NewBufferString(fmt.Sprintf("email=%s&context=%s", token.GetUserName(), routerName))
 	req1, err := http.NewRequest(http.MethodPost, "/roles/test/user", roleBody)
@@ -800,7 +857,7 @@ func (s *S) TestRoleAssignValidateCtxRouterFound(c *check.C) {
 }
 
 func (s *S) TestAssignRoleNotAuthorized(c *check.C) {
-	role, err := permission.NewRole("test", "team", "")
+	role, err := permission.NewRole(context.TODO(), "test", "team", "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(context.TODO(), "app.create")
 	c.Assert(err, check.IsNil)
@@ -848,7 +905,7 @@ func (s *S) TestDissociateRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestDissociateRole(c *check.C) {
-	role, err := permission.NewRole("test", "team", "")
+	role, err := permission.NewRole(context.TODO(), "test", "team", "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(context.TODO(), "app.create")
 	c.Assert(err, check.IsNil)
@@ -888,7 +945,7 @@ func (s *S) TestDissociateRole(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleNotAuthorized(c *check.C) {
-	role, err := permission.NewRole("test", "team", "")
+	role, err := permission.NewRole(context.TODO(), "test", "team", "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(context.TODO(), "app.create")
 	c.Assert(err, check.IsNil)
@@ -920,7 +977,7 @@ func (s *S) TestDissociateRoleNotAuthorized(c *check.C) {
 }
 
 func (s *S) TestListPermissions(c *check.C) {
-	role, err := permission.NewRole("test", "app", "")
+	role, err := permission.NewRole(context.TODO(), "test", "app", "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(context.TODO(), "app")
 	c.Assert(err, check.IsNil)
@@ -946,11 +1003,11 @@ func (s *S) TestListPermissions(c *check.C) {
 }
 
 func (s *S) TestAddDefaultRole(c *check.C) {
-	_, err := permission.NewRole("r1", "team", "")
+	_, err := permission.NewRole(context.TODO(), "r1", "team", "")
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("r2", "team", "")
+	_, err = permission.NewRole(context.TODO(), "r2", "team", "")
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("r3", "global", "")
+	_, err = permission.NewRole(context.TODO(), "r3", "global", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString("team-create=r1&team-create=r2&user-create=r3")
@@ -1004,7 +1061,7 @@ func (s *S) TestAddDefaultRole(c *check.C) {
 }
 
 func (s *S) TestAddDefaultRoleIncompatibleContext(c *check.C) {
-	_, err := permission.NewRole("r1", "team", "")
+	_, err := permission.NewRole(context.TODO(), "r1", "team", "")
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString("user-create=r1")
@@ -1040,7 +1097,7 @@ func (s *S) TestAddDefaultRoleInvalidRole(c *check.C) {
 }
 
 func (s *S) TestRemoveDefaultRole(c *check.C) {
-	r1, err := permission.NewRole("r1", "team", "")
+	r1, err := permission.NewRole(context.TODO(), "r1", "team", "")
 	c.Assert(err, check.IsNil)
 	err = r1.AddEvent(context.TODO(), permTypes.RoleEventTeamCreate.String())
 	c.Assert(err, check.IsNil)
@@ -1075,7 +1132,7 @@ func (s *S) TestRoleUpdateDestroysAndCreatesNewRole(c *check.C) {
 	})
 	user, err := auth.ConvertNewUser(token.User())
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("r1", "app", "")
+	_, err = permission.NewRole(context.TODO(), "r1", "app", "")
 	c.Assert(err, check.IsNil)
 	err = user.AddRole(context.TODO(), "r1", "app")
 	c.Assert(err, check.IsNil)
@@ -1144,7 +1201,7 @@ func (s *S) TestRoleUpdateIncorrectContext(c *check.C) {
 	})
 	user, err := auth.ConvertNewUser(token.User())
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("r1", "app", "")
+	_, err = permission.NewRole(context.TODO(), "r1", "app", "")
 	c.Assert(err, check.IsNil)
 	err = user.AddRole(context.TODO(), "r1", "app")
 	c.Assert(err, check.IsNil)
@@ -1167,7 +1224,7 @@ func (s *S) TestRoleUpdateSingleField(c *check.C) {
 	})
 	user, err := auth.ConvertNewUser(token.User())
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("r1", "app", "Syncopy")
+	_, err = permission.NewRole(context.TODO(), "r1", "app", "Syncopy")
 	c.Assert(err, check.IsNil)
 	err = user.AddRole(context.TODO(), "r1", "app")
 	c.Assert(err, check.IsNil)
@@ -1204,7 +1261,7 @@ func (s *S) TestAssignRoleToTeamToken(c *check.C) {
 	app1 := app.App{Name: "myapp", Platform: "zend", TeamOwner: s.team.Name, Tags: []string{"a"}}
 	err := app.CreateApp(context.TODO(), &app1, s.user)
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("newrole", "app", "")
+	_, err = permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1278,7 +1335,7 @@ func (s *S) TestAssignRoleToTeamTokenRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestAssignTokenRoleToEmptyTeam(c *check.C) {
-	_, err := permission.NewRole("newrole", "team", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "team", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1303,7 +1360,7 @@ func (s *S) TestAssignTokenRoleToEmptyTeam(c *check.C) {
 }
 
 func (s *S) TestAssignRoleToTeamTokenNotAuthorized(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1326,7 +1383,7 @@ func (s *S) TestAssignRoleToTeamTokenNotAuthorized(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromTeamToken(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1367,7 +1424,7 @@ func (s *S) TestDissociateRoleFromTeamToken(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromTeamTokenRoleNotFound(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1409,7 +1466,7 @@ func (s *S) TestDissociateRoleFromTeamTokenRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromTeamTokenNotAuthorized(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	teamToken, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{
 		Team: s.team.Name,
@@ -1441,7 +1498,7 @@ func (s *S) TestAssignRoleToAuthGroup(c *check.C) {
 	app1 := app.App{Name: "myapp", Platform: "zend", TeamOwner: s.team.Name, Tags: []string{"a"}}
 	err := app.CreateApp(context.TODO(), &app1, s.user)
 	c.Assert(err, check.IsNil)
-	_, err = permission.NewRole("newrole", "app", "")
+	_, err = permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	body := strings.NewReader(`context=myapp&group_name=g1&contextType=app`)
 	req, err := http.NewRequest(http.MethodPost, "/1.9/roles/newrole/group", body)
@@ -1515,7 +1572,7 @@ func (s *S) TestAssignRoleToAuthGroupRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestAssignRoleToAuthGroupNotAuthorized(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	body := strings.NewReader(`context=myapp&group_name=g1`)
 	req, err := http.NewRequest(http.MethodPost, "/1.9/roles/newrole/group", body)
@@ -1534,7 +1591,7 @@ func (s *S) TestAssignRoleToAuthGroupNotAuthorized(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromAuthGroup(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	err = servicemanager.AuthGroup.AddRole(context.TODO(), "g1", "newrole", "myapp")
 	c.Assert(err, check.IsNil)
@@ -1576,7 +1633,7 @@ func (s *S) TestDissociateRoleFromAuthGroup(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromAuthGroupRoleNotFound(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	err = servicemanager.AuthGroup.AddRole(context.TODO(), "g1", "newrole", "myapp")
 	c.Assert(err, check.IsNil)
@@ -1624,7 +1681,7 @@ func (s *S) TestDissociateRoleFromAuthGroupRoleNotFound(c *check.C) {
 }
 
 func (s *S) TestDissociateRoleFromAuthGroupNotAuthorized(c *check.C) {
-	_, err := permission.NewRole("newrole", "app", "")
+	_, err := permission.NewRole(context.TODO(), "newrole", "app", "")
 	c.Assert(err, check.IsNil)
 	err = servicemanager.AuthGroup.AddRole(context.TODO(), "g1", "newrole", "myapp")
 	c.Assert(err, check.IsNil)

--- a/api/platform_test.go
+++ b/api/platform_test.go
@@ -49,7 +49,7 @@ func createToken(c *check.C) auth.Token {
 	c.Assert(err, check.IsNil)
 	token, err := nativeScheme.Login(context.TODO(), map[string]string{"email": user.Email, "password": "123456"})
 	c.Assert(err, check.IsNil)
-	role, err := permission.NewRole("platform-admin", string(permTypes.CtxGlobal), "")
+	role, err := permission.NewRole(context.TODO(), "platform-admin", string(permTypes.CtxGlobal), "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(context.TODO(), "*")
 	c.Assert(err, check.IsNil)

--- a/api/pool_test.go
+++ b/api/pool_test.go
@@ -200,7 +200,7 @@ func (s *S) TestRemovePoolUserWithoutAppPerms(c *check.C) {
 	}
 	err := newUser.Create(context.TODO())
 	c.Assert(err, check.IsNil)
-	defer newUser.Delete()
+	defer newUser.Delete(context.TODO())
 	a := app.App{
 		Name:      "test",
 		Platform:  "python",

--- a/api/quota.go
+++ b/api/quota.go
@@ -36,7 +36,7 @@ func getUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err == authTypes.ErrUserNotFound {
 		return &errors.HTTP{
 			Code:    http.StatusNotFound,
@@ -68,7 +68,7 @@ func changeUserQuota(w http.ResponseWriter, r *http.Request, t auth.Token) (err 
 	if !allowed {
 		return permission.ErrUnauthorized
 	}
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err == authTypes.ErrUserNotFound {
 		return &errors.HTTP{
 			Code:    http.StatusNotFound,

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -270,7 +270,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceTeamOwnerMissing(c *check.C) {
 		Scheme:  permission.PermServiceInstance,
 		Context: permission.Context(permTypes.CtxTeam, "anotherTeam"),
 	}
-	role, err := permission.NewRole("instance-user", string(p.Context.CtxType), "")
+	role, err := permission.NewRole(stdContext.TODO(), "instance-user", string(p.Context.CtxType), "")
 	c.Assert(err, check.IsNil)
 	err = role.AddPermissions(stdContext.TODO(), p.Scheme.FullName())
 	c.Assert(err, check.IsNil)

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -92,7 +92,7 @@ func (s *ServiceInstanceSuite) SetUpTest(c *check.C) {
 		Scheme:  permission.PermServiceRead,
 		Context: permission.Context(permTypes.CtxTeam, s.team.Name),
 	})
-	s.user, err = auth.ConvertNewUser(s.token.User())
+	s.user, err = auth.ConvertNewUser(s.token.User(stdContext.TODO()))
 	c.Assert(err, check.IsNil)
 	app.AuthScheme = nativeScheme
 	s.provisioner = provisiontest.ProvisionerInstance

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -96,7 +96,7 @@ func (s *ProvisionSuite) createUserAndTeam(c *check.C) {
 		Context: permission.Context(permTypes.CtxTeam, s.team.Name),
 	})
 	var err error
-	s.user, err = auth.ConvertNewUser(s.token.User())
+	s.user, err = auth.ConvertNewUser(s.token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 }
 

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"context"
 	stdcontext "context"
 	"net/http"
 	"os"
@@ -92,7 +93,7 @@ func (s *S) createUserAndTeam(c *check.C) {
 		Context: permission.Context(permTypes.CtxGlobal, ""),
 	})
 	var err error
-	s.user, err = auth.ConvertNewUser(s.token.User())
+	s.user, err = auth.ConvertNewUser(s.token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	s.team = &authTypes.Team{Name: "tsuruteam"}
 }

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -114,7 +114,7 @@ func webhookCreate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	defer func() {
 		evt.Done(ctx, err)
 	}()
-	err = servicemanager.Webhook.Create(webhook)
+	err = servicemanager.Webhook.Create(ctx, webhook)
 	if err == eventTypes.ErrWebhookAlreadyExists {
 		w.WriteHeader(http.StatusConflict)
 	}
@@ -156,7 +156,7 @@ func webhookUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	defer func() {
 		evt.Done(ctx, err)
 	}()
-	err = servicemanager.Webhook.Update(webhook)
+	err = servicemanager.Webhook.Update(ctx, webhook)
 	if err == eventTypes.ErrWebhookNotFound {
 		w.WriteHeader(http.StatusNotFound)
 	}
@@ -199,5 +199,5 @@ func webhookDelete(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	defer func() {
 		evt.Done(ctx, err)
 	}()
-	return servicemanager.Webhook.Delete(webhookName)
+	return servicemanager.Webhook.Delete(ctx, webhookName)
 }

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -51,7 +51,6 @@ func (s *S) TestWebhookList(c *check.C) {
 			TeamOwner: s.team.Name,
 			Name:      "wh1",
 			URL:       "http://me",
-			Headers:   http.Header{},
 			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
@@ -63,7 +62,6 @@ func (s *S) TestWebhookList(c *check.C) {
 			TeamOwner: s.team.Name,
 			Name:      "wh2",
 			URL:       "http://me",
-			Headers:   http.Header{},
 			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
@@ -119,7 +117,6 @@ func (s *S) TestWebhookListByTeam(c *check.C) {
 			TeamOwner: "t2",
 			Name:      "wh2",
 			URL:       "http://me",
-			Headers:   http.Header{},
 			EventFilter: eventTypes.WebhookEventFilter{
 				TargetTypes:  []string{},
 				TargetValues: []string{},
@@ -154,7 +151,6 @@ func (s *S) TestWebhookCreate(c *check.C) {
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		Headers:   http.Header{},
 		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
@@ -187,7 +183,6 @@ func (s *S) TestWebhookCreateAutoTeam(c *check.C) {
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me",
-		Headers:   http.Header{},
 		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
@@ -266,7 +261,6 @@ func (s *S) TestWebhookUpdate(c *check.C) {
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me/xyz",
-		Headers:   http.Header{},
 		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},
@@ -376,7 +370,6 @@ func (s *S) TestWebhookInfo(c *check.C) {
 		TeamOwner: s.team.Name,
 		Name:      "wh1",
 		URL:       "http://me/xyz",
-		Headers:   http.Header{},
 		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -33,9 +33,9 @@ func (s *S) TestWebhookList(c *check.C) {
 		Name:      "wh2",
 		URL:       "http://me",
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
-	err = servicemanager.Webhook.Create(webhook2)
+	err = servicemanager.Webhook.Create(context.TODO(), webhook2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
 	c.Assert(err, check.IsNil)
@@ -101,9 +101,9 @@ func (s *S) TestWebhookListByTeam(c *check.C) {
 		Name:      "wh2",
 		URL:       "http://me",
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
-	err = servicemanager.Webhook.Create(webhook2)
+	err = servicemanager.Webhook.Create(context.TODO(), webhook2)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks", nil)
 	c.Assert(err, check.IsNil)
@@ -206,7 +206,7 @@ func (s *S) TestWebhookCreateConflict(c *check.C) {
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
 	bodyData, err := form.EncodeToString(webhook1)
 	c.Assert(err, check.IsNil)
@@ -247,7 +247,7 @@ func (s *S) TestWebhookUpdate(c *check.C) {
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
 	webhook1.Name = "---ignored---"
 	webhook1.URL += "/xyz"
@@ -305,7 +305,7 @@ func (s *S) TestWebhookUpdateInvalid(c *check.C) {
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
 	webhook1.URL = ""
 	bodyData, err := form.EncodeToString(webhook1)
@@ -328,7 +328,7 @@ func (s *S) TestWebhookDelete(c *check.C) {
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("DELETE", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)
@@ -360,7 +360,7 @@ func (s *S) TestWebhookInfo(c *check.C) {
 			KindNames: []string{"app.deploy"},
 		},
 	}
-	err := servicemanager.Webhook.Create(webhook1)
+	err := servicemanager.Webhook.Create(context.TODO(), webhook1)
 	c.Assert(err, check.IsNil)
 	request, err := http.NewRequest("GET", "/1.6/events/webhooks/wh1", nil)
 	c.Assert(err, check.IsNil)

--- a/app/actions.go
+++ b/app/actions.go
@@ -97,7 +97,7 @@ var reserveUserApp = action.Action{
 		if !found {
 			return
 		}
-		if user, err := auth.GetUserByEmail(email); err == nil {
+		if user, err := auth.GetUserByEmail(ctx.Context, email); err == nil {
 			servicemanager.UserQuota.Inc(ctx.Context, user, -1)
 		}
 	},

--- a/app/app.go
+++ b/app/app.go
@@ -741,7 +741,7 @@ func Delete(ctx context.Context, app *App, evt *event.Event, requestID string) e
 	if err != nil {
 		logErr("Unable to unbind volumes", err)
 	}
-	owner, err := auth.GetUserByEmail(app.Owner)
+	owner, err := auth.GetUserByEmail(ctx, app.Owner)
 	if err == nil {
 		err = servicemanager.UserQuota.Inc(ctx, owner, -1)
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/app/bind"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/db/storagev2"
 	tsuruEnvs "github.com/tsuru/tsuru/envs"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/event"
@@ -48,6 +49,7 @@ import (
 	"github.com/tsuru/tsuru/types/quota"
 	routerTypes "github.com/tsuru/tsuru/types/router"
 	volumeTypes "github.com/tsuru/tsuru/types/volume"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	check "gopkg.in/check.v1"
 )
 
@@ -229,10 +231,16 @@ func (s *S) TestCreateApp(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	c.Assert(teamQuotaIncCalled, check.Equals, true)
 	c.Assert(userQuotaIncCalled, check.Equals, true)
@@ -261,10 +269,15 @@ func (s *S) TestCreateAppAlreadyExists(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	ra := App{Name: "appname", Platform: "python", TeamOwner: s.team.Name, Pool: "invalid"}
 	err = CreateApp(context.TODO(), &ra, s.user)
@@ -279,10 +292,15 @@ func (s *S) TestCreateAppDefaultPlan(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -302,10 +320,15 @@ func (s *S) TestCreateAppDefaultRouterForPool(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -326,10 +349,16 @@ func (s *S) TestCreateAppDefaultPlanForPool(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -350,10 +379,15 @@ func (s *S) TestCreateAppDefaultPlanWildCardForPool(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -374,10 +408,15 @@ func (s *S) TestCreateAppDefaultPlanWildCardNotMatchForPoolReturnError(c *check.
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err.Error(), check.Equals, "no plan found for pool")
 }
 
@@ -395,10 +434,14 @@ func (s *S) TestCreateAppDefaultPlanWildCardDefaultPlan(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -425,10 +468,15 @@ func (s *S) TestCreateAppWithExplicitPlan(c *check.C) {
 	}
 	expectedHost := "localhost"
 	config.Set("host", expectedHost)
-	s.conn.Users().Update(bson.M{"email": s.user.Email}, bson.M{"$set": bson.M{"quota.limit": 1}})
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1}})
+	c.Assert(err, check.IsNil)
+
 	config.Set("quota:units-per-app", 3)
 	defer config.Unset("quota:units-per-app")
-	err := CreateApp(context.TODO(), &a, s.user)
+	err = CreateApp(context.TODO(), &a, s.user)
 	c.Assert(err, check.IsNil)
 	retrievedApp, err := GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
@@ -474,15 +522,17 @@ func (s *S) TestCreateAppWithExplicitPlanConstraint(c *check.C) {
 
 func (s *S) TestCreateAppUserQuotaExceeded(c *check.C) {
 	app := App{Name: "america", Platform: "python", TeamOwner: s.team.Name}
-	s.conn.Users().Update(
-		bson.M{"email": s.user.Email},
-		bson.M{"$set": bson.M{"quota.limit": 1, "quota.inuse": 1}},
-	)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+	_, err = usersCollection.UpdateOne(context.TODO(), mongoBSON.M{"email": s.user.Email}, mongoBSON.M{"$set": mongoBSON.M{"quota.limit": 1, "quota.inuse": 1}})
+	c.Assert(err, check.IsNil)
+
 	s.mockService.UserQuota.OnInc = func(item quota.QuotaItem, q int) error {
 		c.Assert(item.GetName(), check.Equals, s.user.Email)
 		return &quota.QuotaExceededError{Available: 0, Requested: 1}
 	}
-	err := CreateApp(context.TODO(), &app, s.user)
+	err = CreateApp(context.TODO(), &app, s.user)
 	e, ok := err.(*appTypes.AppCreationError)
 	c.Assert(ok, check.Equals, true)
 	qe, ok := e.Err.(*quota.QuotaExceededError)

--- a/applog/provisioner_wrapper_test.go
+++ b/applog/provisioner_wrapper_test.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/job"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/provisiontest"
@@ -30,14 +30,13 @@ type ProvisionerWrapperSuite struct {
 func newFakeJob(c *check.C) {
 	_, err := servicemanager.Job.GetByName(context.TODO(), "j1")
 	if err == jobTypes.ErrJobNotFound {
-		conn, err := db.Conn()
+		collection, err := storagev2.JobsCollection()
 		c.Assert(err, check.IsNil)
-		defer conn.Close()
 		fakeJob := jobTypes.Job{
 			Name: "j1",
 			Pool: "mypool",
 		}
-		err = conn.Jobs().Insert(fakeJob)
+		_, err = collection.InsertOne(context.TODO(), fakeJob)
 		c.Assert(err, check.IsNil)
 	}
 }

--- a/auth/api_token_test.go
+++ b/auth/api_token_test.go
@@ -14,16 +14,16 @@ func (s *S) TestAPIAuth(c *check.C) {
 	user := User{Email: "para@xmen.com", APIKey: "Quenço"}
 	err := user.Create(context.TODO())
 	c.Assert(err, check.IsNil)
-	APIKey, err := user.RegenerateAPIKey()
+	APIKey, err := user.RegenerateAPIKey(context.TODO())
 	c.Assert(err, check.IsNil)
-	t, err := APIAuth("bearer " + APIKey)
+	t, err := APIAuth(context.TODO(), "bearer "+APIKey)
 	c.Assert(err, check.IsNil)
 	c.Assert(t.Token, check.Equals, APIKey)
 	c.Assert(t.UserEmail, check.Equals, user.Email)
 
 	c.Assert(user.APIKeyUsageCounter, check.Equals, int64(0))
 
-	err = user.Reload()
+	err = user.reload(context.TODO())
 	c.Assert(err, check.IsNil)
 
 	c.Assert(user.APIKeyLastAccess.IsZero(), check.Equals, false)
@@ -32,7 +32,7 @@ func (s *S) TestAPIAuth(c *check.C) {
 }
 
 func (s *S) TestAPIAuthNotFound(c *check.C) {
-	t, err := APIAuth("bearer invalid")
+	t, err := APIAuth(context.TODO(), "bearer invalid")
 	c.Assert(t, check.IsNil)
 	c.Assert(err, check.Equals, ErrInvalidToken)
 }

--- a/auth/multi/multi_test.go
+++ b/auth/multi/multi_test.go
@@ -627,7 +627,7 @@ func (t fakeToken) GetValue() string {
 	return string(t)
 }
 
-func (t fakeToken) User() (*authTypes.User, error) {
+func (t fakeToken) User(ctx context.Context) (*authTypes.User, error) {
 	return &authTypes.User{}, nil
 }
 

--- a/auth/native/native.go
+++ b/auth/native/native.go
@@ -48,7 +48,7 @@ func (s NativeScheme) Login(ctx context.Context, params map[string]string) (auth
 	if err != nil {
 		return nil, err
 	}
-	token, err := createToken(user, password)
+	token, err := createToken(ctx, user, password)
 	if err != nil {
 		return nil, err
 	}
@@ -56,11 +56,11 @@ func (s NativeScheme) Login(ctx context.Context, params map[string]string) (auth
 }
 
 func (s NativeScheme) Auth(ctx context.Context, token string) (auth.Token, error) {
-	return getToken(token)
+	return getToken(ctx, token)
 }
 
 func (s NativeScheme) Logout(ctx context.Context, token string) error {
-	return deleteToken(token)
+	return deleteToken(ctx, token)
 }
 
 func (s NativeScheme) Create(ctx context.Context, user *auth.User) (*auth.User, error) {
@@ -136,7 +136,7 @@ func (s NativeScheme) ResetPassword(ctx context.Context, user *auth.User, resetT
 }
 
 func (s NativeScheme) Remove(ctx context.Context, u *auth.User) error {
-	err := deleteAllTokens(u.Email)
+	err := deleteAllTokens(ctx, u.Email)
 	if err != nil {
 		return err
 	}

--- a/auth/native/native.go
+++ b/auth/native/native.go
@@ -45,7 +45,7 @@ func (s NativeScheme) Login(ctx context.Context, params map[string]string) (auth
 	if !ok {
 		return nil, ErrMissingPasswordError
 	}
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s NativeScheme) Create(ctx context.Context, user *auth.User) (*auth.User, 
 	if !validation.ValidateLength(user.Password, passwordMinLen, passwordMaxLen) {
 		return nil, ErrInvalidPassword
 	}
-	if _, err := auth.GetUserByEmail(user.Email); err == nil {
+	if _, err := auth.GetUserByEmail(ctx, user.Email); err == nil {
 		return nil, ErrEmailRegistered
 	}
 	if err := hashPassword(user); err != nil {
@@ -84,7 +84,7 @@ func (s NativeScheme) Create(ctx context.Context, user *auth.User) (*auth.User, 
 }
 
 func (s NativeScheme) ChangePassword(ctx context.Context, token auth.Token, oldPassword string, newPassword string) error {
-	user, err := auth.ConvertNewUser(token.User())
+	user, err := auth.ConvertNewUser(token.User(ctx))
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (s NativeScheme) ChangePassword(ctx context.Context, token auth.Token, oldP
 	}
 	user.Password = newPassword
 	hashPassword(user)
-	return user.Update()
+	return user.Update(ctx)
 }
 
 func (s NativeScheme) StartPasswordReset(ctx context.Context, user *auth.User) error {
@@ -135,7 +135,7 @@ func (s NativeScheme) ResetPassword(ctx context.Context, user *auth.User, resetT
 	if err != nil {
 		return err
 	}
-	return user.Update()
+	return user.Update(ctx)
 }
 
 func (s NativeScheme) Remove(ctx context.Context, u *auth.User) error {
@@ -143,7 +143,7 @@ func (s NativeScheme) Remove(ctx context.Context, u *auth.User) error {
 	if err != nil {
 		return err
 	}
-	return u.Delete()
+	return u.Delete(ctx)
 }
 
 func (s NativeScheme) Info(ctx context.Context) (*authTypes.SchemeInfo, error) {

--- a/auth/native/native_test.go
+++ b/auth/native/native_test.go
@@ -43,7 +43,7 @@ func (s *S) TestNativeLogin(c *check.C) {
 	token, err := scheme.Login(context.TODO(), params)
 	c.Assert(err, check.IsNil)
 	c.Assert(token.GetValue(), check.Not(check.Equals), "")
-	u, err := token.User()
+	u, err := token.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(u.Email, check.Equals, "timeredbull@globo.com")
 }
@@ -104,7 +104,7 @@ func (s *S) TestNativeCreate(c *check.C) {
 	retUser, err := scheme.Create(context.TODO(), user)
 	c.Assert(err, check.IsNil)
 	c.Assert(retUser, check.Equals, user)
-	dbUser, err := auth.GetUserByEmail(user.Email)
+	dbUser, err := auth.GetUserByEmail(context.TODO(), user.Email)
 	c.Assert(err, check.IsNil)
 	c.Assert(dbUser.Email, check.Equals, user.Email)
 	c.Assert(dbUser.Password, check.Not(check.Equals), "123456")
@@ -174,7 +174,7 @@ func (s *S) TestResetPassword(c *check.C) {
 	u := auth.User{Email: "blues@rush.com"}
 	err := u.Create(context.TODO())
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	p := u.Password
 	err = scheme.StartPasswordReset(context.TODO(), &u)
 	c.Assert(err, check.IsNil)
@@ -193,7 +193,7 @@ func (s *S) TestResetPassword(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = scheme.ResetPassword(context.TODO(), &u, token.Token)
 	c.Assert(err, check.IsNil)
-	u2, err := auth.GetUserByEmail(u.Email)
+	u2, err := auth.GetUserByEmail(context.TODO(), u.Email)
 	c.Assert(err, check.IsNil)
 	c.Assert(u2.Password, check.Not(check.Equals), p)
 	var m authtest.Mail
@@ -230,7 +230,7 @@ func (s *S) TestResetPasswordThirdToken(c *check.C) {
 	u := auth.User{Email: "profecia@raul.com"}
 	err := u.Create(context.TODO())
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	t, err := createPasswordToken(ctx, &u)
 	c.Assert(err, check.IsNil)
 
@@ -258,7 +258,7 @@ func (s *S) TestNativeRemove(c *check.C) {
 	params["password"] = "123456"
 	token, err := scheme.Login(ctx, params)
 	c.Assert(err, check.IsNil)
-	u, err := auth.ConvertNewUser(token.User())
+	u, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	err = scheme.Remove(ctx, u)
 	c.Assert(err, check.IsNil)
@@ -276,6 +276,6 @@ func (s *S) TestNativeRemove(c *check.C) {
 	err = cursor.All(ctx, &tokens)
 	c.Assert(err, check.IsNil)
 	c.Assert(tokens, check.HasLen, 0)
-	_, err = auth.GetUserByEmail("timeredbull@globo.com")
+	_, err = auth.GetUserByEmail(context.TODO(), "timeredbull@globo.com")
 	c.Assert(err, check.Equals, authTypes.ErrUserNotFound)
 }

--- a/auth/native/password_token.go
+++ b/auth/native/password_token.go
@@ -46,8 +46,8 @@ func createPasswordToken(ctx context.Context, u *auth.User) (*passwordToken, err
 	return &t, nil
 }
 
-func (t *passwordToken) user() (*auth.User, error) {
-	return auth.GetUserByEmail(t.UserEmail)
+func (t *passwordToken) user(ctx context.Context) (*auth.User, error) {
+	return auth.GetUserByEmail(ctx, t.UserEmail)
 }
 
 func getPasswordToken(ctx context.Context, token string) (*passwordToken, error) {

--- a/auth/native/password_token_test.go
+++ b/auth/native/password_token_test.go
@@ -51,10 +51,10 @@ func (s *S) TestPasswordTokenUser(c *check.C) {
 	u := auth.User{Email: "need@who.com", Password: "123456"}
 	err := u.Create(context.TODO())
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	t, err := createPasswordToken(context.TODO(), &u)
 	c.Assert(err, check.IsNil)
-	u2, err := t.user()
+	u2, err := t.user(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(*u2, check.DeepEquals, u)
 }

--- a/auth/native/suite_test.go
+++ b/auth/native/suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tsuru/tsuru/auth/authtest"
 	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/db/storagev2"
 	_ "github.com/tsuru/tsuru/storage/mongodb"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	"golang.org/x/crypto/bcrypt"
@@ -39,6 +40,9 @@ func (s *S) SetUpSuite(c *check.C) {
 	config.Set("auth:hash-cost", bcrypt.MinCost)
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "tsuru_auth_native_test")
+
+	storagev2.Reset()
+
 	var err error
 	s.server, err = authtest.NewSMTPServer()
 	c.Assert(err, check.IsNil)

--- a/auth/native/suite_test.go
+++ b/auth/native/suite_test.go
@@ -23,7 +23,6 @@ import (
 func Test(t *testing.T) { check.TestingT(t) }
 
 type S struct {
-	conn   *db.Storage
 	user   *auth.User
 	team   *authTypes.Team
 	server *authtest.SMTPServer
@@ -51,7 +50,6 @@ func (s *S) SetUpSuite(c *check.C) {
 }
 
 func (s *S) SetUpTest(c *check.C) {
-	s.conn, _ = db.Conn()
 	s.user = &auth.User{Email: "timeredbull@globo.com", Password: "123456"}
 	_, err := nativeScheme.Create(context.TODO(), s.user)
 	c.Assert(err, check.IsNil)
@@ -61,9 +59,8 @@ func (s *S) SetUpTest(c *check.C) {
 }
 
 func (s *S) TearDownTest(c *check.C) {
-	err := dbtest.ClearAllCollections(s.conn.Users().Database)
+	err := storagev2.ClearAllCollections(nil)
 	c.Assert(err, check.IsNil)
-	s.conn.Close()
 	cost = 0
 	tokenExpire = 0
 }

--- a/auth/native/token.go
+++ b/auth/native/token.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
@@ -144,7 +143,7 @@ func removeOldTokens(ctx context.Context, userEmail string) error {
 	}
 	var tokens []map[string]interface{}
 
-	opts := options.Find().SetSort(bson.M{"creation": 1}).SetLimit(int64(diff)).SetProjection(bson.M{"_id": 1})
+	opts := options.Find().SetSort(mongoBSON.M{"creation": 1}).SetLimit(int64(diff)).SetProjection(mongoBSON.M{"_id": 1})
 	cursor, err := collection.Find(ctx, mongoBSON.M{"useremail": userEmail}, opts)
 	if err != nil {
 		return nil

--- a/auth/native/token.go
+++ b/auth/native/token.go
@@ -11,16 +11,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storagev2"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/permission"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	"github.com/tsuru/tsuru/validation"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -123,27 +125,31 @@ func newUserToken(u *auth.User) (*Token, error) {
 	return &t, nil
 }
 
-func removeOldTokens(userEmail string) error {
-	conn, err := db.Conn()
+func removeOldTokens(ctx context.Context, userEmail string) error {
+	collection, err := storagev2.TokensCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	var limit int
 	if limit, err = config.GetInt("auth:max-simultaneous-sessions"); err != nil {
 		return err
 	}
-	count, err := conn.Tokens().Find(bson.M{"useremail": userEmail}).Count()
+	count, err := collection.CountDocuments(ctx, mongoBSON.M{"useremail": userEmail})
 	if err != nil {
 		return err
 	}
-	diff := count - limit
+	diff := count - int64(limit)
 	if diff < 1 {
 		return nil
 	}
 	var tokens []map[string]interface{}
-	err = conn.Tokens().Find(bson.M{"useremail": userEmail}).
-		Select(bson.M{"_id": 1}).Sort("creation").Limit(diff).All(&tokens)
+
+	opts := options.Find().SetSort(bson.M{"creation": 1}).SetLimit(int64(diff)).SetProjection(bson.M{"_id": 1})
+	cursor, err := collection.Find(ctx, mongoBSON.M{"useremail": userEmail}, opts)
+	if err != nil {
+		return nil
+	}
+	err = cursor.All(ctx, &tokens)
 	if err != nil {
 		return nil
 	}
@@ -151,7 +157,7 @@ func removeOldTokens(userEmail string) error {
 	for _, token := range tokens {
 		ids = append(ids, token["_id"])
 	}
-	_, err = conn.Tokens().RemoveAll(bson.M{"_id": bson.M{"$in": ids}})
+	_, err = collection.DeleteMany(ctx, mongoBSON.M{"_id": mongoBSON.M{"$in": ids}})
 	return err
 }
 
@@ -165,41 +171,39 @@ func checkPassword(passwordHash string, password string) error {
 	return auth.AuthenticationFailure{Message: "Authentication failed, wrong password."}
 }
 
-func createToken(u *auth.User, password string) (*Token, error) {
+func createToken(ctx context.Context, u *auth.User, password string) (*Token, error) {
 	if u.Email == "" {
 		return nil, errors.New("User does not have an email")
 	}
 	if err := checkPassword(u.Password, password); err != nil {
 		return nil, err
 	}
-	conn, err := db.Conn()
+	collection, err := storagev2.TokensCollection()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	token, err := newUserToken(u)
 	if err != nil {
 		return nil, err
 	}
-	err = conn.Tokens().Insert(token)
-	go removeOldTokens(u.Email)
+	_, err = collection.InsertOne(ctx, token)
+	go removeOldTokens(ctx, u.Email)
 	return token, err
 }
 
-func getToken(header string) (*Token, error) {
-	conn, err := db.Conn()
+func getToken(ctx context.Context, header string) (*Token, error) {
+	collection, err := storagev2.TokensCollection()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	var t Token
 	token, err := auth.ParseToken(header)
 	if err != nil {
 		return nil, err
 	}
-	err = conn.Tokens().Find(bson.M{"token": token}).One(&t)
+	err = collection.FindOne(ctx, mongoBSON.M{"token": token}).Decode(&t)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == mongo.ErrNoDocuments {
 			return nil, auth.ErrInvalidToken
 		}
 		return nil, err
@@ -210,21 +214,23 @@ func getToken(header string) (*Token, error) {
 	return &t, nil
 }
 
-func deleteToken(token string) error {
-	conn, err := db.Conn()
+func deleteToken(ctx context.Context, token string) error {
+	collection, err := storagev2.TokensCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	return conn.Tokens().Remove(bson.M{"token": token})
+	_, err = collection.DeleteOne(ctx, mongoBSON.M{"token": token})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func deleteAllTokens(email string) error {
-	conn, err := db.Conn()
+func deleteAllTokens(ctx context.Context, email string) error {
+	collection, err := storagev2.TokensCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	_, err = conn.Tokens().RemoveAll(bson.M{"useremail": email})
+	_, err = collection.DeleteMany(ctx, mongoBSON.M{"useremail": email})
 	return err
 }

--- a/auth/native/token.go
+++ b/auth/native/token.go
@@ -186,7 +186,7 @@ func createToken(ctx context.Context, u *auth.User, password string) (*Token, er
 		return nil, err
 	}
 	_, err = collection.InsertOne(ctx, token)
-	go removeOldTokens(ctx, u.Email)
+	go removeOldTokens(context.WithoutCancel(ctx), u.Email)
 	return token, err
 }
 

--- a/auth/native/token.go
+++ b/auth/native/token.go
@@ -50,8 +50,8 @@ func (t *Token) GetValue() string {
 	return t.Token
 }
 
-func (t *Token) User() (*authTypes.User, error) {
-	return auth.ConvertOldUser(auth.GetUserByEmail(t.UserEmail))
+func (t *Token) User(ctx context.Context) (*authTypes.User, error) {
+	return auth.ConvertOldUser(auth.GetUserByEmail(ctx, t.UserEmail))
 }
 
 func (t *Token) GetUserName() string {

--- a/auth/native/token_test.go
+++ b/auth/native/token_test.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/globalsign/mgo/bson"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/errors"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	"golang.org/x/crypto/bcrypt"
 	check "gopkg.in/check.v1"
 )
@@ -141,10 +142,14 @@ func (s *S) TestNewTokenReturnsErrorWhenUserIsNil(c *check.C) {
 }
 
 func (s *S) TestRemoveOld(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	config.Set("auth:max-simultaneous-sessions", 6)
 	defer config.Unset("auth:max-simultaneous-sessions")
 	user := "removeme@tsuru.io"
-	defer s.conn.Tokens().RemoveAll(bson.M{"useremail": user})
+	defer tokensCollection.DeleteMany(ctx, mongoBSON.M{"useremail": user})
 	initial := time.Now().Add(-48 * time.Hour)
 	for i := 0; i < 30; i++ {
 		token := Token{
@@ -153,14 +158,19 @@ func (s *S) TestRemoveOld(c *check.C) {
 			Creation:  initial.Add(time.Duration(i) * time.Hour),
 			UserEmail: user,
 		}
-		err := s.conn.Tokens().Insert(token)
+		_, err = tokensCollection.InsertOne(ctx, token)
 		c.Check(err, check.IsNil)
 	}
-	err := removeOldTokens(user)
+	err = removeOldTokens(ctx, user)
 	c.Assert(err, check.IsNil)
 	var tokens []Token
-	err = s.conn.Tokens().Find(bson.M{"useremail": user}).All(&tokens)
+
+	cursor, err := tokensCollection.Find(ctx, mongoBSON.M{"useremail": user})
 	c.Assert(err, check.IsNil)
+
+	err = cursor.All(ctx, &tokens)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(tokens, check.HasLen, 6)
 	names := make([]string, len(tokens))
 	for i := range tokens {
@@ -174,64 +184,76 @@ func (s *S) TestRemoveOld(c *check.C) {
 }
 
 func (s *S) TestRemoveOldNothingToRemove(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	config.Set("auth:max-simultaneous-sessions", 6)
 	defer config.Unset("auth:max-simultaneous-sessions")
 	user := "removeme@tsuru.io"
-	defer s.conn.Tokens().RemoveAll(bson.M{"useremail": user})
+	defer tokensCollection.DeleteMany(ctx, mongoBSON.M{"useremail": user})
 	t := Token{
 		Token:     "blablabla",
 		UserEmail: user,
 		Creation:  time.Now(),
 		Expires:   time.Hour,
 	}
-	err := s.conn.Tokens().Insert(t)
+	_, err = tokensCollection.InsertOne(ctx, t)
 	c.Assert(err, check.IsNil)
-	err = removeOldTokens(user)
+	err = removeOldTokens(ctx, user)
 	c.Assert(err, check.IsNil)
-	count, err := s.conn.Tokens().Find(bson.M{"useremail": user}).Count()
+	count, err := tokensCollection.CountDocuments(ctx, mongoBSON.M{"useremail": user})
 	c.Assert(err, check.IsNil)
-	c.Assert(count, check.Equals, 1)
+	c.Assert(count, check.Equals, int64(1))
 }
 
 func (s *S) TestRemoveOldWithoutSetting(c *check.C) {
-	err := removeOldTokens("something@tsuru.io")
+	err := removeOldTokens(context.TODO(), "something@tsuru.io")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *S) TestCreateTokenShouldSaveTheTokenInTheDatabase(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	u := auth.User{Email: "wolverine@xmen.com", Password: "123456"}
-	_, err := nativeScheme.Create(context.TODO(), &u)
+	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
 	defer u.Delete()
-	_, err = createToken(&u, "123456")
+	_, err = createToken(ctx, &u, "123456")
 	c.Assert(err, check.IsNil)
 	var result Token
-	err = s.conn.Tokens().Find(bson.M{"useremail": u.Email}).One(&result)
+	err = tokensCollection.FindOne(ctx, mongoBSON.M{"useremail": u.Email}).Decode(&result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result.Token, check.NotNil)
 }
 
 func (s *S) TestCreateTokenRemoveOldTokens(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	config.Set("auth:max-simultaneous-sessions", 2)
 	u := auth.User{Email: "para@xmen.com", Password: "123456"}
-	_, err := nativeScheme.Create(context.TODO(), &u)
+	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
 	defer u.Delete()
-	defer s.conn.Tokens().RemoveAll(bson.M{"useremail": u.Email})
+	defer tokensCollection.DeleteMany(ctx, mongoBSON.M{"useremail": u.Email})
 	t1, err := newUserToken(&u)
 	c.Assert(err, check.IsNil)
 	t2 := t1
 	t2.Token += "aa"
-	err = s.conn.Tokens().Insert(t1, t2)
+	_, err = tokensCollection.InsertMany(ctx, []any{t1, t2})
 	c.Assert(err, check.IsNil)
-	_, err = createToken(&u, "123456")
+	_, err = createToken(ctx, &u, "123456")
 	c.Assert(err, check.IsNil)
 	ok := make(chan bool, 1)
 	go func() {
 		for {
-			ct, err := s.conn.Tokens().Find(bson.M{"useremail": u.Email}).Count()
+			ct, err := tokensCollection.CountDocuments(ctx, mongoBSON.M{"useremail": u.Email})
 			c.Assert(err, check.IsNil)
-			if ct == 2 {
+			if ct == int64(2) {
 				ok <- true
 				return
 			}
@@ -246,60 +268,66 @@ func (s *S) TestCreateTokenRemoveOldTokens(c *check.C) {
 }
 
 func (s *S) TestCreateTokenUsesDefaultCostWhenHasCostIsUndefined(c *check.C) {
+	ctx := context.TODO()
 	err := config.Unset("auth:hash-cost")
 	c.Assert(err, check.IsNil)
 	defer config.Set("auth:hash-cost", bcrypt.MinCost)
 	u := auth.User{Email: "wolverine@xmen.com", Password: "123456"}
-	_, err = nativeScheme.Create(context.TODO(), &u)
+	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
 	defer u.Delete()
 	cost = 0
 	tokenExpire = 0
-	_, err = createToken(&u, "123456")
+	_, err = createToken(ctx, &u, "123456")
 	c.Assert(err, check.IsNil)
 }
 
 func (s *S) TestCreateTokenShouldReturnErrorIfTheProvidedUserDoesNotHaveEmailDefined(c *check.C) {
+	ctx := context.TODO()
 	u := auth.User{Password: "123"}
-	_, err := createToken(&u, "123")
+	_, err := createToken(ctx, &u, "123")
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, "^User does not have an email$")
 }
 
 func (s *S) TestCreateTokenShouldValidateThePassword(c *check.C) {
+	ctx := context.TODO()
 	u := auth.User{Email: "me@gmail.com", Password: "123456"}
 	_, err := nativeScheme.Create(context.TODO(), &u)
 	c.Assert(err, check.IsNil)
 	defer u.Delete()
-	_, err = createToken(&u, "123")
+	_, err = createToken(ctx, &u, "123")
 	c.Assert(err, check.NotNil)
 }
 
 func (s *S) TestGetToken(c *check.C) {
-	t, err := getToken("bearer " + s.token.GetValue())
+	t, err := getToken(context.TODO(), "bearer "+s.token.GetValue())
 	c.Assert(err, check.IsNil)
 	c.Assert(t.Token, check.Equals, s.token.GetValue())
 }
 
 func (s *S) TestGetTokenEmptyToken(c *check.C) {
-	u, err := getToken("bearer tokenthatdoesnotexist")
+	u, err := getToken(context.TODO(), "bearer tokenthatdoesnotexist")
 	c.Assert(u, check.IsNil)
 	c.Assert(err, check.Equals, auth.ErrInvalidToken)
 }
 
 func (s *S) TestGetTokenNotFound(c *check.C) {
-	t, err := getToken("bearer invalid")
+	t, err := getToken(context.TODO(), "bearer invalid")
 	c.Assert(t, check.IsNil)
 	c.Assert(err, check.Equals, auth.ErrInvalidToken)
 }
 
 func (s *S) TestGetTokenInvalid(c *check.C) {
-	t, err := getToken("invalid")
+	t, err := getToken(context.TODO(), "invalid")
 	c.Assert(t, check.IsNil)
 	c.Assert(err, check.Equals, auth.ErrInvalidToken)
 }
 
 func (s *S) TestGetExpiredToken(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
 
 	t := Token{
 		Token:    "tsuru-healer",
@@ -307,43 +335,53 @@ func (s *S) TestGetExpiredToken(c *check.C) {
 		Expires:  0,
 	}
 
-	defer s.conn.Tokens().Remove(bson.M{"token": t.Token})
+	defer tokensCollection.DeleteOne(ctx, mongoBSON.M{"token": t.Token})
 	t.Creation = time.Now().Add(-24 * time.Hour)
 	t.Expires = time.Hour
-	s.conn.Tokens().Insert(t)
-	t2, err := getToken(t.Token)
+	_, err = tokensCollection.InsertOne(ctx, t)
+	c.Assert(err, check.IsNil)
+
+	t2, err := getToken(ctx, t.Token)
 	c.Assert(t2, check.IsNil)
 	c.Assert(err, check.Equals, auth.ErrInvalidToken)
 }
 
 func (s *S) TestGetTokenNoExpiration(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	t := Token{
 		Token:    "tsuru-healer",
 		Creation: time.Now(),
 		Expires:  0,
 	}
-	defer s.conn.Tokens().Remove(bson.M{"token": t.Token})
+	defer tokensCollection.DeleteOne(ctx, mongoBSON.M{"token": t.Token})
 	t.Creation = time.Now().Add(-24 * time.Hour)
-	err := s.conn.Tokens().Insert(t)
+	_, err = tokensCollection.InsertOne(ctx, t)
 	c.Assert(err, check.IsNil)
 
-	t2, err := getToken(t.Token)
+	t2, err := getToken(ctx, t.Token)
 	c.Assert(err, check.IsNil)
 	c.Assert(t2.GetValue(), check.DeepEquals, t.GetValue())
 }
 
 func (s *S) TestDeleteToken(c *check.C) {
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
+	c.Assert(err, check.IsNil)
+
 	t := Token{
 		Token:    "tsuru-healer",
 		Creation: time.Now(),
 		Expires:  0,
 	}
 
-	err := s.conn.Tokens().Insert(t)
+	_, err = tokensCollection.InsertOne(ctx, t)
 	c.Assert(err, check.IsNil)
-	err = deleteToken(t.Token)
+	err = deleteToken(ctx, t.Token)
 	c.Assert(err, check.IsNil)
-	_, err = getToken("bearer " + t.Token)
+	_, err = getToken(ctx, "bearer "+t.Token)
 	c.Assert(err, check.Equals, auth.ErrInvalidToken)
 }
 
@@ -429,24 +467,26 @@ func (s *S) TestUserCheckPasswordValidatesThePassword(c *check.C) {
 }
 
 func (s *S) TestDeleteAllTokens(c *check.C) {
-	tokens := []Token{
-		{Token: "t1", UserEmail: "x@x.com", Creation: time.Now(), Expires: time.Hour},
-		{Token: "t2", UserEmail: "x@x.com", Creation: time.Now(), Expires: time.Hour},
-		{Token: "t3", UserEmail: "y@y.com", Creation: time.Now(), Expires: time.Hour},
+	tokens := []any{
+		Token{Token: "t1", UserEmail: "x@x.com", Creation: time.Now(), Expires: time.Hour},
+		Token{Token: "t2", UserEmail: "x@x.com", Creation: time.Now(), Expires: time.Hour},
+		Token{Token: "t3", UserEmail: "y@y.com", Creation: time.Now(), Expires: time.Hour},
 	}
-	err := s.conn.Tokens().Insert(tokens[0])
+
+	ctx := context.TODO()
+	tokensCollection, err := storagev2.TokensCollection()
 	c.Assert(err, check.IsNil)
-	err = s.conn.Tokens().Insert(tokens[1])
+
+	result, err := tokensCollection.InsertMany(ctx, tokens)
 	c.Assert(err, check.IsNil)
-	err = s.conn.Tokens().Insert(tokens[2])
+	c.Assert(result.InsertedIDs, check.HasLen, 3)
+
+	err = deleteAllTokens(ctx, "x@x.com")
 	c.Assert(err, check.IsNil)
-	err = deleteAllTokens("x@x.com")
+	count, err := tokensCollection.CountDocuments(ctx, mongoBSON.M{"useremail": "x@x.com"})
 	c.Assert(err, check.IsNil)
-	var tokensDB []Token
-	err = s.conn.Tokens().Find(bson.M{"useremail": "x@x.com"}).All(&tokensDB)
+	c.Assert(count, check.Equals, int64(0))
+	count, err = tokensCollection.CountDocuments(ctx, mongoBSON.M{"useremail": "y@y.com"})
 	c.Assert(err, check.IsNil)
-	c.Assert(tokensDB, check.HasLen, 0)
-	err = s.conn.Tokens().Find(bson.M{"useremail": "y@y.com"}).All(&tokensDB)
-	c.Assert(err, check.IsNil)
-	c.Assert(tokensDB, check.HasLen, 1)
+	c.Assert(count, check.Equals, int64(1))
 }

--- a/auth/native/token_test.go
+++ b/auth/native/token_test.go
@@ -220,7 +220,7 @@ func (s *S) TestCreateTokenShouldSaveTheTokenInTheDatabase(c *check.C) {
 	u := auth.User{Email: "wolverine@xmen.com", Password: "123456"}
 	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	_, err = createToken(ctx, &u, "123456")
 	c.Assert(err, check.IsNil)
 	var result Token
@@ -238,7 +238,7 @@ func (s *S) TestCreateTokenRemoveOldTokens(c *check.C) {
 	u := auth.User{Email: "para@xmen.com", Password: "123456"}
 	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	defer tokensCollection.DeleteMany(ctx, mongoBSON.M{"useremail": u.Email})
 	t1, err := newUserToken(&u)
 	c.Assert(err, check.IsNil)
@@ -275,7 +275,7 @@ func (s *S) TestCreateTokenUsesDefaultCostWhenHasCostIsUndefined(c *check.C) {
 	u := auth.User{Email: "wolverine@xmen.com", Password: "123456"}
 	_, err = nativeScheme.Create(ctx, &u)
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	cost = 0
 	tokenExpire = 0
 	_, err = createToken(ctx, &u, "123456")
@@ -295,7 +295,7 @@ func (s *S) TestCreateTokenShouldValidateThePassword(c *check.C) {
 	u := auth.User{Email: "me@gmail.com", Password: "123456"}
 	_, err := nativeScheme.Create(context.TODO(), &u)
 	c.Assert(err, check.IsNil)
-	defer u.Delete()
+	defer u.Delete(context.TODO())
 	_, err = createToken(ctx, &u, "123")
 	c.Assert(err, check.NotNil)
 }
@@ -386,14 +386,14 @@ func (s *S) TestDeleteToken(c *check.C) {
 }
 
 func (s *S) TestTokenGetUser(c *check.C) {
-	u, err := s.token.User()
+	u, err := s.token.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(u.Email, check.Equals, s.user.Email)
 }
 
 func (s *S) TestTokenGetUserUnknownEmail(c *check.C) {
 	t := Token{UserEmail: "something@something.com"}
-	u, err := t.User()
+	u, err := t.User(context.TODO())
 	c.Assert(u, check.IsNil)
 	c.Assert(err, check.NotNil)
 }

--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -178,7 +178,7 @@ func (s *oAuthScheme) handleToken(ctx context.Context, t *oauth2.Token) (*tokenW
 		return nil, err
 	}
 	token := tokenWrapper{Token: *t, UserEmail: user.Email}
-	err = token.save()
+	err = token.save(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -186,11 +186,11 @@ func (s *oAuthScheme) handleToken(ctx context.Context, t *oauth2.Token) (*tokenW
 }
 
 func (s *oAuthScheme) Logout(ctx context.Context, token string) error {
-	return deleteToken(token)
+	return deleteToken(ctx, token)
 }
 
 func (s *oAuthScheme) Auth(ctx context.Context, header string) (auth.Token, error) {
-	token, err := getToken(header)
+	token, err := getToken(ctx, header)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (s *oAuthScheme) Create(ctx context.Context, user *auth.User) (*auth.User, 
 }
 
 func (s *oAuthScheme) Remove(ctx context.Context, u *auth.User) error {
-	err := deleteAllTokens(u.Email)
+	err := deleteAllTokens(ctx, u.Email)
 	if err != nil {
 		return err
 	}

--- a/auth/oauth/oauth.go
+++ b/auth/oauth/oauth.go
@@ -155,7 +155,7 @@ func (s *oAuthScheme) handleToken(ctx context.Context, t *oauth2.Token) (*tokenW
 	if user.Email == "" {
 		return nil, ErrEmptyUserEmail
 	}
-	dbUser, err := auth.GetUserByEmail(user.Email)
+	dbUser, err := auth.GetUserByEmail(ctx, user.Email)
 	if err != nil {
 		if err != authTypes.ErrUserNotFound {
 			return nil, err
@@ -171,7 +171,7 @@ func (s *oAuthScheme) handleToken(ctx context.Context, t *oauth2.Token) (*tokenW
 		providerGroups := set.FromSlice(user.Groups)
 		if !dbGroups.Equal(providerGroups) {
 			dbUser.Groups = user.Groups
-			err = dbUser.Update()
+			err = dbUser.Update(ctx)
 		}
 	}
 	if err != nil {
@@ -250,5 +250,5 @@ func (s *oAuthScheme) Remove(ctx context.Context, u *auth.User) error {
 	if err != nil {
 		return err
 	}
-	return u.Delete()
+	return u.Delete(ctx)
 }

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -47,7 +47,7 @@ func (s *S) TestOAuthLogin(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(token.GetValue(), check.Equals, "my_token")
 	c.Assert(token.GetUserName(), check.Equals, "rand@althor.com")
-	u, err := token.User()
+	u, err := token.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(u.Email, check.Equals, "rand@althor.com")
 	c.Assert(s.reqs, check.HasLen, 2)
@@ -186,7 +186,7 @@ func (s *S) TestOAuthCreate(c *check.C) {
 	user := auth.User{Email: "x@x.com", Password: "something"}
 	_, err := scheme.Create(context.TODO(), &user)
 	c.Assert(err, check.IsNil)
-	dbUser, err := auth.GetUserByEmail(user.Email)
+	dbUser, err := auth.GetUserByEmail(context.TODO(), user.Email)
 	c.Assert(err, check.IsNil)
 	c.Assert(dbUser.Email, check.Equals, user.Email)
 	c.Assert(dbUser.Password, check.Equals, "")
@@ -201,7 +201,7 @@ func (s *S) TestOAuthRemove(c *check.C) {
 	params["redirectUrl"] = "http://localhost"
 	token, err := scheme.Login(context.TODO(), params)
 	c.Assert(err, check.IsNil)
-	u, err := auth.ConvertNewUser(token.User())
+	u, err := auth.ConvertNewUser(token.User(context.TODO()))
 	c.Assert(err, check.IsNil)
 	err = scheme.Remove(context.TODO(), u)
 	c.Assert(err, check.IsNil)
@@ -214,6 +214,6 @@ func (s *S) TestOAuthRemove(c *check.C) {
 	err = coll.Find(bson.M{"useremail": "rand@althor.com"}).All(&tokens)
 	c.Assert(err, check.IsNil)
 	c.Assert(tokens, check.HasLen, 0)
-	_, err = auth.GetUserByEmail("rand@althor.com")
+	_, err = auth.GetUserByEmail(context.TODO(), "rand@althor.com")
 	c.Assert(err, check.Equals, authTypes.ErrUserNotFound)
 }

--- a/auth/oauth/oauth_test.go
+++ b/auth/oauth/oauth_test.go
@@ -11,11 +11,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/globalsign/mgo/bson"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storagev2"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	"golang.org/x/oauth2"
 	check "gopkg.in/check.v1"
 )
@@ -55,7 +56,7 @@ func (s *S) TestOAuthLogin(c *check.C) {
 	c.Assert(s.bodies[0], check.Equals, "code=abcdefg&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost")
 	c.Assert(s.reqs[1].URL.Path, check.Equals, "/user")
 	c.Assert(s.reqs[1].Header.Get("Authorization"), check.Equals, "Bearer my_token")
-	dbToken, err := getToken("my_token")
+	dbToken, err := getToken(context.TODO(), "my_token")
 	c.Assert(err, check.IsNil)
 	c.Assert(dbToken.AccessToken, check.Equals, "my_token")
 	c.Assert(dbToken.UserEmail, check.Equals, "rand@althor.com")
@@ -156,7 +157,7 @@ func (s *S) TestOAuthParseInvalidStatus(c *check.C) {
 
 func (s *S) TestOAuthAuth(c *check.C) {
 	existing := tokenWrapper{Token: oauth2.Token{AccessToken: "myvalidtoken"}, UserEmail: "x@x.com"}
-	err := existing.save()
+	err := existing.save(context.TODO())
 	c.Assert(err, check.IsNil)
 	scheme := oAuthScheme{}
 	token, err := scheme.Auth(context.TODO(), "bearer myvalidtoken")
@@ -173,7 +174,7 @@ func (s *S) TestOAuthAuth_WhenTokenHasExpired(c *check.C) {
 		},
 		UserEmail: "x@x.com",
 	}
-	err := token.save()
+	err := token.save(context.TODO())
 	c.Assert(err, check.IsNil)
 	scheme := oAuthScheme{}
 	_, err = scheme.Auth(context.TODO(), "bearer myexpiredtoken")
@@ -209,9 +210,13 @@ func (s *S) TestOAuthRemove(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer conn.Close()
 	var tokens []tokenWrapper
-	coll := collection()
-	defer coll.Close()
-	err = coll.Find(bson.M{"useremail": "rand@althor.com"}).All(&tokens)
+	collection, err := storagev2.OAuth2TokensCollection()
+	c.Assert(err, check.IsNil)
+
+	cursor, err := collection.Find(context.TODO(), mongoBSON.M{"useremail": "rand@althor.com"})
+	c.Assert(err, check.IsNil)
+
+	err = cursor.All(context.TODO(), &tokens)
 	c.Assert(err, check.IsNil)
 	c.Assert(tokens, check.HasLen, 0)
 	_, err = auth.GetUserByEmail(context.TODO(), "rand@althor.com")

--- a/auth/oauth/suite_test.go
+++ b/auth/oauth/suite_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/tsuru/config"
-	"github.com/tsuru/tsuru/db"
 	"github.com/tsuru/tsuru/db/storagev2"
 	check "gopkg.in/check.v1"
 )
@@ -19,7 +18,6 @@ import (
 func Test(t *testing.T) { check.TestingT(t) }
 
 type S struct {
-	conn   *db.Storage
 	server *httptest.Server
 	reqs   []*http.Request
 	bodies []string
@@ -49,7 +47,6 @@ func (s *S) SetUpSuite(c *check.C) {
 }
 
 func (s *S) SetUpTest(c *check.C) {
-	s.conn, _ = db.Conn()
 	s.reqs = make([]*http.Request, 0)
 	s.bodies = make([]string, 0)
 	s.rsps = make(map[string]string)
@@ -58,7 +55,6 @@ func (s *S) SetUpTest(c *check.C) {
 func (s *S) TearDownTest(c *check.C) {
 	err := storagev2.ClearAllCollections(nil)
 	c.Assert(err, check.IsNil)
-	s.conn.Close()
 }
 
 func (s *S) TearDownSuite(c *check.C) {

--- a/auth/oauth/suite_test.go
+++ b/auth/oauth/suite_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/db"
-	"github.com/tsuru/tsuru/db/dbtest"
+	"github.com/tsuru/tsuru/db/storagev2"
 	check "gopkg.in/check.v1"
 )
 
@@ -56,15 +56,12 @@ func (s *S) SetUpTest(c *check.C) {
 }
 
 func (s *S) TearDownTest(c *check.C) {
-	err := dbtest.ClearAllCollections(s.conn.Users().Database)
+	err := storagev2.ClearAllCollections(nil)
 	c.Assert(err, check.IsNil)
 	s.conn.Close()
 }
 
 func (s *S) TearDownSuite(c *check.C) {
 	s.server.Close()
-	conn, err := db.Conn()
-	c.Assert(err, check.IsNil)
-	defer conn.Close()
-	dbtest.ClearAllCollections(conn.Users().Database)
+	storagev2.ClearAllCollections(nil)
 }

--- a/auth/oauth/token.go
+++ b/auth/oauth/token.go
@@ -30,8 +30,8 @@ func (t *tokenWrapper) GetValue() string {
 	return t.AccessToken
 }
 
-func (t *tokenWrapper) User() (*authTypes.User, error) {
-	return auth.ConvertOldUser(auth.GetUserByEmail(t.UserEmail))
+func (t *tokenWrapper) User(ctx context.Context) (*authTypes.User, error) {
+	return auth.ConvertOldUser(auth.GetUserByEmail(ctx, t.UserEmail))
 }
 
 func (t *tokenWrapper) GetUserName() string {

--- a/auth/oauth/token.go
+++ b/auth/oauth/token.go
@@ -7,15 +7,12 @@ package oauth
 import (
 	"context"
 
-	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
-	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/db"
-	"github.com/tsuru/tsuru/db/storage"
-	"github.com/tsuru/tsuru/log"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/permission"
 	authTypes "github.com/tsuru/tsuru/types/auth"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/oauth2"
 )
 
@@ -46,17 +43,21 @@ func (t *tokenWrapper) Permissions(ctx context.Context) ([]permission.Permission
 	return auth.BaseTokenPermission(ctx, t)
 }
 
-func getToken(header string) (*tokenWrapper, error) {
+func getToken(ctx context.Context, header string) (*tokenWrapper, error) {
 	var t tokenWrapper
 	token, err := auth.ParseToken(header)
 	if err != nil {
 		return nil, err
 	}
-	coll := collection()
-	defer coll.Close()
-	err = coll.Find(bson.M{"token.accesstoken": token}).One(&t)
+
+	collection, err := storagev2.OAuth2TokensCollection()
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		return nil, err
+	}
+
+	err = collection.FindOne(ctx, mongoBSON.M{"token.accesstoken": token}).Decode(&t)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
 			return nil, auth.ErrInvalidToken
 		}
 		return nil, err
@@ -64,36 +65,33 @@ func getToken(header string) (*tokenWrapper, error) {
 	return &t, nil
 }
 
-func deleteToken(token string) error {
-	coll := collection()
-	defer coll.Close()
-	return coll.Remove(bson.M{"token.accesstoken": token})
+func deleteToken(ctx context.Context, token string) error {
+	collection, err := storagev2.OAuth2TokensCollection()
+	if err != nil {
+		return err
+	}
+	_, err = collection.DeleteOne(ctx, mongoBSON.M{"token.accesstoken": token})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deleteAllTokens(email string) error {
-	coll := collection()
-	defer coll.Close()
-	_, err := coll.RemoveAll(bson.M{"useremail": email})
+func deleteAllTokens(ctx context.Context, email string) error {
+	collection, err := storagev2.OAuth2TokensCollection()
+	if err != nil {
+		return err
+	}
+	_, err = collection.DeleteMany(ctx, mongoBSON.M{"useremail": email})
 	return err
 }
 
-func (t *tokenWrapper) save() error {
-	coll := collection()
-	defer coll.Close()
-	return coll.Insert(t)
-}
-
-func collection() *storage.Collection {
-	name, err := config.GetString("auth:oauth:collection")
+func (t *tokenWrapper) save(ctx context.Context) error {
+	collection, err := storagev2.OAuth2TokensCollection()
 	if err != nil {
-		name = "oauth_tokens"
-		log.Debugf("auth:oauth:collection not found using default value: %s.", name)
+		return err
 	}
-	conn, err := db.Conn()
-	if err != nil {
-		log.Errorf("Failed to connect to the database: %s", err)
-	}
-	coll := conn.Collection(name)
-	coll.EnsureIndex(mgo.Index{Key: []string{"token.accesstoken"}})
-	return coll
+	_, err = collection.InsertOne(ctx, t)
+	return err
 }

--- a/auth/oidc/oidc.go
+++ b/auth/oidc/oidc.go
@@ -97,7 +97,7 @@ func (s *oidcScheme) Auth(ctx context.Context, token string) (auth.Token, error)
 		return nil, errMissingEmailClaim
 	}
 
-	user, err := auth.GetUserByEmail(identity.Email)
+	user, err := auth.GetUserByEmail(ctx, identity.Email)
 	if err == authTypes.ErrUserNotFound {
 		if s.registrationEnabled {
 			user = &auth.User{Email: identity.Email, Groups: identity.Groups}
@@ -121,7 +121,7 @@ func (s *oidcScheme) Auth(ctx context.Context, token string) (auth.Token, error)
 		providerGroups := set.FromSlice(identity.Groups)
 		if !dbGroups.Equal(providerGroups) {
 			user.Groups = identity.Groups
-			err = user.Update()
+			err = user.Update(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/auth/oidc/oidc_test.go
+++ b/auth/oidc/oidc_test.go
@@ -91,7 +91,7 @@ func (s *AuthSuite) TestLoginWithRSAKey(c *check.C) {
 	c.Assert(tsuruToken, check.Not(check.IsNil))
 	c.Assert(tsuruToken.GetUserName(), check.Equals, userEmail)
 
-	authUser, err := auth.GetUserByEmail(userEmail)
+	authUser, err := auth.GetUserByEmail(context.TODO(), userEmail)
 	c.Assert(err, check.IsNil)
 	c.Assert(authUser.Email, check.Equals, userEmail)
 }
@@ -114,7 +114,7 @@ func (s *AuthSuite) TestLoginWithRSAKeyWithBearer(c *check.C) {
 	c.Assert(tsuruToken, check.Not(check.IsNil))
 	c.Assert(tsuruToken.GetUserName(), check.Equals, userEmail)
 
-	authUser, err := auth.GetUserByEmail(userEmail)
+	authUser, err := auth.GetUserByEmail(context.TODO(), userEmail)
 	c.Assert(err, check.IsNil)
 	c.Assert(authUser.Email, check.Equals, userEmail)
 }
@@ -142,7 +142,7 @@ func (s *AuthSuite) TestLoginWithGroupsRSAKey(c *check.C) {
 	c.Assert(tsuruToken, check.Not(check.IsNil))
 	c.Assert(tsuruToken.GetUserName(), check.Equals, userEmail)
 
-	authUser, err := auth.GetUserByEmail(userEmail)
+	authUser, err := auth.GetUserByEmail(context.TODO(), userEmail)
 	c.Assert(err, check.IsNil)
 	c.Assert(authUser.Email, check.Equals, userEmail)
 	c.Assert(authUser.Groups, check.DeepEquals, []string{"group1", "group2"})
@@ -207,11 +207,11 @@ func (s *AuthSuite) TestLoginWithDisabledUser(c *check.C) {
 	userEmail := "disabled-user-test@company.com"
 
 	user := &auth.User{Email: userEmail, Disabled: true}
-	user.Delete() // remove from previous crashed tests
+	user.Delete(context.TODO()) // remove from previous crashed tests
 	err = user.Create(context.TODO())
 	c.Assert(err, check.IsNil)
 
-	defer user.Delete()
+	defer user.Delete(context.TODO())
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"email": userEmail,

--- a/auth/oidc/token.go
+++ b/auth/oidc/token.go
@@ -60,7 +60,7 @@ func (t *jwtToken) GetValue() string {
 	return t.Raw
 }
 
-func (t *jwtToken) User() (*authTypes.User, error) {
+func (t *jwtToken) User(ctx context.Context) (*authTypes.User, error) {
 	return t.AuthUser, nil
 }
 

--- a/auth/peer/peer.go
+++ b/auth/peer/peer.go
@@ -39,7 +39,7 @@ func (t *Token) GetValue() string {
 	return t.Token
 }
 
-func (t *Token) User() (*authTypes.User, error) {
+func (t *Token) User(ctx context.Context) (*authTypes.User, error) {
 	return nil, errors.New("no token user")
 }
 

--- a/auth/suite_test.go
+++ b/auth/suite_test.go
@@ -78,7 +78,7 @@ func (s *S) TearDownTest(c *check.C) {
 	s.server.Stop()
 	if s.user.Password != s.hashed {
 		s.user.Password = s.hashed
-		err := s.user.Update()
+		err := s.user.Update(context.TODO())
 		c.Assert(err, check.IsNil)
 	}
 }

--- a/auth/team_token.go
+++ b/auth/team_token.go
@@ -42,7 +42,7 @@ func (t *teamToken) GetValue() string {
 	return t.Token
 }
 
-func (t *teamToken) User() (*authTypes.User, error) {
+func (t *teamToken) User(ctx context.Context) (*authTypes.User, error) {
 	return &authTypes.User{
 		Email:     fmt.Sprintf("%s@%s", t.TokenID, TsuruTokenEmailDomain),
 		Quota:     quota.UnlimitedQuota,
@@ -114,7 +114,7 @@ func (s *teamTokenService) Delete(ctx context.Context, tokenID string) error {
 		return err
 	}
 	tt := teamToken(*token)
-	u, err := tt.User()
+	u, err := tt.User(ctx)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (s *teamTokenService) Delete(ctx context.Context, tokenID string) error {
 }
 
 func (s *teamTokenService) Create(ctx context.Context, args authTypes.TeamTokenCreateArgs, token authTypes.Token) (authTypes.TeamToken, error) {
-	u, err := token.User()
+	u, err := token.User(ctx)
 	if err != nil {
 		return authTypes.TeamToken{}, err
 	}

--- a/auth/team_token_test.go
+++ b/auth/team_token_test.go
@@ -139,7 +139,7 @@ func (s *S) Test_TeamTokenService_Authenticate_Expired(c *check.C) {
 }
 
 func (s *S) Test_TeamTokenService_AddRole(c *check.C) {
-	_, err := permission.NewRole("app-deployer", "app", "")
+	_, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	token, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{Team: s.team.Name}, &userToken{user: s.user})
 	c.Assert(err, check.IsNil)
@@ -156,7 +156,7 @@ func (s *S) Test_TeamTokenService_AddRole(c *check.C) {
 }
 
 func (s *S) Test_TeamTokenService_AddRoleTwice(c *check.C) {
-	_, err := permission.NewRole("app-deployer", "app", "")
+	_, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	token, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{Team: s.team.Name}, &userToken{user: s.user})
 	c.Assert(err, check.IsNil)
@@ -172,7 +172,7 @@ func (s *S) Test_TeamTokenService_AddRoleTwice(c *check.C) {
 }
 
 func (s *S) Test_TeamTokenService_AddRole_TokenNotFound(c *check.C) {
-	_, err := permission.NewRole("app-deployer", "app", "")
+	_, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	err = servicemanager.TeamToken.AddRole(context.TODO(), "invalid-token", "app-deployer", "myapp")
 	c.Assert(err, check.Equals, authTypes.ErrTeamTokenNotFound)
@@ -186,7 +186,7 @@ func (s *S) Test_TeamTokenService_AddRole_RoleNotFound(c *check.C) {
 }
 
 func (s *S) Test_TeamTokenService_RemoveRole(c *check.C) {
-	_, err := permission.NewRole("app-deployer", "app", "")
+	_, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	token, err := servicemanager.TeamToken.Create(context.TODO(), authTypes.TeamTokenCreateArgs{Team: s.team.Name}, &userToken{user: s.user})
 	c.Assert(err, check.IsNil)
@@ -252,7 +252,7 @@ func (s *S) Test_TeamTokenService_FindByUserToken(c *check.C) {
 }
 
 func (s *S) Test_TeamTokenService_FindByUserToken_ValidatePermissions(c *check.C) {
-	r1, err := permission.NewRole("app-deployer", "app", "")
+	r1, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	err = r1.AddPermissions(context.TODO(), permission.PermAppDeploy.FullName())
 	c.Assert(err, check.IsNil)
@@ -401,11 +401,11 @@ func (s *S) Test_TeamTokenService_Update_Expires(c *check.C) {
 }
 
 func (s *S) Test_TeamToken_Permissions(c *check.C) {
-	r1, err := permission.NewRole("app-deployer", "app", "")
+	r1, err := permission.NewRole(context.TODO(), "app-deployer", "app", "")
 	c.Assert(err, check.IsNil)
 	err = r1.AddPermissions(context.TODO(), "app.read", "app.deploy")
 	c.Assert(err, check.IsNil)
-	r2, err := permission.NewRole("app-updater", "app", "")
+	r2, err := permission.NewRole(context.TODO(), "app-updater", "app", "")
 	c.Assert(err, check.IsNil)
 	err = r2.AddPermissions(context.TODO(), "app.update")
 	c.Assert(err, check.IsNil)

--- a/auth/team_token_test.go
+++ b/auth/team_token_test.go
@@ -37,7 +37,7 @@ func (t *userToken) Engine() string {
 	return "user"
 }
 
-func (t *userToken) User() (*authTypes.User, error) {
+func (t *userToken) User(ctx context.Context) (*authTypes.User, error) {
 	return ConvertOldUser(t.user, nil)
 }
 func (t *userToken) Permissions(ctx context.Context) ([]permission.Permission, error) {
@@ -115,7 +115,7 @@ func (s *S) Test_TeamTokenService_Authenticate(c *check.C) {
 	namedToken, ok := t.(authTypes.NamedToken)
 	c.Assert(ok, check.Equals, true)
 	c.Assert(namedToken.GetTokenName(), check.Equals, fmt.Sprintf("cobrateam-%s", token.Token[:5]))
-	u, err := t.User()
+	u, err := t.User(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(u, check.DeepEquals, &authTypes.User{Email: fmt.Sprintf("%s@tsuru-team-token", namedToken.GetTokenName()), Quota: quota.UnlimitedQuota, FromToken: true})
 	perms, err := t.Permissions(context.TODO())

--- a/auth/token.go
+++ b/auth/token.go
@@ -54,7 +54,7 @@ func ParseToken(header string) (string, error) {
 }
 
 func BaseTokenPermission(ctx context.Context, t Token) ([]permission.Permission, error) {
-	u, err := ConvertNewUser(t.User())
+	u, err := ConvertNewUser(t.User(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -258,16 +258,16 @@ func UpdateRoleFromAllUsers(ctx context.Context, roleName, newRoleName, permissi
 		role.Description = desc
 	}
 	if (newRoleName == "") || (role.Name == newRoleName) {
-		return role.Update()
+		return role.Update(ctx)
 	}
 	role.Name = newRoleName
-	err = role.Add()
+	err = role.Add(ctx)
 	if err != nil {
 		return err
 	}
 	usersWithRole, err := ListUsersWithRole(roleName)
 	if err != nil {
-		errDtr := permission.DestroyRole(role.Name)
+		errDtr := permission.DestroyRole(ctx, role.Name)
 		if errDtr != nil {
 			return tsuruErrors.NewMultiError(err, errDtr)
 		}
@@ -276,7 +276,7 @@ func UpdateRoleFromAllUsers(ctx context.Context, roleName, newRoleName, permissi
 	for _, user := range usersWithRole {
 		errAddRole := user.AddRole(ctx, role.Name, string(role.ContextType))
 		if errAddRole != nil {
-			errDtr := permission.DestroyRole(role.Name)
+			errDtr := permission.DestroyRole(ctx, role.Name)
 			if errDtr != nil {
 				return tsuruErrors.NewMultiError(errAddRole, errDtr)
 			}
@@ -287,7 +287,7 @@ func UpdateRoleFromAllUsers(ctx context.Context, roleName, newRoleName, permissi
 			return errAddRole
 		}
 	}
-	err = permission.DestroyRole(roleName)
+	err = permission.DestroyRole(ctx, roleName)
 	if err != nil {
 		return err
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/globalsign/mgo/bson"
 	"github.com/pkg/errors"
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/db/storagev2"
@@ -131,7 +130,7 @@ func (u *User) Update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = usersCollection.ReplaceOne(ctx, bson.M{"email": u.Email}, u)
+	_, err = usersCollection.ReplaceOne(ctx, mongoBSON.M{"email": u.Email}, u)
 	return err
 }
 

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/globalsign/mgo/bson"
 	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/permission"
@@ -298,7 +297,7 @@ func (s *S) TestUserPermissionsWithRemovedRole(c *check.C) {
 	c.Assert(err, check.IsNil)
 	rolesCollection, err := storagev2.RolesCollection()
 	c.Assert(err, check.IsNil)
-	_, err = rolesCollection.DeleteOne(context.TODO(), bson.M{"_id": role.Name})
+	_, err = rolesCollection.DeleteOne(context.TODO(), mongoBSON.M{"_id": role.Name})
 	c.Assert(err, check.IsNil)
 	perms, err := u.Permissions(context.TODO())
 	c.Assert(err, check.IsNil)

--- a/cmd/tsurud/migrate.go
+++ b/cmd/tsurud/migrate.go
@@ -218,7 +218,7 @@ func setPoolToApps() error {
 }
 
 func createRole(ctx context.Context, name, contextType string) (permission.Role, error) {
-	role, err := permission.NewRole(name, contextType, "")
+	role, err := permission.NewRole(ctx, name, contextType, "")
 	if err == permTypes.ErrRoleAlreadyExists {
 		role, err = permission.FindRole(ctx, name)
 	}

--- a/cmd/tsurud/migrate.go
+++ b/cmd/tsurud/migrate.go
@@ -265,7 +265,7 @@ func migrateRoles() error {
 	if err != nil {
 		return err
 	}
-	users, err := auth.ListUsers()
+	users, err := auth.ListUsers(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -89,7 +89,7 @@ func addSuperRole(ctx context.Context, u *auth.User) error {
 	defaultRoleName := "AllowAll"
 	r, err := permission.FindRole(ctx, defaultRoleName)
 	if err != nil {
-		r, err = permission.NewRole(defaultRoleName, string(permTypes.CtxGlobal), "")
+		r, err = permission.NewRole(ctx, defaultRoleName, string(permTypes.CtxGlobal), "")
 		if err != nil {
 			return err
 		}

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -35,7 +35,7 @@ func (createRootUserCmd) Run(context *cmd.Context) error {
 		return err
 	}
 	email := context.Args[0]
-	user, err := auth.GetUserByEmail(email)
+	user, err := auth.GetUserByEmail(ctx, email)
 	if err == nil {
 		err = addSuperRole(ctx, user)
 		if err != nil {

--- a/cmd/tsurud/token_test.go
+++ b/cmd/tsurud/token_test.go
@@ -33,7 +33,7 @@ func (s *S) TestCreateRootUserCmdRun(c *check.C) {
 	err := command.Run(&context)
 	c.Assert(err, check.IsNil)
 	c.Assert(stdout.String(), check.Equals, "Password: \nConfirm: \nRoot user successfully created.\n")
-	u, err := auth.GetUserByEmail("my@user.com")
+	u, err := auth.GetUserByEmail(stdContext.TODO(), "my@user.com")
 	c.Assert(err, check.IsNil)
 	perms, err := u.Permissions(stdContext.TODO())
 	c.Assert(err, check.IsNil)

--- a/db/storage.go
+++ b/db/storage.go
@@ -105,12 +105,6 @@ func (s *Storage) Users() *storage.Collection {
 	return c
 }
 
-func (s *Storage) Tokens() *storage.Collection {
-	coll := s.Collection("tokens")
-	coll.EnsureIndex(mgo.Index{Key: []string{"token"}})
-	return coll
-}
-
 func (s *Storage) PasswordTokens() *storage.Collection {
 	return s.Collection("password_tokens")
 }

--- a/db/storage.go
+++ b/db/storage.go
@@ -109,10 +109,6 @@ func (s *Storage) PasswordTokens() *storage.Collection {
 	return s.Collection("password_tokens")
 }
 
-func (s *Storage) Roles() *storage.Collection {
-	return s.Collection("roles")
-}
-
 func IsCollectionExistsError(err error) bool {
 	if err == nil {
 		return false

--- a/db/storage.go
+++ b/db/storage.go
@@ -84,14 +84,6 @@ func (s *Storage) Apps() *storage.Collection {
 	return c
 }
 
-// Jobs returns the jobs collection from MongoDB.
-func (s *Storage) Jobs() *storage.Collection {
-	jobNameIndex := mgo.Index{Key: []string{"name"}, Unique: true}
-	c := s.Collection("jobs")
-	c.EnsureIndex(jobNameIndex)
-	return c
-}
-
 // Services returns the services collection from MongoDB.
 func (s *Storage) Services() *storage.Collection {
 	return s.Collection("services")

--- a/db/storage.go
+++ b/db/storage.go
@@ -105,10 +105,6 @@ func (s *Storage) Users() *storage.Collection {
 	return c
 }
 
-func (s *Storage) PasswordTokens() *storage.Collection {
-	return s.Collection("password_tokens")
-}
-
 func IsCollectionExistsError(err error) bool {
 	if err == nil {
 		return false

--- a/db/storage.go
+++ b/db/storage.go
@@ -94,17 +94,6 @@ func (s *Storage) ServiceInstances() *storage.Collection {
 	return s.Collection("service_instances")
 }
 
-// Users returns the users collection from MongoDB.
-func (s *Storage) Users() *storage.Collection {
-	c := s.Collection("users")
-	emailIndex := mgo.Index{Key: []string{"email"}, Unique: true}
-	c.EnsureIndex(emailIndex)
-
-	apikeyIndex := mgo.Index{Key: []string{"apikey"}}
-	c.EnsureIndex(apikeyIndex)
-	return c
-}
-
 func IsCollectionExistsError(err error) bool {
 	if err == nil {
 		return false

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -80,15 +80,6 @@ func (s *S) TestUsers(c *check.C) {
 	c.Assert(users, HasUniqueIndex, []string{"email"})
 }
 
-func (s *S) TestTokens(c *check.C) {
-	strg, err := Conn()
-	c.Assert(err, check.IsNil)
-	defer strg.Close()
-	tokens := strg.Tokens()
-	tokensc := strg.Collection("tokens")
-	c.Assert(tokens, check.DeepEquals, tokensc)
-}
-
 func (s *S) TestPasswordTokens(c *check.C) {
 	strg, err := Conn()
 	c.Assert(err, check.IsNil)

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -80,15 +80,6 @@ func (s *S) TestUsers(c *check.C) {
 	c.Assert(users, HasUniqueIndex, []string{"email"})
 }
 
-func (s *S) TestPasswordTokens(c *check.C) {
-	strg, err := Conn()
-	c.Assert(err, check.IsNil)
-	defer strg.Close()
-	tokens := strg.PasswordTokens()
-	tokensc := strg.Collection("password_tokens")
-	c.Assert(tokens, check.DeepEquals, tokensc)
-}
-
 func (s *S) TestApps(c *check.C) {
 	strg, err := Conn()
 	c.Assert(err, check.IsNil)

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -70,16 +70,6 @@ func (s *S) TestHealthCheck(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) TestUsers(c *check.C) {
-	strg, err := Conn()
-	c.Assert(err, check.IsNil)
-	defer strg.Close()
-	users := strg.Users()
-	usersc := strg.Collection("users")
-	c.Assert(users, check.DeepEquals, usersc)
-	c.Assert(users, HasUniqueIndex, []string{"email"})
-}
-
 func (s *S) TestApps(c *check.C) {
 	strg, err := Conn()
 	c.Assert(err, check.IsNil)

--- a/db/storage_test.go
+++ b/db/storage_test.go
@@ -116,12 +116,3 @@ func (s *S) TestServiceInstances(c *check.C) {
 	serviceInstancesc := strg.Collection("service_instances")
 	c.Assert(serviceInstances, check.DeepEquals, serviceInstancesc)
 }
-
-func (s *S) TestRoles(c *check.C) {
-	strg, err := Conn()
-	c.Assert(err, check.IsNil)
-	defer strg.Close()
-	roles := strg.Roles()
-	rolesc := strg.Collection("roles")
-	c.Assert(roles, check.DeepEquals, rolesc)
-}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -43,3 +43,7 @@ func JobsCollection() (*mongo.Collection, error) {
 func TokensCollection() (*mongo.Collection, error) {
 	return Collection("tokens")
 }
+
+func PasswordTokensCollection() (*mongo.Collection, error) {
+	return Collection("password_tokens")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -47,3 +47,7 @@ func TokensCollection() (*mongo.Collection, error) {
 func PasswordTokensCollection() (*mongo.Collection, error) {
 	return Collection("password_tokens")
 }
+
+func UsersCollection() (*mongo.Collection, error) {
+	return Collection("users")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -35,3 +35,7 @@ func RolesCollection() (*mongo.Collection, error) {
 func PlatformImagesCollection() (*mongo.Collection, error) {
 	return Collection("platform_images")
 }
+
+func JobsCollection() (*mongo.Collection, error) {
+	return Collection("jobs")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -39,3 +39,7 @@ func PlatformImagesCollection() (*mongo.Collection, error) {
 func JobsCollection() (*mongo.Collection, error) {
 	return Collection("jobs")
 }
+
+func TokensCollection() (*mongo.Collection, error) {
+	return Collection("tokens")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -55,3 +55,7 @@ func UsersCollection() (*mongo.Collection, error) {
 func TeamTokensCollection() (*mongo.Collection, error) {
 	return Collection("team_tokens")
 }
+
+func TeamsCollection() (*mongo.Collection, error) {
+	return Collection("teams")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -51,3 +51,7 @@ func PasswordTokensCollection() (*mongo.Collection, error) {
 func UsersCollection() (*mongo.Collection, error) {
 	return Collection("users")
 }
+
+func TeamTokensCollection() (*mongo.Collection, error) {
+	return Collection("team_tokens")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -67,3 +67,8 @@ func PlansCollection() (*mongo.Collection, error) {
 func WebhookCollection() (*mongo.Collection, error) {
 	return Collection("webhook")
 }
+
+func OAuth2TokensCollection() (*mongo.Collection, error) {
+	collectionName := getOAuthTokensCollectionName()
+	return Collection(collectionName)
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -63,3 +63,7 @@ func TeamsCollection() (*mongo.Collection, error) {
 func PlansCollection() (*mongo.Collection, error) {
 	return Collection("plans")
 }
+
+func WebhookCollection() (*mongo.Collection, error) {
+	return Collection("webhook")
+}

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -59,3 +59,7 @@ func TeamTokensCollection() (*mongo.Collection, error) {
 func TeamsCollection() (*mongo.Collection, error) {
 	return Collection("teams")
 }
+
+func PlansCollection() (*mongo.Collection, error) {
+	return Collection("plans")
+}

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -110,6 +110,15 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "tokens",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys: mongoBSON.D{{Key: "token", Value: 1}},
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -119,6 +119,19 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "users",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "email", Value: 1}},
+				Options: options.Index().SetUnique(true),
+			},
+			{
+				Keys: mongoBSON.D{{Key: "apikey", Value: 1}},
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -100,6 +100,16 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "jobs",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "name", Value: 1}},
+				Options: options.Index().SetUnique(true), //nolint
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -147,6 +147,26 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "cache",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "expireat", Value: 1}},
+				Options: options.Index().SetExpireAfterSeconds(1),
+			},
+		},
+	},
+
+	{
+		Collection: "service_broker_catalog_cache",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "expireat", Value: 1}},
+				Options: options.Index().SetExpireAfterSeconds(1),
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -132,6 +132,21 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "team_tokens",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "token", Value: 1}},
+				Options: options.Index().SetUnique(true),
+			},
+
+			{
+				Keys:    mongoBSON.D{{Key: "token_id", Value: 1}},
+				Options: options.Index().SetUnique(true),
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -167,6 +167,16 @@ var EnsureIndexes = []EnsureIndex{
 			},
 		},
 	},
+
+	{
+		Collection: "webhook",
+		Indexes: []mongo.IndexModel{
+			{
+				Keys:    mongoBSON.D{{Key: "name", Value: 1}},
+				Options: options.Index().SetUnique(true),
+			},
+		},
+	},
 }
 
 func EnsureIndexesCreated(db *mongo.Database) error {

--- a/db/storagev2/storage.go
+++ b/db/storagev2/storage.go
@@ -69,7 +69,10 @@ func connect() (*mongo.Client, *string, error) {
 		ctx,
 		options.Client().
 			ApplyURI(uri).
-			SetAppName("tsurud"),
+			SetAppName("tsurud").
+			SetBSONOptions(&options.BSONOptions{
+				NilSliceAsEmpty: true,
+			}),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/event/event.go
+++ b/event/event.go
@@ -1137,7 +1137,7 @@ func (e *Event) done(ctx context.Context, evtErr error, customData interface{}, 
 			log.Errorf("[events] error marking event as done - %#v: %s", e, err)
 		} else {
 			if !abort && servicemanager.Webhook != nil {
-				servicemanager.Webhook.Notify(e.ID.Hex())
+				servicemanager.Webhook.Notify(ctx, e.ID.Hex())
 			}
 		}
 	}()

--- a/event/webhook/webhook.go
+++ b/event/webhook/webhook.go
@@ -117,7 +117,7 @@ func (s *webhookService) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (s *webhookService) Notify(evtID string) {
+func (s *webhookService) Notify(ctx context.Context, evtID string) {
 	select {
 	case s.evtCh <- evtID:
 	case <-s.quitCh:
@@ -267,7 +267,7 @@ func validateURLs(w eventTypes.Webhook) error {
 	return nil
 }
 
-func (s *webhookService) Create(w eventTypes.Webhook) error {
+func (s *webhookService) Create(ctx context.Context, w eventTypes.Webhook) error {
 	if w.Name == "" {
 		return &tsuruErrors.ValidationError{Message: "webhook name must not be empty"}
 	}
@@ -280,19 +280,19 @@ func (s *webhookService) Create(w eventTypes.Webhook) error {
 	if err != nil {
 		return err
 	}
-	return s.storage.Insert(w)
+	return s.storage.Insert(ctx, w)
 }
 
-func (s *webhookService) Update(w eventTypes.Webhook) error {
+func (s *webhookService) Update(ctx context.Context, w eventTypes.Webhook) error {
 	err := validateURLs(w)
 	if err != nil {
 		return err
 	}
-	return s.storage.Update(w)
+	return s.storage.Update(ctx, w)
 }
 
-func (s *webhookService) Delete(name string) error {
-	return s.storage.Delete(name)
+func (s *webhookService) Delete(ctx context.Context, name string) error {
+	return s.storage.Delete(ctx, name)
 }
 
 func (s *webhookService) Find(ctx context.Context, name string) (eventTypes.Webhook, error) {

--- a/event/webhook/webhook.go
+++ b/event/webhook/webhook.go
@@ -186,6 +186,9 @@ func webhookBody(hook *eventTypes.Webhook, evt *event.Event) (io.Reader, error) 
 		hook.Method != http.MethodPatch {
 		return nil, nil
 	}
+	if hook.Headers == nil {
+		hook.Headers = make(http.Header)
+	}
 	hook.Headers.Set("Content-Type", "application/json")
 	data, err := json.Marshal(evt)
 	if err != nil {

--- a/event/webhook/webhook.go
+++ b/event/webhook/webhook.go
@@ -214,6 +214,11 @@ func (s *webhookService) doHook(hook eventTypes.Webhook, evt *event.Event) (err 
 		return err
 	}
 	req.Header = hook.Headers
+
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+
 	if req.UserAgent() == "" {
 		req.Header.Set("User-Agent", defaultUserAgent)
 	}

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -355,9 +355,8 @@ func (s *S) TestWebhookServiceUpdate(c *check.C) {
 	w, err := s.service.Find(context.TODO(), "xyz")
 	c.Assert(err, check.IsNil)
 	c.Assert(w, check.DeepEquals, eventTypes.Webhook{
-		Name:    "xyz",
-		URL:     "http://b",
-		Headers: http.Header{},
+		Name: "xyz",
+		URL:  "http://b",
 		EventFilter: eventTypes.WebhookEventFilter{
 			TargetTypes:  []string{},
 			TargetValues: []string{},

--- a/event/webhook/webhook_test.go
+++ b/event/webhook/webhook_test.go
@@ -83,7 +83,7 @@ func (s *S) TestWebhookServiceNotify(c *check.C) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	err = s.service.storage.Insert(eventTypes.Webhook{
+	err = s.service.storage.Insert(context.TODO(), eventTypes.Webhook{
 		Name:   "xyz",
 		URL:    srv.URL + "/a/b/c?a=b&c=d",
 		Method: "PUT",
@@ -93,7 +93,7 @@ func (s *S) TestWebhookServiceNotify(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(evt.UniqueID.Hex())
+	s.service.Notify(context.TODO(), evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, "ahoy {{ --")
 	c.Assert(receivedReq.Method, check.Equals, "PUT")
@@ -141,12 +141,12 @@ func (s *S) TestWebhookServiceNotifyDefaultBody(c *check.C) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	err = s.service.storage.Insert(eventTypes.Webhook{
+	err = s.service.storage.Insert(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  srv.URL,
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(evt.UniqueID.Hex())
+	s.service.Notify(context.TODO(), evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, string(evtData))
 	c.Assert(receivedReq.Method, check.Equals, "POST")
@@ -181,7 +181,7 @@ func (s *S) TestWebhookServiceNotifyTemplate(c *check.C) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	err = s.service.storage.Insert(eventTypes.Webhook{
+	err = s.service.storage.Insert(context.TODO(), eventTypes.Webhook{
 		Name:   "xyz",
 		URL:    srv.URL + "/a/b/c?a=b&c=d",
 		Method: "PUT",
@@ -191,7 +191,7 @@ func (s *S) TestWebhookServiceNotifyTemplate(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(evt.UniqueID.Hex())
+	s.service.Notify(context.TODO(), evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, "app.update.env.set event for app named myapp")
 	c.Assert(receivedReq.Method, check.Equals, "PUT")
@@ -239,13 +239,13 @@ func (s *S) TestWebhookServiceNotifyProxy(c *check.C) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	err = s.service.storage.Insert(eventTypes.Webhook{
+	err = s.service.storage.Insert(context.TODO(), eventTypes.Webhook{
 		Name:     "xyz",
 		URL:      "http://xyz/",
 		ProxyURL: srv.URL,
 	})
 	c.Assert(err, check.IsNil)
-	s.service.Notify(evt.UniqueID.Hex())
+	s.service.Notify(context.TODO(), evt.UniqueID.Hex())
 	<-called
 	c.Assert(string(receivedBody), check.Equals, string(evtData))
 	c.Assert(receivedReq.Method, check.Equals, "POST")
@@ -254,7 +254,7 @@ func (s *S) TestWebhookServiceNotifyProxy(c *check.C) {
 }
 
 func (s *S) TestWebhookServiceCreate(c *check.C) {
-	err := s.service.Create(eventTypes.Webhook{
+	err := s.service.Create(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  "http://a",
 		Body: "ahoy",
@@ -328,7 +328,7 @@ func (s *S) TestWebhookServiceCreateInvalid(c *check.C) {
 	}
 
 	for _, test := range tests {
-		err := s.service.Create(eventTypes.Webhook{
+		err := s.service.Create(context.TODO(), eventTypes.Webhook{
 			Name:     test.name,
 			URL:      test.url,
 			ProxyURL: test.proxyURL,
@@ -342,12 +342,12 @@ func (s *S) TestWebhookServiceCreateInvalid(c *check.C) {
 }
 
 func (s *S) TestWebhookServiceUpdate(c *check.C) {
-	err := s.service.Create(eventTypes.Webhook{
+	err := s.service.Create(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  "http://a",
 	})
 	c.Assert(err, check.IsNil)
-	err = s.service.Update(eventTypes.Webhook{
+	err = s.service.Update(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  "http://b",
 	})
@@ -368,7 +368,7 @@ func (s *S) TestWebhookServiceUpdate(c *check.C) {
 }
 
 func (s *S) TestWebhookServiceUpdateInvalid(c *check.C) {
-	err := s.service.Update(eventTypes.Webhook{
+	err := s.service.Update(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  "http://b",
 	})
@@ -376,18 +376,18 @@ func (s *S) TestWebhookServiceUpdateInvalid(c *check.C) {
 }
 
 func (s *S) TestWebhookServiceDelete(c *check.C) {
-	err := s.service.Create(eventTypes.Webhook{
+	err := s.service.Create(context.TODO(), eventTypes.Webhook{
 		Name: "xyz",
 		URL:  "http://a",
 	})
 	c.Assert(err, check.IsNil)
-	err = s.service.Delete("xyz")
+	err = s.service.Delete(context.TODO(), "xyz")
 	c.Assert(err, check.IsNil)
 	_, err = s.service.Find(context.TODO(), "xyz")
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }
 
 func (s *S) TestWebhookServiceDeleteNotFound(c *check.C) {
-	err := s.service.Delete("xyz")
+	err := s.service.Delete(context.TODO(), "xyz")
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }

--- a/job/actions.go
+++ b/job/actions.go
@@ -6,17 +6,16 @@ package job
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	jobTypes "github.com/tsuru/tsuru/types/job"
-	"gopkg.in/mgo.v2/bson"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 )
 
 var provisionJob = action.Action{
@@ -135,14 +134,14 @@ var insertJob = action.Action{
 }
 
 func insertJobDB(ctx context.Context, job *jobTypes.Job) error {
-	conn, err := db.Conn()
+	collection, err := storagev2.JobsCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = servicemanager.Job.GetByName(ctx, job.Name)
 	if err == jobTypes.ErrJobNotFound {
-		return conn.Jobs().Insert(job)
+		_, err = collection.InsertOne(ctx, job)
+		return err
 	} else if err == nil {
 		return jobTypes.ErrJobAlreadyExists
 	}
@@ -150,19 +149,22 @@ func insertJobDB(ctx context.Context, job *jobTypes.Job) error {
 }
 
 func updateJobDB(ctx context.Context, job *jobTypes.Job) error {
-	conn, err := db.Conn()
+	collection, err := storagev2.JobsCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+
 	oldJob, err := servicemanager.Job.GetByName(ctx, job.Name)
 	if err != nil {
 		return err
 	}
 	if reflect.DeepEqual(*oldJob, *job) {
-		return errors.New(fmt.Sprintf("no new values to be patched into job %s", job.Name))
+		return nil
 	}
-	return conn.Jobs().Update(bson.M{"name": job.Name}, job)
+
+	_, err = collection.ReplaceOne(ctx, mongoBSON.M{"name": job.Name}, job)
+
+	return err
 }
 
 var reserveTeamCronjob = action.Action{

--- a/job/actions.go
+++ b/job/actions.go
@@ -232,7 +232,7 @@ var reserveUserCronjob = action.Action{
 		if !found {
 			return
 		}
-		if user, err := auth.GetUserByEmail(email); err == nil {
+		if user, err := auth.GetUserByEmail(ctx.Context, email); err == nil {
 			servicemanager.UserQuota.Inc(ctx.Context, user, -1)
 		}
 	},

--- a/job/job.go
+++ b/job/job.go
@@ -106,7 +106,7 @@ func (*jobService) RemoveJob(ctx context.Context, job *jobTypes.Job) error {
 
 	servicemanager.TeamQuota.Inc(ctx, &authTypes.Team{Name: job.TeamOwner}, -1)
 	var user *auth.User
-	if user, err = auth.GetUserByEmail(job.Owner); err == nil {
+	if user, err = auth.GetUserByEmail(ctx, job.Owner); err == nil {
 		servicemanager.UserQuota.Inc(ctx, user, -1)
 	}
 	return nil

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/types/app"
+	"github.com/tsuru/tsuru/types/bind"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	jobTypes "github.com/tsuru/tsuru/types/job"
 	provisionTypes "github.com/tsuru/tsuru/types/provision"
@@ -293,7 +294,9 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 					},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(300); return &i }(),
+					ServiceEnvs:           []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -344,8 +347,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -388,8 +393,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -437,8 +444,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -483,9 +492,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "foo", Value: "bar"}, {Name: "xxx", Value: "yyy"}}},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "foo", Value: "bar"}, {Name: "xxx", Value: "yyy"}}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -527,8 +537,9 @@ func (s *S) TestUpdateJob(c *check.C) {
 						Command:               []string{"echo", "hello!"},
 					},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
+					ServiceEnvs:           []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "xxx", Value: "yyy"}}},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "xxx", Value: "yyy"}}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -568,8 +579,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -727,8 +740,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -776,8 +791,10 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -822,9 +839,12 @@ func (s *S) TestUpdateJob(c *check.C) {
 					Container: jobTypes.ContainerInfo{
 						OriginalImageSrc:      "alpine:v1",
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
+						Command:               []string{},
 					},
+					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -862,6 +882,7 @@ func (s *S) TestUpdateJob(c *check.C) {
 				Owner:     s.user.Email,
 				Pool:      s.Pool,
 				Teams:     []string{s.team.Name},
+				Metadata:  app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -873,7 +894,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ConcurrencyPolicy:     func() *string { s := "Forbid"; return &s }(),
+					ConcurrencyPolicy: func() *string { s := "Forbid"; return &s }(),
+					ServiceEnvs:       []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
 			},

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/types/app"
-	"github.com/tsuru/tsuru/types/bind"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	jobTypes "github.com/tsuru/tsuru/types/job"
 	provisionTypes "github.com/tsuru/tsuru/types/provision"
@@ -294,9 +293,7 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 					},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(300); return &i }(),
-					ServiceEnvs:           []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -347,10 +344,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -393,10 +388,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -444,10 +437,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -492,10 +483,9 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "foo", Value: "bar"}, {Name: "xxx", Value: "yyy"}}, Annotations: []app.MetadataItem{}},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "foo", Value: "bar"}, {Name: "xxx", Value: "yyy"}}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -537,9 +527,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						Command:               []string{"echo", "hello!"},
 					},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
-					ServiceEnvs:           []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "xxx", Value: "yyy"}}, Annotations: []app.MetadataItem{}},
+				Metadata: app.Metadata{Labels: []app.MetadataItem{{Name: "xxx", Value: "yyy"}}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -579,10 +568,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:latest",
@@ -740,10 +727,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -791,10 +776,8 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -839,12 +822,9 @@ func (s *S) TestUpdateJob(c *check.C) {
 					Container: jobTypes.ContainerInfo{
 						OriginalImageSrc:      "alpine:v1",
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
-						Command:               []string{},
 					},
-					ServiceEnvs: []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
-				Metadata: app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -882,7 +862,6 @@ func (s *S) TestUpdateJob(c *check.C) {
 				Owner:     s.user.Email,
 				Pool:      s.Pool,
 				Teams:     []string{s.team.Name},
-				Metadata:  app.Metadata{Labels: []app.MetadataItem{}, Annotations: []app.MetadataItem{}},
 				DeployOptions: &jobTypes.DeployOptions{
 					Kind:  provisionTypes.DeployImage,
 					Image: "alpine:v1",
@@ -894,8 +873,7 @@ func (s *S) TestUpdateJob(c *check.C) {
 						InternalRegistryImage: "fake.registry.io/job-some-job:latest",
 						Command:               []string{"echo", "hello!"},
 					},
-					ConcurrencyPolicy: func() *string { s := "Forbid"; return &s }(),
-					ServiceEnvs:       []bind.ServiceEnvVar{}, Envs: []bind.EnvVar{},
+					ConcurrencyPolicy:     func() *string { s := "Forbid"; return &s }(),
 					ActiveDeadlineSeconds: func() *int64 { i := int64(0); return &i }(),
 				},
 			},

--- a/permission/permissiontest/testing.go
+++ b/permission/permissiontest/testing.go
@@ -31,7 +31,7 @@ func ExistingUserWithPermission(c *check.C, scheme auth.Scheme, user *auth.User,
 		if idx != -1 {
 			baseName = baseName[:idx]
 		}
-		role, err := permission.NewRole(baseName+p.Scheme.FullName()+p.Context.Value, string(p.Context.CtxType), "")
+		role, err := permission.NewRole(ctx, baseName+p.Scheme.FullName()+p.Context.Value, string(p.Context.CtxType), "")
 		c.Assert(err, check.IsNil)
 		name := p.Scheme.FullName()
 		if name == "" {

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -65,6 +65,7 @@ func (s *InstanceSuite) SetUpTest(c *check.C) {
 	s.team = &authTypes.Team{Name: "raul"}
 
 	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
 
 	_, err = usersCollection.InsertOne(context.TODO(), s.user)
 	c.Assert(err, check.IsNil)

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -63,7 +63,10 @@ func (s *InstanceSuite) SetUpTest(c *check.C) {
 	dbtest.ClearAllCollections(s.conn.Apps().Database)
 	s.user = &auth.User{Email: "cidade@raul.com", Password: "123"}
 	s.team = &authTypes.Team{Name: "raul"}
-	err := s.conn.Users().Insert(s.user)
+
+	usersCollection, err := storagev2.UsersCollection()
+
+	_, err = usersCollection.InsertOne(context.TODO(), s.user)
 	c.Assert(err, check.IsNil)
 
 	servicemock.SetMockService(&s.mockService)
@@ -962,7 +965,11 @@ func (s *InstanceSuite) TestGetIdentfier(c *check.C) {
 
 func (s *InstanceSuite) TestGrantTeamToInstance(c *check.C) {
 	user := &auth.User{Email: "test@raul.com", Password: "123"}
-	err := s.conn.Users().Insert(user)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.InsertOne(context.TODO(), user)
 	c.Assert(err, check.IsNil)
 	team := authTypes.Team{Name: "test2"}
 	s.mockService.Team.OnFindByName = func(name string) (*authTypes.Team, error) {
@@ -986,7 +993,11 @@ func (s *InstanceSuite) TestGrantTeamToInstance(c *check.C) {
 
 func (s *InstanceSuite) TestRevokeTeamToInstance(c *check.C) {
 	user := &auth.User{Email: "test@raul.com", Password: "123"}
-	err := s.conn.Users().Insert(user)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.InsertOne(context.TODO(), user)
 	c.Assert(err, check.IsNil)
 	team := authTypes.Team{Name: "test2"}
 	s.mockService.Team.OnFindByName = func(name string) (*authTypes.Team, error) {
@@ -1014,7 +1025,11 @@ func (s *InstanceSuite) TestRevokeTeamToInstance(c *check.C) {
 
 func (s *InstanceSuite) TestRevokeTeamOwner(c *check.C) {
 	user := &auth.User{Email: "user@tsuru.io", Password: "12345"}
-	err := s.conn.Users().Insert(user)
+
+	usersCollection, err := storagev2.UsersCollection()
+	c.Assert(err, check.IsNil)
+
+	_, err = usersCollection.InsertOne(context.TODO(), user)
 	c.Assert(err, check.IsNil)
 	team := authTypes.Team{Name: "team-one"}
 	s.mockService.Team.OnFindByName = func(name string) (*authTypes.Team, error) {

--- a/storage/mongodb/auth_quota_test.go
+++ b/storage/mongodb/auth_quota_test.go
@@ -5,31 +5,33 @@
 package mongodb
 
 import (
+	"context"
+
 	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/db"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/storage/storagetest"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	check "gopkg.in/check.v1"
 )
 
 type userStorage struct{}
 
 func (s *userStorage) Create(user *auth.User) error {
-	conn, err := db.Conn()
+	usersCollection, err := storagev2.UsersCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	err = conn.Users().Insert(user)
+	_, err = usersCollection.InsertOne(context.TODO(), user)
 	return err
 }
 
 func (s *userStorage) Remove(user *auth.User) error {
-	conn, err := db.Conn()
+	usersCollection, err := storagev2.UsersCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	err = conn.Users().Remove(user)
+
+	_, err = usersCollection.DeleteOne(context.TODO(), mongoBSON.M{"email": user.Email})
 	return err
 }
 

--- a/storage/mongodb/plan.go
+++ b/storage/mongodb/plan.go
@@ -7,18 +7,12 @@ package mongodb
 import (
 	"context"
 
-	"github.com/globalsign/mgo"
-	"github.com/globalsign/mgo/bson"
-	"github.com/tsuru/tsuru/db"
-	dbStorage "github.com/tsuru/tsuru/db/storage"
 	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/types/app"
 	mongoBSON "go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
-
-const plansCollectionName = "plans"
 
 var _ app.PlanStorage = &PlanStorage{}
 
@@ -33,34 +27,30 @@ type planOnMongoDB struct {
 	Override *app.PlanOverride `bson:"-"`
 }
 
-func plansCollection(conn *db.Storage) *dbStorage.Collection {
-	return conn.Collection(plansCollectionName)
-}
-
 func (s *PlanStorage) Insert(ctx context.Context, p app.Plan) error {
-	conn, err := db.Conn()
+	collection, err := storagev2.PlansCollection()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+
 	if p.Default {
-		query := bson.M{"default": true}
-		span := newMongoDBSpan(ctx, mongoSpanUpdateAll, plansCollectionName)
+		query := mongoBSON.M{"default": true}
+		span := newMongoDBSpan(ctx, mongoSpanUpdateAll, collection.Name())
 		span.SetQueryStatement(query)
 		defer span.Finish()
 
-		_, err = plansCollection(conn).UpdateAll(query, bson.M{"$unset": bson.M{"default": false}})
+		_, err = collection.UpdateMany(ctx, query, mongoBSON.M{"$unset": mongoBSON.M{"default": false}})
 		if err != nil {
 			span.SetError(err)
 			return err
 		}
 	}
 
-	span := newMongoDBSpan(ctx, mongoSpanInsert, plansCollectionName)
+	span := newMongoDBSpan(ctx, mongoSpanInsert, collection.Name())
 	defer span.Finish()
 
-	err = plansCollection(conn).Insert(planOnMongoDB(p))
-	if err != nil && mgo.IsDup(err) {
+	_, err = collection.InsertOne(ctx, planOnMongoDB(p))
+	if err != nil && mongo.IsDuplicateKeyError(err) {
 		return app.ErrPlanAlreadyExists
 	}
 	span.SetError(err)
@@ -86,15 +76,14 @@ func (s *PlanStorage) FindDefault(ctx context.Context) (*app.Plan, error) {
 }
 
 func (s *PlanStorage) findByQuery(ctx context.Context, query mongoBSON.M) ([]app.Plan, error) {
-	span := newMongoDBSpan(ctx, mongoSpanFind, plansCollectionName)
-	span.SetQueryStatement(query)
-	defer span.Finish()
-
-	collection, err := storagev2.Collection(plansCollectionName)
+	collection, err := storagev2.PlansCollection()
 	if err != nil {
-		span.SetError(err)
 		return nil, err
 	}
+
+	span := newMongoDBSpan(ctx, mongoSpanFind, collection.Name())
+	span.SetQueryStatement(query)
+	defer span.Finish()
 
 	cursor, err := collection.Find(ctx, query, &options.FindOptions{Sort: mongoBSON.M{"_id": 1}})
 	if err != nil {
@@ -117,16 +106,16 @@ func (s *PlanStorage) findByQuery(ctx context.Context, query mongoBSON.M) ([]app
 }
 
 func (s *PlanStorage) FindByName(ctx context.Context, name string) (*app.Plan, error) {
-	span := newMongoDBSpan(ctx, mongoSpanFind, plansCollectionName)
+	var p planOnMongoDB
+	collection, err := storagev2.PlansCollection()
+	if err != nil {
+		return nil, err
+	}
+
+	span := newMongoDBSpan(ctx, mongoSpanFind, collection.Name())
 	span.SetMongoID(name)
 	defer span.Finish()
 
-	var p planOnMongoDB
-	collection, err := storagev2.Collection(plansCollectionName)
-	if err != nil {
-		span.SetError(err)
-		return nil, err
-	}
 	err = collection.FindOne(ctx, mongoBSON.M{"_id": name}).Decode(&p)
 	if err != nil {
 		span.SetError(err)
@@ -140,20 +129,27 @@ func (s *PlanStorage) FindByName(ctx context.Context, name string) (*app.Plan, e
 }
 
 func (s *PlanStorage) Delete(ctx context.Context, p app.Plan) error {
-	span := newMongoDBSpan(ctx, mongoSpanDelete, plansCollectionName)
+	collection, err := storagev2.PlansCollection()
+	if err != nil {
+		return err
+	}
+
+	span := newMongoDBSpan(ctx, mongoSpanDelete, collection.Name())
 	span.SetMongoID(p.Name)
 	defer span.Finish()
 
-	conn, err := db.Conn()
+	result, err := collection.DeleteOne(ctx, mongoBSON.M{"_id": p.Name})
+	if err == mongo.ErrNoDocuments {
+		return app.ErrPlanNotFound
+	}
 	if err != nil {
 		span.SetError(err)
 		return err
 	}
-	defer conn.Close()
-	err = plansCollection(conn).RemoveId(p.Name)
-	if err == mgo.ErrNotFound {
+
+	if result.DeletedCount == 0 {
 		return app.ErrPlanNotFound
 	}
-	span.SetError(err)
-	return err
+
+	return nil
 }

--- a/storage/storagetest/auth_quota_suite.go
+++ b/storage/storagetest/auth_quota_suite.go
@@ -41,8 +41,9 @@ func (s *UserQuotaSuite) TestGetNotFound(c *check.C) {
 
 func (s *UserQuotaSuite) TestSetLimit(c *check.C) {
 	user := &auth.User{Email: "example@example.com", Quota: quota.Quota{Limit: 5}}
-	s.UserStorage.Create(user)
-	err := s.UserQuotaStorage.SetLimit(context.TODO(), "example@example.com", 1)
+	err := s.UserStorage.Create(user)
+	c.Assert(err, check.IsNil)
+	err = s.UserQuotaStorage.SetLimit(context.TODO(), "example@example.com", 1)
 	c.Assert(err, check.IsNil)
 	quota, err := s.UserQuotaStorage.Get(context.TODO(), "example@example.com")
 	c.Assert(err, check.IsNil)

--- a/storage/storagetest/webhook_suite.go
+++ b/storage/storagetest/webhook_suite.go
@@ -7,7 +7,6 @@ package storagetest
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"sort"
 
 	eventTypes "github.com/tsuru/tsuru/types/event"
@@ -30,7 +29,7 @@ func (s *WebhookSuite) TestInsertWebhook(c *check.C) {
 			TargetValues: []string{"myapp"},
 		},
 	}
-	err := s.WebhookStorage.Insert(w)
+	err := s.WebhookStorage.Insert(context.TODO(), w)
 	c.Assert(err, check.IsNil)
 	webhook, err := s.WebhookStorage.FindByName(context.TODO(), w.Name)
 	c.Assert(err, check.IsNil)
@@ -39,7 +38,6 @@ func (s *WebhookSuite) TestInsertWebhook(c *check.C) {
 		TeamOwner: "team1",
 		URL:       "http://mysrv.com:123/abc?a=b",
 		Method:    "GET",
-		Headers:   http.Header{},
 		EventFilter: eventTypes.WebhookEventFilter{
 			KindTypes:    []string{},
 			KindNames:    []string{},
@@ -71,7 +69,7 @@ func (s *WebhookSuite) TestFindByEvent(c *check.C) {
 			Method:      "GET",
 			EventFilter: f,
 		}
-		err := s.WebhookStorage.Insert(w)
+		err := s.WebhookStorage.Insert(context.TODO(), w)
 		c.Assert(err, check.IsNil)
 	}
 	tests := []struct {
@@ -161,9 +159,9 @@ func (s *WebhookSuite) TestFindByEvent(c *check.C) {
 
 func (s *WebhookSuite) TestInsertDuplicateWebhook(c *check.C) {
 	t := eventTypes.Webhook{Name: "Webhookname"}
-	err := s.WebhookStorage.Insert(t)
+	err := s.WebhookStorage.Insert(context.TODO(), t)
 	c.Assert(err, check.IsNil)
-	err = s.WebhookStorage.Insert(t)
+	err = s.WebhookStorage.Insert(context.TODO(), t)
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookAlreadyExists)
 }
 
@@ -178,10 +176,10 @@ func webhooksNames(hooks []eventTypes.Webhook) []string {
 
 func (s *WebhookSuite) TestFindAllByTeams(c *check.C) {
 	w1 := eventTypes.Webhook{Name: "wh1", TeamOwner: "t1"}
-	err := s.WebhookStorage.Insert(w1)
+	err := s.WebhookStorage.Insert(context.TODO(), w1)
 	c.Assert(err, check.IsNil)
 	w2 := eventTypes.Webhook{Name: "wh2", TeamOwner: "t2"}
-	err = s.WebhookStorage.Insert(w2)
+	err = s.WebhookStorage.Insert(context.TODO(), w2)
 	c.Assert(err, check.IsNil)
 	webhooks, err := s.WebhookStorage.FindAllByTeams(context.TODO(), nil)
 	c.Assert(err, check.IsNil)
@@ -199,11 +197,11 @@ func (s *WebhookSuite) TestFindAllByTeams(c *check.C) {
 
 func (s *WebhookSuite) TestDelete(c *check.C) {
 	w := eventTypes.Webhook{Name: "wh1"}
-	err := s.WebhookStorage.Insert(w)
+	err := s.WebhookStorage.Insert(context.TODO(), w)
 	c.Assert(err, check.IsNil)
-	err = s.WebhookStorage.Delete("wh1")
+	err = s.WebhookStorage.Delete(context.TODO(), "wh1")
 	c.Assert(err, check.IsNil)
-	err = s.WebhookStorage.Delete("wh1")
+	err = s.WebhookStorage.Delete(context.TODO(), "wh1")
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 	_, err = s.WebhookStorage.FindByName(context.TODO(), "wh1")
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
@@ -211,17 +209,16 @@ func (s *WebhookSuite) TestDelete(c *check.C) {
 
 func (s *WebhookSuite) TestUpdate(c *check.C) {
 	w := eventTypes.Webhook{Name: "wh1"}
-	err := s.WebhookStorage.Insert(w)
+	err := s.WebhookStorage.Insert(context.TODO(), w)
 	c.Assert(err, check.IsNil)
 	w.Method = "GET"
-	err = s.WebhookStorage.Update(w)
+	err = s.WebhookStorage.Update(context.TODO(), w)
 	c.Assert(err, check.IsNil)
 	dbW, err := s.WebhookStorage.FindByName(context.TODO(), "wh1")
 	c.Assert(err, check.IsNil)
 	c.Assert(dbW, check.DeepEquals, &eventTypes.Webhook{
-		Name:    "wh1",
-		Method:  "GET",
-		Headers: http.Header{},
+		Name:   "wh1",
+		Method: "GET",
 		EventFilter: eventTypes.WebhookEventFilter{
 			KindTypes:    []string{},
 			KindNames:    []string{},
@@ -232,7 +229,7 @@ func (s *WebhookSuite) TestUpdate(c *check.C) {
 }
 
 func (s *WebhookSuite) TestUpdateNotFound(c *check.C) {
-	err := s.WebhookStorage.Update(eventTypes.Webhook{Name: "wh1"})
+	err := s.WebhookStorage.Update(context.TODO(), eventTypes.Webhook{Name: "wh1"})
 	c.Assert(err, check.Equals, eventTypes.ErrWebhookNotFound)
 }
 

--- a/types/auth/token.go
+++ b/types/auth/token.go
@@ -13,7 +13,7 @@ import (
 type Token interface {
 	GetValue() string
 	GetUserName() string
-	User() (*User, error)
+	User(ctx context.Context) (*User, error)
 	Engine() string
 	Permissions(ctx context.Context) ([]permission.Permission, error)
 }

--- a/types/event/webhook.go
+++ b/types/event/webhook.go
@@ -38,19 +38,19 @@ type Webhook struct {
 }
 
 type WebhookService interface {
-	Notify(evtID string)
-	Create(Webhook) error
-	Update(Webhook) error
-	Delete(string) error
+	Notify(ctx context.Context, evtID string)
+	Create(context.Context, Webhook) error
+	Update(context.Context, Webhook) error
+	Delete(context.Context, string) error
 	Find(context.Context, string) (Webhook, error)
 	List(context.Context, []string) ([]Webhook, error)
 }
 
 type WebhookStorage interface {
-	Insert(Webhook) error
-	Update(Webhook) error
+	Insert(context.Context, Webhook) error
+	Update(context.Context, Webhook) error
 	FindAllByTeams(context.Context, []string) ([]Webhook, error)
 	FindByName(context.Context, string) (*Webhook, error)
 	FindByEvent(ctx context.Context, f WebhookEventFilter, isSuccess bool) ([]Webhook, error)
-	Delete(string) error
+	Delete(context.Context, string) error
 }


### PR DESCRIPTION
MGO driver was unmaintained for years, cause a compatibility problem with newest mongodb releases, to ensure our maintenance  for long term, it's important to migrate to a active maintained driver, is a gradual change that may cause a unexpected bugs, to reduce the risk, we will work on this delivering small parts of work.


Added on part 1:

- [x] read teams 
- [x] read plans
- [x] read team tokens
- [x] read webhooks
- [x] read tracked instances
- [x] read quota
- [x] read cache
- [x] read app group

Added on part 2:
- [x] read service broker
- [x] read volumes
- [x] read events
- [x] write events
- [x] read event blocks
- [x] write event blocks

Added on part 3:
- [x] read cluster
- [x] read dynamic router
- [x] read platform images
- [x] write platform images
- [x] read platforms
- [x] write platforms
- [x] read pools
- [x] write pools
- [x] read pool constraints
- [x] write pool constraints
- [x] read service and service instances
- [x] read roles

TODO: 

- [x] write teams
- [x] write plans
- [x] write team tokens
- [x] ensure index of cache collection
- [x] write cache
- [x] write webhooks
- [ ] write tracked instances
- [ ] write quota
- [ ] write auth group
- [ ] write cluster
- [ ] write dynamic router
- [ ] write service broker
- [ ] write volumes
- [ ] read apps
- [ ] write apps
- [ ] write service and service instances
- [x] write roles
- [x] read password tokens
- [x] write password tokens
- [x] read tokens
- [x] write tokens
- [x] read users
- [x] write users
- [x] read jobs
- [x] write jobs