### PR TITLE
Feat - Multiple App Healthchecks

### DIFF
--- a/app/version/customdata.go
+++ b/app/version/customdata.go
@@ -14,13 +14,12 @@ import (
 	provTypes "github.com/tsuru/tsuru/types/provision"
 )
 
-var (
-	procfileRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+):\s*(.+)$`)
-)
+var procfileRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+):\s*(.+)$`)
 
 type customData struct {
 	Hooks       *provTypes.TsuruYamlHooks
 	Healthcheck *provTypes.TsuruYamlHealthcheck
+	Processes   []provTypes.TsuruYamlProcess
 	Kubernetes  *tsuruYamlKubernetesConfig
 }
 
@@ -61,6 +60,7 @@ func unmarshalYamlData(data map[string]interface{}) (provTypes.TsuruYamlData, er
 
 	result := provTypes.TsuruYamlData{
 		Hooks:       custom.Hooks,
+		Processes:   custom.Processes,
 		Healthcheck: custom.Healthcheck,
 	}
 	if custom.Kubernetes == nil {
@@ -176,6 +176,14 @@ func GetProcessesFromProcfile(strProcfile string) map[string][]string {
 		if p := procfileRegex.FindStringSubmatch(process); p != nil {
 			processes[p[1]] = []string{strings.TrimSpace(p[2])}
 		}
+	}
+	return processes
+}
+
+func GetProcessesFromYamlProcess(yamlProcesses []provTypes.TsuruYamlProcess) map[string][]string {
+	processes := make(map[string][]string, len(yamlProcesses))
+	for _, process := range yamlProcesses {
+		processes[process.Name] = []string{strings.TrimSpace(process.Command)}
 	}
 	return processes
 }

--- a/app/version/customdata.go
+++ b/app/version/customdata.go
@@ -19,8 +19,8 @@ var procfileRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+):\s*(.+)$`)
 type customData struct {
 	Hooks       *provTypes.TsuruYamlHooks
 	Healthcheck *provTypes.TsuruYamlHealthcheck
-	Processes   []provTypes.TsuruYamlProcess
 	Kubernetes  *tsuruYamlKubernetesConfig
+	Processes   []provTypes.TsuruYamlProcess
 }
 
 type tsuruYamlKubernetesConfig struct {

--- a/app/version/customdata_test.go
+++ b/app/version/customdata_test.go
@@ -5,13 +5,14 @@
 package version
 
 import (
+	provTypes "github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
 )
 
 func (s *S) TestGetProcessesFromProcfile(c *check.C) {
 	tests := []struct {
-		procfile string
 		expected map[string][]string
+		procfile string
 	}{
 		{procfile: "", expected: map[string][]string{}},
 		{procfile: "invalid", expected: map[string][]string{}},
@@ -34,6 +35,33 @@ func (s *S) TestGetProcessesFromProcfile(c *check.C) {
 	}
 	for i, t := range tests {
 		v := GetProcessesFromProcfile(t.procfile)
+		c.Check(v, check.DeepEquals, t.expected, check.Commentf("failed test %d", i))
+	}
+}
+
+func (s *S) TestGetProcessesFromYamlProcess(c *check.C) {
+	tests := []struct {
+		expected  map[string][]string
+		processes []provTypes.TsuruYamlProcess
+	}{
+		{processes: nil, expected: map[string][]string{}},
+		{processes: []provTypes.TsuruYamlProcess{}, expected: map[string][]string{}},
+		{
+			processes: []provTypes.TsuruYamlProcess{{Name: "web", Command: "python app.py"}},
+			expected: map[string][]string{
+				"web": {"python app.py"},
+			},
+		},
+		{
+			processes: []provTypes.TsuruYamlProcess{{Name: "web", Command: "python app.py"}, {Name: "worker", Command: "python worker.py"}},
+			expected: map[string][]string{
+				"web":    {"python app.py"},
+				"worker": {"python worker.py"},
+			},
+		},
+	}
+	for i, t := range tests {
+		v := GetProcessesFromYamlProcess(t.processes)
 		c.Check(v, check.DeepEquals, t.expected, check.Commentf("failed test %d", i))
 	}
 }

--- a/builder/kubernetes/build.go
+++ b/builder/kubernetes/build.go
@@ -359,9 +359,19 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 		if len(tsuruYamlData.Processes) > 0 {
 			// If it uses, try to get processes and commands from YML
 			processes = version.GetProcessesFromYamlProcess(tsuruYamlData.Processes)
+			if tsuruYamlData.Healthcheck != nil {
+				fmt.Fprintln(w, " ---> WARNING: Global healthcheck configuration will be IGNORED when YML contains 'processes' configuration")
+			}
+			if len(tc.Procfile) > 0 {
+				fmt.Fprintln(w, " ---> WARNING: Procfile will be IGNORED when YML contains 'processes' configuration")
+			}
 		} else {
 			// If it does not uses new `processes` on YML, use current implementation
 			processes = version.GetProcessesFromProcfile(tc.Procfile)
+			fmt.Fprintln(w, " ---> WARNING: Process configuration via Procfile will be deprecated in future releases, favor YML 'processes' configuration instead")
+			if tsuruYamlData.Healthcheck != nil {
+				fmt.Fprintln(w, " ---> WARNING: Global healthcheck configuration will be deprecated in future releases, favor YAML 'processes' configuration instead")
+			}
 		}
 
 		// Default to web process name and entrypoint and cmd from container

--- a/builder/kubernetes/build_test.go
+++ b/builder/kubernetes/build_test.go
@@ -339,6 +339,7 @@ kubernetes:
 		Healthcheck: &provisiontypes.TsuruYamlHealthcheck{
 			Path: "/healthz",
 		},
+		Processes: []provisiontypes.TsuruYamlProcess{},
 		Hooks: &provisiontypes.TsuruYamlHooks{
 			Build: []string{"mkdir /path/to/my/dir", "/path/to/script.sh"},
 		},
@@ -864,6 +865,7 @@ CMD ["--port", "8888"]
 		Healthcheck: &provisiontypes.TsuruYamlHealthcheck{
 			Path: "/healthz",
 		},
+		Processes: []provisiontypes.TsuruYamlProcess{},
 	})
 }
 

--- a/builder/kubernetes/build_test.go
+++ b/builder/kubernetes/build_test.go
@@ -358,6 +358,169 @@ kubernetes:
 	})
 }
 
+func (s *S) TestBuild_BuildWithSourceCodeWithProcessesOnYaml(c *check.C) {
+	a, _, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+
+	a.Env = map[string]bindTypes.EnvVar{
+		"MY_ENV1": {Name: "MY_ENV1", Value: "value 1"},
+		"MY_ENV2": {Name: "MY_ENV2", Value: "value 2"},
+	}
+	s.mockService.PlatformImage.OnCurrentImage = func(registry imagetypes.ImageRegistry, platform string) (string, error) {
+		if c.Check(registry, check.DeepEquals, imagetypes.ImageRegistry("")) &&
+			c.Check(platform, check.DeepEquals, "python") {
+			return "docker.io/tsuru/python:latest", nil
+		}
+
+		return "", fmt.Errorf("bad platform")
+	}
+
+	buildServiceAddress := setupBuildServer(s.t, &fakeBuildServer{
+		OnBuild: func(req *buildpb.BuildRequest, stream buildpb.Build_BuildServer) error {
+			// NOTE(nettoclaudio): cannot call c.Assert here since it might call runtime.Goexit and
+			// provoke an deadlock on RPC client and server.
+			c.Check(req.GetApp(), check.DeepEquals, &buildpb.TsuruApp{
+				Name: "myapp",
+				EnvVars: map[string]string{
+					"TSURU_SERVICES": "{}",
+					"TSURU_APPNAME":  "myapp",
+					"TSURU_APPDIR":   "/home/application/current",
+					"MY_ENV1":        "value 1",
+					"MY_ENV2":        "value 2",
+				},
+			})
+			c.Check(req.GetKind(), check.DeepEquals, buildpb.BuildKind_BUILD_KIND_APP_BUILD_WITH_SOURCE_UPLOAD)
+			c.Check(req.GetSourceImage(), check.DeepEquals, "docker.io/tsuru/python:latest")
+			c.Check(req.GetDestinationImages(), check.DeepEquals, []string{"tsuru/app-myapp:v1", "tsuru/app-myapp:latest"})
+			c.Check(req.GetData(), check.DeepEquals, []byte(`my awesome source code :P`))
+
+			err := stream.Send(&buildpb.BuildResponse{Data: &buildpb.BuildResponse_Output{Output: "--> Starting container image build\n"}})
+			c.Check(err, check.IsNil)
+
+			err = stream.Send(&buildpb.BuildResponse{Data: &buildpb.BuildResponse_Output{Output: "------- some container build progress\n"}})
+			c.Check(err, check.IsNil)
+
+			err = stream.Send(&buildpb.BuildResponse{Data: &buildpb.BuildResponse_Output{Output: "--> Container image build finished\n"}})
+			c.Check(err, check.IsNil)
+
+			err = stream.Send(&buildpb.BuildResponse{Data: &buildpb.BuildResponse_TsuruConfig{TsuruConfig: &buildpb.TsuruConfig{
+				Procfile: "web: ./path/wont-be-used.py --port ${PORT}\nworker: ./path/worker-wont-be-used.sh --verbose",
+				TsuruYaml: `
+processes:
+  - name: web
+    command: ./path/app.py --port ${PORT}
+    healthcheck:
+      path: /healthz
+  - name: worker
+    command: ./path/worker.sh --verbose
+  - name: web-secondary
+    command: ./path/app-secondary.py --port ${PORT}
+    healthcheck:
+      path: /healthz-secondary
+
+hooks:
+  build:
+  - mkdir /path/to/my/dir
+  - /path/to/script.sh
+
+kubernetes:
+  groups:
+    my-app:
+      web:
+        ports:
+        - name: http
+          port: 80
+          target_port: 8080
+        - name: http-grpc
+          port: 3000
+          protocol: TCP
+`,
+			}}})
+			c.Check(err, check.IsNil)
+
+			return nil
+		},
+	})
+	s.clusterClient.CustomData[buildServiceAddressKey] = buildServiceAddress
+
+	evt, err := event.New(context.TODO(), &event.Opts{
+		Target:  eventTypes.Target{Type: eventTypes.TargetTypeApp, Value: a.Name},
+		Kind:    permission.PermAppDeploy,
+		Owner:   s.token,
+		Allowed: event.Allowed(permission.PermAppDeploy),
+	})
+	c.Assert(err, check.IsNil)
+
+	data := bytes.NewBufferString("my awesome source code :P")
+
+	var output bytes.Buffer
+
+	appVersion, err := s.b.Build(context.TODO(), a, evt, builder.BuildOpts{
+		Message:     "Add my awesome feature :P",
+		ArchiveFile: data,
+		ArchiveSize: int64(data.Len()),
+		Output:      &output,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(output.String(), check.Matches, "(?s).*--> Starting container image build(.*)")
+	c.Assert(output.String(), check.Matches, "(?s).*------- some container build progress(.*)")
+	c.Assert(output.String(), check.Matches, "(?s).*--> Container image build finished(.*)")
+
+	c.Assert(appVersion, check.NotNil)
+	c.Assert(appVersion.Version(), check.DeepEquals, 1)
+	c.Assert(appVersion.VersionInfo().EventID, check.DeepEquals, evt.UniqueID.Hex())
+	c.Assert(appVersion.VersionInfo().Description, check.DeepEquals, "Add my awesome feature :P")
+	c.Assert(appVersion.VersionInfo().DeployImage, check.DeepEquals, "tsuru/app-myapp:v1")
+
+	processes, err := appVersion.Processes()
+	c.Assert(err, check.IsNil)
+	c.Assert(processes, check.DeepEquals, map[string][]string{
+		"web":           {"./path/app.py --port ${PORT}"},
+		"worker":        {"./path/worker.sh --verbose"},
+		"web-secondary": {"./path/app-secondary.py --port ${PORT}"},
+	})
+
+	tsuruYaml, err := appVersion.TsuruYamlData()
+	c.Assert(err, check.IsNil)
+	c.Assert(tsuruYaml, check.DeepEquals, provisiontypes.TsuruYamlData{
+		Processes: []provisiontypes.TsuruYamlProcess{
+			{
+				Healthcheck: &provisiontypes.TsuruYamlHealthcheck{
+					Path: "/healthz",
+				},
+				Name:    "web",
+				Command: "./path/app.py --port ${PORT}",
+			},
+			{
+				Name:    "worker",
+				Command: "./path/worker.sh --verbose",
+			},
+			{
+				Healthcheck: &provisiontypes.TsuruYamlHealthcheck{
+					Path: "/healthz-secondary",
+				},
+				Name:    "web-secondary",
+				Command: "./path/app-secondary.py --port ${PORT}",
+			},
+		},
+		Hooks: &provisiontypes.TsuruYamlHooks{
+			Build: []string{"mkdir /path/to/my/dir", "/path/to/script.sh"},
+		},
+		Kubernetes: &provisiontypes.TsuruYamlKubernetesConfig{
+			Groups: map[string]provisiontypes.TsuruYamlKubernetesGroup{
+				"my-app": map[string]provisiontypes.TsuruYamlKubernetesProcessConfig{
+					"web": {
+						Ports: []provisiontypes.TsuruYamlKubernetesProcessPortConfig{
+							{Name: "http", Port: 80, TargetPort: 8080},
+							{Name: "http-grpc", Port: 3000, Protocol: "TCP"},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
 func (s *S) TestBuild_BuildWithContainerImage(c *check.C) {
 	a, _, rollback := s.mock.DefaultReactions(c)
 	defer rollback()

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -501,7 +501,8 @@ func createAppDeployment(ctx context.Context, client *ClusterClient, depName str
 	var hcData hcResult
 	// NOTE: Here is the code that create probes for HEALTHCHECK!
 	if len(yamlData.Processes) > 0 {
-		healthcheck, err := yamlData.GetHCFromProcessName(process)
+		var healthcheck *provTypes.TsuruYamlHealthcheck
+		healthcheck, err = yamlData.GetHCFromProcessName(process)
 		if err != nil {
 			return false, nil, nil, errors.WithStack(err)
 		}

--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -291,10 +290,6 @@ func ensureHealthCheckDefaults(hc *provTypes.TsuruYamlHealthcheck) error {
 	if hc.Scheme == "" {
 		hc.Scheme = provision.DefaultHealthcheckScheme
 	}
-	hc.Method = strings.ToUpper(hc.Method)
-	if hc.Method == "" {
-		hc.Method = http.MethodGet
-	}
 	if hc.IntervalSeconds == 0 {
 		hc.IntervalSeconds = 10
 	}
@@ -303,9 +298,6 @@ func ensureHealthCheckDefaults(hc *provTypes.TsuruYamlHealthcheck) error {
 	}
 	if hc.AllowedFailures == 0 {
 		hc.AllowedFailures = 3
-	}
-	if hc.Method != http.MethodGet {
-		return errors.New("healthcheck: only GET method is supported in kubernetes provisioner")
 	}
 
 	return nil
@@ -509,7 +501,7 @@ func createAppDeployment(ctx context.Context, client *ClusterClient, depName str
 	var hcData hcResult
 	// NOTE: Here is the code that create probes for HEALTHCHECK!
 	if len(yamlData.Processes) > 0 {
-		err, healthcheck := yamlData.GetHCFromProcessName(process)
+		healthcheck, err := yamlData.GetHCFromProcessName(process)
 		if err != nil {
 			return false, nil, nil, errors.WithStack(err)
 		}

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -524,7 +524,8 @@ func (s *S) TestServiceManagerDeployServiceWithNodeAffinity(c *check.C) {
 								Values:   []string{"minikube"},
 							},
 						},
-					}},
+					},
+				},
 			},
 		},
 	}
@@ -2253,33 +2254,6 @@ func (s *S) TestServiceManagerDeployServiceCancelRollback(c *check.C) {
 	c.Assert(buf.String(), check.Matches, `(?s).* ---> 1 of 1 new units created.*? ---> 0 of 1 new units ready.*? ROLLING BACK AFTER FAILURE .*`)
 }
 
-func (s *S) TestServiceManagerDeployServiceWithHCInvalidMethod(c *check.C) {
-	waitDep := s.mock.DeploymentReactions(c)
-	defer waitDep()
-	m := serviceManager{client: s.clusterClient}
-	a := &appTypes.App{Name: "myapp", TeamOwner: s.team.Name}
-	err := app.CreateApp(context.TODO(), a, s.user)
-	c.Assert(err, check.IsNil)
-	version := newCommittedVersion(c, a, map[string]interface{}{
-		"processes": map[string]interface{}{
-			"web": "cm1",
-			"p2":  "cmd2",
-		},
-		"healthcheck": provTypes.TsuruYamlHealthcheck{
-			Path:   "/hc",
-			Method: "POST",
-		},
-	})
-	c.Assert(err, check.IsNil)
-	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
-		App:     a,
-		Version: version,
-	}, servicecommon.ProcessSpec{
-		"p1": servicecommon.ProcessState{Start: true},
-	})
-	c.Assert(err, check.ErrorMatches, "healthcheck: only GET method is supported in kubernetes provisioner")
-}
-
 func (s *S) TestServiceManagerDeployServiceWithUID(c *check.C) {
 	config.Set("docker:uid", 1001)
 	defer config.Unset("docker:uid")
@@ -2686,7 +2660,8 @@ func (s *S) TestServiceManagerDeployTopologySpreadConstraintEnable(c *check.C) {
 			TopologyKey:       "kubernetes.io/zone",
 			WhenUnsatisfiable: apiv1.ScheduleAnyway,
 			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"tsuru.io/app-name": "myapp", "tsuru.io/app-process": "p1", "tsuru.io/app-version": "1"}},
-		}}
+		},
+	}
 	c.Assert(dep.Spec.Template.Spec.TopologySpreadConstraints, check.DeepEquals, topologySpreadConstraints)
 }
 
@@ -3839,7 +3814,8 @@ func (s *S) TestDefineSelectorAndAffinity(c *check.C) {
 											Values:   []string{"minikube"},
 										},
 									},
-								}},
+								},
+							},
 						},
 					},
 				})

--- a/router/rebuild/rebuild_test.go
+++ b/router/rebuild/rebuild_test.go
@@ -82,8 +82,7 @@ func (s *S) TestRebuildRoutesSetsHealthcheck(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	expected := routerTypes.HealthcheckData{
-		Path:   "/healthcheck",
-		Status: 302,
+		Path: "/healthcheck",
 	}
 	c.Assert(routertest.FakeRouter.GetHealthcheck("my-test-app"), check.DeepEquals, expected)
 }

--- a/types/provision/provision.go
+++ b/types/provision/provision.go
@@ -15,8 +15,8 @@ var ErrProcessNotFound = errors.New("process name could not be found on YAML dat
 type TsuruYamlData struct {
 	Hooks       *TsuruYamlHooks            `json:"hooks,omitempty" bson:",omitempty"`
 	Healthcheck *TsuruYamlHealthcheck      `json:"healthcheck,omitempty" bson:",omitempty"`
-	Processes   []TsuruYamlProcess         `json:"processes,omitempty" bson:",omitempty"`
 	Kubernetes  *TsuruYamlKubernetesConfig `json:"kubernetes,omitempty" bson:",omitempty"`
+	Processes   []TsuruYamlProcess         `json:"processes,omitempty" bson:",omitempty"`
 }
 
 type TsuruYamlHooks struct {
@@ -30,20 +30,15 @@ type TsuruYamlRestartHooks struct {
 }
 
 type TsuruYamlHealthcheck struct {
+	Headers              map[string]string `json:"headers,omitempty" bson:",omitempty"`
 	Path                 string            `json:"path"`
-	Method               string            `json:"method"`
-	Status               int               `json:"status"`
 	Scheme               string            `json:"scheme"`
 	Command              []string          `json:"command,omitempty" bson:",omitempty"`
-	Headers              map[string]string `json:"headers,omitempty" bson:",omitempty"`
-	Match                string            `json:"match,omitempty" bson:",omitempty"`
-	RouterBody           string            `json:"router_body,omitempty" yaml:"router_body" bson:"router_body,omitempty"`
-	UseInRouter          bool              `json:"use_in_router,omitempty" yaml:"use_in_router" bson:"use_in_router,omitempty"`
-	ForceRestart         bool              `json:"force_restart,omitempty" yaml:"force_restart" bson:"force_restart,omitempty"`
 	AllowedFailures      int               `json:"allowed_failures,omitempty" yaml:"allowed_failures" bson:"allowed_failures,omitempty"`
 	IntervalSeconds      int               `json:"interval_seconds,omitempty" yaml:"interval_seconds" bson:"interval_seconds,omitempty"`
 	TimeoutSeconds       int               `json:"timeout_seconds,omitempty" yaml:"timeout_seconds" bson:"timeout_seconds,omitempty"`
 	DeployTimeoutSeconds int               `json:"deploy_timeout_seconds,omitempty" yaml:"deploy_timeout_seconds" bson:"deploy_timeout_seconds,omitempty"`
+	ForceRestart         bool              `json:"force_restart,omitempty" yaml:"force_restart" bson:"force_restart,omitempty"`
 }
 
 type TsuruYamlProcess struct {
@@ -89,25 +84,23 @@ type TsuruYamlKubernetesProcessPortConfig struct {
 
 func (y TsuruYamlData) ToRouterHC() router.HealthcheckData {
 	hc := y.Healthcheck
-	if hc == nil || !hc.UseInRouter {
+	if hc == nil {
 		return router.HealthcheckData{
 			Path: "/",
 		}
 	}
 	return router.HealthcheckData{
-		Path:   hc.Path,
-		Status: hc.Status,
-		Body:   hc.RouterBody,
+		Path: hc.Path,
 	}
 }
 
-func (y TsuruYamlData) GetHCFromProcessName(process string) (error, *TsuruYamlHealthcheck) {
+func (y TsuruYamlData) GetHCFromProcessName(process string) (*TsuruYamlHealthcheck, error) {
 	for _, tsuruProcessData := range y.Processes {
 		if tsuruProcessData.Name == process {
-			return nil, tsuruProcessData.Healthcheck
+			return tsuruProcessData.Healthcheck, nil
 		}
 	}
-	return ErrProcessNotFound, nil
+	return nil, ErrProcessNotFound
 }
 
 func (y *TsuruYamlKubernetesConfig) GetProcessConfigs(procName string) *TsuruYamlKubernetesProcessConfig {

--- a/types/router/router.go
+++ b/types/router/router.go
@@ -11,9 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	ErrDynamicRouterNotFound = errors.New("dynamic router not found")
-)
+var ErrDynamicRouterNotFound = errors.New("dynamic router not found")
 
 type DynamicRouter struct {
 	Name           string
@@ -59,8 +57,6 @@ type DynamicRouterStorage interface {
 
 type HealthcheckData struct {
 	Path    string
-	Status  int
-	Body    string
 	TCPOnly bool
 }
 
@@ -68,17 +64,9 @@ func (hc *HealthcheckData) String() string {
 	if hc.TCPOnly {
 		return "tcp only"
 	}
-	status := ""
-	if hc.Status != 0 {
-		status = fmt.Sprintf(", status: %d", hc.Status)
-	}
 	path := hc.Path
 	if path == "" {
 		path = "/"
 	}
-	body := hc.Body
-	if body != "" {
-		body = fmt.Sprintf(", body: %q", body)
-	}
-	return fmt.Sprintf("path: %q%s%s", path, status, body)
+	return fmt.Sprintf("path: %q", path)
 }


### PR DESCRIPTION
The ideia is to introduce a new format to tsuru.yaml. It might deprecate Procfile usage.

```yaml
processes:
  - name: web
    command: python app.py
    healthcheck:
      path: /
      scheme: http
  - name: web-secondary
    command: python app2.py
    healthcheck:
      path: /
      scheme: http
```