### PR TITLE
feat: Add filtering by tags in service instance list

### DIFF
--- a/api/permission.go
+++ b/api/permission.go
@@ -670,7 +670,7 @@ func validateContextValue(ctx context.Context, role permission.Role, contextValu
 			return &errors.ValidationError{Message: err.Error()}
 		}
 	case permTypes.CtxServiceInstance:
-		sInstances, err := service.GetServicesInstancesByTeamsAndNames(ctx, nil, []string{contextValue}, "", "")
+		sInstances, err := service.GetServicesInstancesByTeamsAndNames(ctx, nil, []string{contextValue}, "", "", []string{})
 		if err != nil {
 			return &errors.ValidationError{Message: err.Error()}
 		}

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -324,7 +324,7 @@ func removeServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 	return nil
 }
 
-func readableInstances(ctx stdContext.Context, contexts []permTypes.PermissionContext, appName, serviceName string) ([]service.ServiceInstance, error) {
+func readableInstances(ctx stdContext.Context, contexts []permTypes.PermissionContext, appName, serviceName string, tags []string) ([]service.ServiceInstance, error) {
 	teams := []string{}
 	instanceNames := []string{}
 	for _, c := range contexts {
@@ -343,7 +343,7 @@ func readableInstances(ctx stdContext.Context, contexts []permTypes.PermissionCo
 			teams = append(teams, c.Value)
 		}
 	}
-	return service.GetServicesInstancesByTeamsAndNames(ctx, teams, instanceNames, appName, serviceName)
+	return service.GetServicesInstancesByTeamsAndNames(ctx, teams, instanceNames, appName, serviceName, tags)
 }
 
 func filtersForServiceList(contexts []permTypes.PermissionContext) (teams []string, serviceNames []string, global bool) {
@@ -386,7 +386,8 @@ func serviceInstances(w http.ResponseWriter, r *http.Request, t auth.Token) erro
 	ctx := r.Context()
 	appName := r.URL.Query().Get("app")
 	contexts := permission.ContextsForPermission(ctx, t, permission.PermServiceInstanceRead)
-	instances, err := readableInstances(ctx, contexts, appName, "")
+	tags := r.URL.Query()["tag"]
+	instances, err := readableInstances(ctx, contexts, appName, "", tags)
 	if err != nil {
 		return err
 	}
@@ -542,7 +543,7 @@ func serviceInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		return err
 	}
 	contexts := permission.ContextsForPermission(ctx, t, permission.PermServiceInstanceRead)
-	instances, err := readableInstances(ctx, contexts, "", serviceName)
+	instances, err := readableInstances(ctx, contexts, "", serviceName, []string{})
 	if err != nil {
 		return err
 	}

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -454,7 +454,7 @@ func GetServiceInstancesByServices(ctx context.Context, services []Service, tags
 	return instances, err
 }
 
-func GetServicesInstancesByTeamsAndNames(ctx context.Context, teams []string, names []string, appName, serviceName string) ([]ServiceInstance, error) {
+func GetServicesInstancesByTeamsAndNames(ctx context.Context, teams []string, names []string, appName, serviceName string, tags []string) ([]ServiceInstance, error) {
 	filter := mongoBSON.M{}
 	if teams != nil || names != nil {
 		orConditions := []mongoBSON.M{}
@@ -474,6 +474,9 @@ func GetServicesInstancesByTeamsAndNames(ctx context.Context, teams []string, na
 	}
 	if serviceName != "" {
 		filter["service_name"] = serviceName
+	}
+	if len(tags) > 0 {
+		filter["tags"] = mongoBSON.M{"$all": tags}
 	}
 	collection, err := storagev2.ServiceInstancesCollection()
 	if err != nil {

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -292,6 +292,173 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToJob(c *check.C) {
 	c.Assert(sInstances, check.DeepEquals, expected)
 }
 
+func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesNoFilters(c *check.C) {
+	sInstance1 := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team1"},
+		Tags:        []string{"tag1"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team2"},
+		Tags:        []string{"tag2"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+
+	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance1)
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
+	c.Assert(err, check.IsNil)
+
+	sInstances, err := GetServicesInstancesByTeamsAndNames(context.TODO(), nil, nil, "", "", nil)
+	c.Assert(err, check.IsNil)
+
+	expected := []ServiceInstance{sInstance1, sInstance2}
+
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
+func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTeams(c *check.C) {
+	sInstance1 := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team1"},
+		Tags:        []string{},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team2"},
+		Tags:        []string{},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance1)
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
+	c.Assert(err, check.IsNil)
+
+	sInstances, err := GetServicesInstancesByTeamsAndNames(context.TODO(), []string{"team1"}, nil, "", "", nil)
+	c.Assert(err, check.IsNil)
+
+	expected := []ServiceInstance{sInstance1}
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
+func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByNames(c *check.C) {
+	sInstance1 := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team1"},
+		Tags:        []string{},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team2"},
+		Tags:        []string{},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance1)
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
+	c.Assert(err, check.IsNil)
+
+	sInstances, err := GetServicesInstancesByTeamsAndNames(context.TODO(), nil, []string{"t3sql"}, "", "", nil)
+	c.Assert(err, check.IsNil)
+
+	expected := []ServiceInstance{sInstance1}
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
+func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTags(c *check.C) {
+	sInstance1 := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Tags:        []string{"tag1", "tag2"},
+		Teams:       []string{"team1"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Tags:        []string{"tag1", "tag3"},
+		Teams:       []string{"team1"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance1)
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
+	c.Assert(err, check.IsNil)
+
+	sInstances, err := GetServicesInstancesByTeamsAndNames(context.TODO(), nil, nil, "", "", []string{"tag1"})
+	c.Assert(err, check.IsNil)
+
+	expected := []ServiceInstance{sInstance1, sInstance2}
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
+func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByMultipleCriteria(c *check.C) {
+	sInstance1 := ServiceInstance{
+		Name:        "t3sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team1"},
+		Tags:        []string{"tag1"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	sInstance2 := ServiceInstance{
+		Name:        "s9sql",
+		ServiceName: "mysql",
+		Teams:       []string{"team2"},
+		Tags:        []string{"tag1", "tag3"},
+		Apps:        []string{},
+		Jobs:        []string{},
+		Parameters:  map[string]interface{}{},
+	}
+	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance1)
+	c.Assert(err, check.IsNil)
+	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
+	c.Assert(err, check.IsNil)
+
+	sInstances, err := GetServicesInstancesByTeamsAndNames(context.TODO(), []string{"team2"}, []string{"s9sql"}, "", "", []string{"tag1"})
+	c.Assert(err, check.IsNil)
+
+	expected := []ServiceInstance{sInstance2}
+	c.Assert(sInstances, check.DeepEquals, expected)
+}
+
 func (s *InstanceSuite) TestGetServiceInstancesByServices(c *check.C) {
 	srvc := Service{Name: "mysql"}
 	servicesCollection, err := storagev2.ServicesCollection()


### PR DESCRIPTION
When I started developing an improvement to the "tsuru service list" command, I noticed that the GET request made by the tsuru-client makes a request to the endpoint '/1.0/services/instances' and not to '/1.0/services/', so I made this endpoint also able to use tags to filter service instances.