### PR TITLE
Feat/auto scale behavior client

### DIFF
--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -4727,6 +4727,22 @@ definitions:
           $ref: "#/definitions/AutoScalePrometheus"
       version:
         type: integer
+      behavior:
+        type: object
+        description: Behavior settings for scaling actions
+        properties:
+          scaleDown:
+            type: object
+            properties:
+              stabilizationWindow:
+                type: integer
+                description: Time in seconds for stabilization before scaling down
+              percentagePolicyValue:
+                type: integer
+                description: Percentage threshold for scaling down
+              unitsPolicyValue:
+                type: integer
+                description: Minimum number of units to scale down
   AutoScaleSchedule:
     description: Auto Scale schedules struct
     type: object

--- a/provision/kubernetes/autoscale.go
+++ b/provision/kubernetes/autoscale.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
-	"k8s.io/utils/ptr"
 	k8sutilsptr "k8s.io/utils/ptr"
 )
 
@@ -658,7 +657,7 @@ func settingValueStabilizationWindow(behavior *autoscalingv2.HorizontalPodAutosc
 		behavior.ScaleDown.StabilizationWindowSeconds = behaviorSpec.StabilizationWindow
 		return
 	}
-	behavior.ScaleDown.StabilizationWindowSeconds = ptr.To(int32(300))
+	behavior.ScaleDown.StabilizationWindowSeconds = k8sutilsptr.To(int32(300))
 }
 
 func getPoliciesFromBehavior(behaviorSpec *provTypes.ScaleDownPoliciy) (policies []autoscalingv2.HPAScalingPolicy) {

--- a/provision/kubernetes/autoscale_test.go
+++ b/provision/kubernetes/autoscale_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
 )
 
 func toInt32Ptr(i int32) *int32 {
@@ -69,7 +70,8 @@ func testHPAWithTarget(tg autoscalingv2.MetricTarget) *autoscalingv2.HorizontalP
 			},
 			Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleDown: &autoscalingv2.HPAScalingRules{
-					SelectPolicy: &policyMin,
+					SelectPolicy:               &policyMin,
+					StabilizationWindowSeconds: toInt32Ptr(300),
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						{
 							Type:          autoscalingv2.PercentScalingPolicy,
@@ -166,7 +168,8 @@ func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs 
 				HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{
 					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 						ScaleDown: &autoscalingv2.HPAScalingRules{
-							SelectPolicy: &policyMin,
+							StabilizationWindowSeconds: ptr.To(int32(300)),
+							SelectPolicy:               &policyMin,
 							Policies: []autoscalingv2.HPAScalingPolicy{
 								{
 									Type:          autoscalingv2.PercentScalingPolicy,
@@ -1102,6 +1105,13 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 			AverageCPU: "500m",
 			Version:    1,
 			Process:    "web",
+			Behavior: provTypes.BehaviorAutoScaleSpec{
+				ScaleDown: &provTypes.ScaleDownPoliciy{
+					StabilizationWindow:   ptr.To(int32(300)),
+					PercentagePolicyValue: ptr.To(int32(10)),
+					UnitsPolicyValue:      ptr.To(int32(3)),
+				},
+			},
 		},
 		{
 			MinUnits:   2,
@@ -1109,6 +1119,13 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 			AverageCPU: "200m",
 			Version:    1,
 			Process:    "worker",
+			Behavior: provTypes.BehaviorAutoScaleSpec{
+				ScaleDown: &provTypes.ScaleDownPoliciy{
+					StabilizationWindow:   ptr.To(int32(300)),
+					PercentagePolicyValue: ptr.To(int32(10)),
+					UnitsPolicyValue:      ptr.To(int32(3)),
+				},
+			},
 		},
 	})
 }

--- a/provision/kubernetes/autoscale_test.go
+++ b/provision/kubernetes/autoscale_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/utils/ptr"
 )
 
 func toInt32Ptr(i int32) *int32 {
@@ -168,7 +167,7 @@ func testKEDAScaledObject(cpuTrigger *kedav1alpha1.ScaleTriggers, scheduleSpecs 
 				HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{
 					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
 						ScaleDown: &autoscalingv2.HPAScalingRules{
-							StabilizationWindowSeconds: ptr.To(int32(300)),
+							StabilizationWindowSeconds: toInt32Ptr(300),
 							SelectPolicy:               &policyMin,
 							Policies: []autoscalingv2.HPAScalingPolicy{
 								{
@@ -1107,9 +1106,9 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 			Process:    "web",
 			Behavior: provTypes.BehaviorAutoScaleSpec{
 				ScaleDown: &provTypes.ScaleDownPoliciy{
-					StabilizationWindow:   ptr.To(int32(300)),
-					PercentagePolicyValue: ptr.To(int32(10)),
-					UnitsPolicyValue:      ptr.To(int32(3)),
+					StabilizationWindow:   toInt32Ptr(300),
+					PercentagePolicyValue: toInt32Ptr(10),
+					UnitsPolicyValue:      toInt32Ptr(3),
 				},
 			},
 		},
@@ -1121,9 +1120,9 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 			Process:    "worker",
 			Behavior: provTypes.BehaviorAutoScaleSpec{
 				ScaleDown: &provTypes.ScaleDownPoliciy{
-					StabilizationWindow:   ptr.To(int32(300)),
-					PercentagePolicyValue: ptr.To(int32(10)),
-					UnitsPolicyValue:      ptr.To(int32(3)),
+					StabilizationWindow:   toInt32Ptr(300),
+					PercentagePolicyValue: toInt32Ptr(10),
+					UnitsPolicyValue:      toInt32Ptr(3),
 				},
 			},
 		},


### PR DESCRIPTION
This code aims to return the scale down behavior value in the API. The returned fields are:

- `stabilizationWindow`
- `percentagePolicyValue`
- `unitsPolicyValue`

Another change made was setting the default value of `stabilizationWindow` to 300 seconds if it is not provided.