### PR TITLE
registry: tweaks for image cleanup

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -737,21 +737,12 @@ func Delete(ctx context.Context, app *appTypes.App, evt *event.Event, requestID 
 	if err != nil {
 		logErr("Unable to unbind app", err)
 	}
-	if prov != nil {
-		provisionerName := prov.GetName()
-		cluster, clusterErr := servicemanager.Cluster.FindByPool(ctx, provisionerName, app.Pool)
-		if clusterErr != nil && clusterErr != provTypes.ErrNoCluster {
-			log.Errorf("unable to get cluster name for app %s: %+v", appName, clusterErr)
-		}
-		if cluster != nil {
-			err = registry.RemoveAppImages(ctx, appName, cluster)
-			if err != nil {
-				log.Errorf("failed to remove images from registry for app %s: %s", appName, err)
-			}
-		} else {
-			log.Errorf("unable to remove images for app %s: no cluster associated with the app", appName)
-		}
+
+	err = registry.RemoveAppImages(ctx, appName)
+	if err != nil {
+		log.Errorf("failed to remove images from registry for app %s: %s", appName, err)
 	}
+
 	err = servicemanager.AppVersion.DeleteVersions(ctx, appName)
 	if err != nil {
 		log.Errorf("failed to remove image names from storage for app %s: %s", appName, err)

--- a/app/image/gc/gc.go
+++ b/app/image/gc/gc.go
@@ -511,9 +511,9 @@ func pruneAllVersionsByApp(ctx context.Context, appVersions appTypes.AppVersions
 	}
 	if prov != nil {
 		provisionerName := prov.GetName()
-		cluster, err := servicemanager.Cluster.FindByPool(ctx, provisionerName, appStruct.Pool)
-		if err != nil && err != provision.ErrNoCluster {
-			log.Errorf("unable to get cluster name for app %s: %+v", appStruct.Name, err)
+		cluster, clusterFinderErr := servicemanager.Cluster.FindByPool(ctx, provisionerName, appStruct.Pool)
+		if clusterFinderErr != nil && clusterFinderErr != provision.ErrNoCluster {
+			log.Errorf("unable to get cluster name for app %s: %+v", appStruct.Name, clusterFinderErr)
 		}
 		if cluster != nil {
 			err = registry.RemoveAppImages(ctx, appStruct.Name, cluster)

--- a/app/image/gc/gc_test.go
+++ b/app/image/gc/gc_test.go
@@ -36,6 +36,7 @@ import (
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	eventTypes "github.com/tsuru/tsuru/types/event"
 	permTypes "github.com/tsuru/tsuru/types/permission"
+	provisionTypes "github.com/tsuru/tsuru/types/provision"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
 	check "gopkg.in/check.v1"
@@ -47,11 +48,13 @@ type S struct {
 	user        *auth.User
 	team        string
 	mockService servicemock.MockService
+	cluster     *provisionTypes.Cluster
 }
 
 var _ = check.Suite(&S{})
 
 func (s *S) SetUpSuite(c *check.C) {
+	var err error
 	config.Set("log:disable-syslog", true)
 	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=100")
 	config.Set("database:name", "app_image_gc_tests")
@@ -64,6 +67,13 @@ func (s *S) SetUpSuite(c *check.C) {
 
 	provision.DefaultProvisioner = "fake"
 	app.AuthScheme = auth.ManagedScheme(native.NativeScheme{})
+	s.cluster = &provisionTypes.Cluster{
+		Name:        "c1",
+		Addresses:   []string{"addr1"},
+		Provisioner: "fake",
+		Default:     true,
+	}
+	c.Assert(err, check.IsNil)
 }
 
 func (s *S) SetUpTest(c *check.C) {
@@ -97,6 +107,13 @@ func (s *S) SetUpTest(c *check.C) {
 	}
 	servicemanager.AppVersion, err = version.AppVersionService()
 	c.Assert(err, check.IsNil)
+	s.mockService.Cluster.OnFindByName = func(name string) (*provisionTypes.Cluster, error) {
+		c.Assert(name, check.Equals, s.cluster.Name)
+		return nil, provisionTypes.ErrNoCluster
+	}
+	s.mockService.Cluster.OnList = func() ([]provisionTypes.Cluster, error) {
+		return []provisionTypes.Cluster{*s.cluster}, nil
+	}
 }
 
 func (s *S) TearDownTest(c *check.C) {
@@ -159,6 +176,7 @@ func (s *S) TestGCStartAppNotFound(c *check.C) {
 		}
 	}))
 	u, _ := url.Parse(srv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	config.Set("docker:registry", u.Host)
 	defer config.Unset("docker:registry")
 	defer srv.Close()
@@ -168,7 +186,7 @@ func (s *S) TestGCStartAppNotFound(c *check.C) {
 	gc.start()
 	err := gc.Shutdown(context.Background())
 	c.Assert(err, check.IsNil)
-	c.Assert(regDeleteCalls, check.DeepEquals, []string{
+	expectedCalls := []string{
 		"/v2/tsuru/app-myapp/manifests/v0",
 		"/v2/tsuru/app-myapp/manifests//v2/tsuru/app-myapp/manifests/v0",
 		"/v2/tsuru/app-myapp/manifests/v1",
@@ -219,7 +237,10 @@ func (s *S) TestGCStartAppNotFound(c *check.C) {
 		"/v2/tsuru/app-myapp/manifests//v2/tsuru/app-myapp/manifests/v10-builder",
 		"/v2/tsuru/app-myapp/manifests/v11-builder",
 		"/v2/tsuru/app-myapp/manifests//v2/tsuru/app-myapp/manifests/v11-builder",
-	})
+	}
+	sort.Strings(regDeleteCalls)
+	sort.Strings(expectedCalls)
+	c.Assert(regDeleteCalls, check.DeepEquals, expectedCalls)
 	versions, err := servicemanager.AppVersion.AppVersions(context.TODO(), fakeApp)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(versions.Versions), check.Equals, 0)
@@ -244,6 +265,7 @@ func (s *S) TestGCStartWithApp(c *check.C) {
 		}
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)
@@ -329,6 +351,7 @@ func (s *S) TestGCStartWithRunningEvent(c *check.C) {
 		}
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:gc:dry-run", true)
@@ -410,6 +433,7 @@ func (s *S) TestGCStartIgnoreErrorOnProvisioner(c *check.C) {
 		}
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)
@@ -445,6 +469,7 @@ func (s *S) TestGCStartWithErrorOnRegistry(c *check.C) {
 		http.Error(w, "Unavailable", http.StatusInternalServerError)
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)
@@ -487,6 +512,7 @@ func (s *S) TestDryRunGCStartWithApp(c *check.C) {
 		}
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)
@@ -567,6 +593,7 @@ func (s *S) TestGCNoOPWithApp(c *check.C) {
 		regDeleteCalls++
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)
@@ -602,6 +629,7 @@ func (s *S) TestGCStartWithAppStressNotFound(c *check.C) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	u, _ := url.Parse(registrySrv.URL)
+	s.cluster.CustomData = map[string]string{"registry": u.Host}
 	defer registrySrv.Close()
 
 	config.Set("docker:registry", u.Host)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -839,7 +839,7 @@ func (c *ErrorCommand) Run(context *Context) error {
 	if c.msg == "abort" {
 		return ErrAbortCommand
 	}
-	return fmt.Errorf(c.msg)
+	return fmt.Errorf("%s", c.msg)
 }
 
 type FailAndWorkCommand struct {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2
 	github.com/felixge/fgprof v0.9.1
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/fsouza/go-dockerclient v1.9.8
 	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/google/gops v0.0.0-20180311052415-160b358b10d6
 	github.com/gorilla/mux v1.8.0
@@ -66,15 +65,13 @@ require golang.org/x/text v0.15.0
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
-	github.com/containerd/containerd v1.6.18 // indirect
+	github.com/containerd/containerd v1.6.18
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.1 // indirect
@@ -109,18 +106,13 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/moby/patternmatcher v0.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
-	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.7.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
-	github.com/opencontainers/runc v1.1.14 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8 h1:V8krnnfGj4pV65YLUm3C0/8bl7V5Nry2Pwvy3ru/wLc=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -15,10 +13,6 @@ github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
-github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/Microsoft/hcsshim v0.9.6 h1:VwnDOgLeoi2du6dAznfmspNqTiwczvjv4K7NxuY9jsY=
-github.com/Microsoft/hcsshim v0.9.6/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -79,8 +73,6 @@ github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKs
 github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
-github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
-github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -112,8 +104,6 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/fsouza/go-dockerclient v1.9.8 h1:UdfyV4/w8VthS2VS0muJqUSPL/e6XSj49jqPnbuUOWA=
-github.com/fsouza/go-dockerclient v1.9.8/go.mod h1:74lNReDQxrOaogajs51IvZgkDME4qe9yPJAUEUTJtHw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globocom/mongo-go-prometheus v0.1.1 h1:8rWfdrwq5Jc+gmB8YUNcwHr9M6SrAdjajsiY2Bevlvo=
@@ -330,12 +320,8 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
-github.com/moby/patternmatcher v0.5.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
-github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
-github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c h1:RC8WMpjonrBfyAh6VN/POIPtYD5tRAq0qMqCRjQNK+g=
 github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c/go.mod h1:9OcmHNQQUTbk4XCffrLgN1NEKc2mh5u++biHVrvHsSU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -369,12 +355,6 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.27.2 h1:SKU0CXeKE/WVgIV1T61kSa3+IRE8Ekrv9rdXDwwTqnY=
 github.com/onsi/gomega v1.27.2/go.mod h1:5mR3phAHpkAVIDkHEUBY6HGVsU+cpcEscrGPB4oPlZI=
-github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
-github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
-github.com/opencontainers/runc v1.1.14 h1:rgSuzbmgz5DUJjeSnw337TxDbRuqjs6iqQck/2weR6w=
-github.com/opencontainers/runc v1.1.14/go.mod h1:E4C2z+7BxR7GHXp0hAY53mek+x49X1LjPNeMTfRGvOA=
 github.com/opentracing-contrib/go-stdlib v1.0.1-0.20201028152118-adbfc141dfc2 h1:Fy4bjXz8oBZwuPQ0NgTjOG068OSuBlv2BPWtH6+Yuv8=
 github.com/opentracing-contrib/go-stdlib v1.0.1-0.20201028152118-adbfc141dfc2/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/log/file_logger.go
+++ b/log/file_logger.go
@@ -44,7 +44,7 @@ func (l *fileLogger) Errorf(format string, o ...interface{}) {
 }
 
 func (l *fileLogger) Fatal(o string) {
-	l.logger.Printf(fmt.Sprintf(fatalPrefix, o))
+	l.logger.Printf(fatalPrefix, o)
 	os.Exit(1)
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -202,6 +202,9 @@ request:
 				continue
 			}
 			if resp.StatusCode == http.StatusUnauthorized && resp.Header.Get("WWW-Authenticate") != "" && r.checkTokenIsValidForRenew() {
+				if resp.Body != nil {
+					resp.Body.Close()
+				}
 				to := auth.TokenOptions{}
 				to.Username = r.authConfig.Username
 				to.Secret = r.authConfig.Password

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -49,7 +49,7 @@ func RemoveImageIgnoreNotFound(ctx context.Context, imageName string) error {
 	err := RemoveImage(ctx, imageName)
 	if err != nil {
 		cause := errors.Cause(err)
-		if cause != ErrDigestNotFound && cause != ErrImageNotFound {
+		if cause != ErrDeleteDisabled && cause != ErrDigestNotFound && cause != ErrImageNotFound {
 			return err
 		}
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -240,9 +240,9 @@ request:
 				}
 			}
 			to.Scopes = parseScopes(to.Scopes).normalize()
-			respAuth, err := auth.FetchToken(ctx, r.client, req.Header, to)
-			if err != nil {
-				return nil, err
+			respAuth, tokenErr := auth.FetchToken(ctx, r.client, req.Header, to)
+			if tokenErr != nil {
+				return nil, tokenErr
 			}
 			if respAuth.IssuedAt.IsZero() {
 				respAuth.IssuedAt = time.Now()
@@ -297,9 +297,9 @@ func (r *dockerRegistry) registryAuth(ctx context.Context, image string) error {
 			return nil
 		}
 	} else {
-		clusters, err := servicemanager.Cluster.List(ctx)
-		if err != nil {
-			return err
+		clusters, clusterListErr := servicemanager.Cluster.List(ctx)
+		if err != clusterListErr {
+			return clusterListErr
 		}
 		for _, cluster := range clusters {
 			clusterRegistry, registryExists := cluster.CustomData["registry"]

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -227,8 +227,8 @@ request:
 			if exp := respAuth.IssuedAt.Add(time.Duration(float64(respAuth.ExpiresIn)*0.9) * time.Second); time.Now().Before(exp) {
 				r.expires = exp
 			}
-			r.token = respAuth.AccessToken
-			continue request
+			r.token = respAuth.Token
+			goto request
 		}
 		if err != nil {
 			return nil, err

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -123,7 +123,7 @@ func (s *S) TestRegistryRemoveAppImagesErrorErrDeleteDisabled(c *check.C) {
 	c.Assert(s.server.Repos[0].Tags, check.HasLen, 1)
 	s.server.SetStorageDelete(false)
 	err = RemoveAppImages(context.TODO(), "test")
-	c.Assert(errors.Cause(err), check.Equals, ErrDeleteDisabled)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *S) TestRegistryRemoveAppImages(c *check.C) {

--- a/registry/testing/server.go
+++ b/registry/testing/server.go
@@ -12,9 +12,17 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrMissingToken   = errors.New("missing token")
+	ErrBadToken       = errors.New("bad token")
+	ErrBadCredentials = errors.New("bad credentials")
 )
 
 type Repository struct {
@@ -22,6 +30,8 @@ type Repository struct {
 	Tags     map[string]string
 	Username string
 	Password string
+	Token    string
+	Expire   int
 }
 
 type tagListResponse struct {
@@ -35,6 +45,12 @@ type RegistryServer struct {
 	Repos         []Repository
 	reposLock     sync.RWMutex
 	storageDelete bool
+	tokenAuth     bool
+}
+
+type TokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresIn int    `json:"expires_in"`
 }
 
 // NewServer returns a new instance of the fake server.
@@ -84,6 +100,10 @@ func (s *RegistryServer) SetStorageDelete(sd bool) {
 	s.reposLock.Unlock()
 }
 
+func (s *RegistryServer) SetTokenAuth(enabled bool) {
+	s.tokenAuth = enabled
+}
+
 // ServeHTTP handler HTTP requests, dealing with prepared failures before
 // dispatching the request to the proper internal handler.
 func (s *RegistryServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -95,11 +115,25 @@ func (s *RegistryServer) buildMuxer() {
 	s.muxer.Path("/v2/{name:.*}/manifests/{tag:.*}").Methods("HEAD").HandlerFunc(s.getDigest)
 	s.muxer.Path("/v2/{name:.*}/manifests/{digest:.*}").Methods("DELETE").HandlerFunc(s.removeTag)
 	s.muxer.Path("/v2/{name:.*}/tags/list").Methods("GET").HandlerFunc(s.listTags)
+	s.muxer.Path("/token/{name:.*}").Methods("GET").HandlerFunc(s.getToken)
 }
 
-func (s *RegistryServer) auth(w http.ResponseWriter, r *http.Request) error {
+func (s *RegistryServer) auth(r *http.Request) error {
 	name := mux.Vars(r)["name"]
 	repo, _ := s.findRepository(name)
+	if s.tokenAuth {
+		authTokenHeader := r.Header.Get("Authorization")
+		if authTokenHeader == "" || strings.Contains(authTokenHeader, "Basic") {
+			return ErrMissingToken
+		}
+		if authTokenHeader != "Bearer "+repo.Token {
+			return ErrBadToken
+		}
+		if authTokenHeader == "Bearer "+repo.Token {
+			return nil
+		}
+	}
+
 	if len(repo.Username) == 0 && len(repo.Password) == 0 {
 		return nil
 	}
@@ -108,21 +142,46 @@ func (s *RegistryServer) auth(w http.ResponseWriter, r *http.Request) error {
 	credentials := fmt.Sprintf("%s:%s", repo.Username, repo.Password)
 	b64Credentials := "Basic " + base64.StdEncoding.EncodeToString([]byte(credentials))
 	if authHeader != b64Credentials {
-		return fmt.Errorf("bad credentials")
+		return ErrBadCredentials
 	}
 	return nil
 }
 
-func (s *RegistryServer) removeTag(w http.ResponseWriter, r *http.Request) {
-	err := s.auth(w, r)
-	if err != nil {
-		w.WriteHeader(http.StatusForbidden)
+func (s *RegistryServer) getToken(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	repo, _ := s.findRepository(name)
+	scope := r.URL.Query().Get("scope")
+	service := r.URL.Query().Get("service")
+
+	if scope == "" || service == "" {
+		http.Error(w, "missing scope or service", http.StatusBadRequest)
 		return
 	}
 
+	response := TokenResponse{Token: repo.Token, ExpiresIn: repo.Expire}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (s *RegistryServer) handleAuthError(w http.ResponseWriter, err error, name string) {
+	cause := errors.Cause(err)
+	if cause == ErrMissingToken {
+		w.Header().Set("Www-Authenticate", "Bearer realm=\"http://"+s.Addr()+"/token/"+name+"\",service=\""+s.Addr()+"\",scope=\"repository:"+name+":push\"")
+		w.WriteHeader(http.StatusUnauthorized)
+	} else {
+		w.WriteHeader(http.StatusForbidden)
+	}
+}
+func (s *RegistryServer) removeTag(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
-	digest := mux.Vars(r)["digest"]
 	repo, index := s.findRepository(name)
+	err := s.auth(r)
+	if err != nil {
+		s.handleAuthError(w, err, name)
+		return
+	}
+
+	digest := mux.Vars(r)["digest"]
 	if index < 0 {
 		http.Error(w, fmt.Sprintf("unknown repository name=%s", name), http.StatusNotFound)
 		return
@@ -144,15 +203,14 @@ func (s *RegistryServer) removeTag(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *RegistryServer) getDigest(w http.ResponseWriter, r *http.Request) {
-	err := s.auth(w, r)
+	name := mux.Vars(r)["name"]
+	repo, index := s.findRepository(name)
+	err := s.auth(r)
 	if err != nil {
-		w.WriteHeader(http.StatusForbidden)
+		s.handleAuthError(w, err, name)
 		return
 	}
-
-	name := mux.Vars(r)["name"]
 	tag := mux.Vars(r)["tag"]
-	repo, index := s.findRepository(name)
 	if index < 0 {
 		http.Error(w, fmt.Sprintf("unknown repository name=%s", name), http.StatusNotFound)
 		return
@@ -169,14 +227,13 @@ func (s *RegistryServer) getDigest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *RegistryServer) listTags(w http.ResponseWriter, r *http.Request) {
-	err := s.auth(w, r)
-	if err != nil {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-
 	name := mux.Vars(r)["name"]
 	repo, index := s.findRepository(name)
+	err := s.auth(r)
+	if err != nil {
+		s.handleAuthError(w, err, name)
+		return
+	}
 	if index < 0 {
 		http.Error(w, fmt.Sprintf("unknown repository name=%s", name), http.StatusNotFound)
 		return


### PR DESCRIPTION
- using docker config style and dropping old registry credential config for all clusters
- allowing using separated credentials for different clusters instead single auth basic credential
- fix on RemoveAppImages when app is removed
- add support for docker registry realm style authentication