### PR TITLE
fix: Improving local development experience

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   mongo:
     container_name: mongo

--- a/router/api/router.go
+++ b/router/api/router.go
@@ -218,11 +218,13 @@ func (r *apiRouter) do(ctx context.Context, method, path string, headers http.He
 	}
 	resp, err := r.client.Do(req)
 	if r.debug {
-		bodyData, _ := io.ReadAll(body)
-		if err == nil {
-			code = resp.StatusCode
+		if body != nil {
+			bodyData, _ := io.ReadAll(body)
+			if err == nil {
+				code = resp.StatusCode
+			}
+			log.Debugf("%s %s %s %s: %d", r.routerName, method, url, string(bodyData), code)
 		}
-		log.Debugf("%s %s %s %s: %d", r.routerName, method, url, string(bodyData), code)
 	}
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
1. Removed deprecated `version` for `docker-compose.yml`
2. Local environment  on the Mac M series should start properly using `make local-mac-mseries`
3. Fixed bug that prevents Tsuru API to start when there's a Router without TLS support and debug flag is active.