### PR TITLE
ci: add k8s 1.31 to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         k8s_version:
         - "1.29"
         - "1.30"
+        - "1.31.0"
     steps:
     - uses: actions/checkout@master
     - name: Running up Kubernetes (using Minikube)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         k8s_version:
         - "1.29"
         - "1.30"
-        - "1.31.0"
+        - "1.31"
     steps:
     - uses: actions/checkout@master
     - name: Running up Kubernetes (using Minikube)


### PR DESCRIPTION
Kubernetes v1.31, the latest stable release, was made available on August 13th, 2024.

See https://kubernetes.io/releases/.