### PR TITLE
Fix: Cert issuer validation for apps

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -2134,8 +2134,6 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			Message: fmt.Sprintf("%s (%s)", err.Error(), cname),
 		}
 	}
-	// *new errors to alert the user.
-
 	// The issuer already exists...
 	// if err == app.ErrCertIssuerAlreadyExist {
 	// 	return &errors.HTTP{
@@ -2143,7 +2141,6 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
 	// 	}
 	// }
-
 	// Issuer not allowed by pool constraints
 	// if err == app.ErrCertIssuerNotFoundInPoolConstraints {
 	// 	return &errors.HTTP{

--- a/api/app.go
+++ b/api/app.go
@@ -2134,12 +2134,6 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			Message: fmt.Sprintf("%s (%s)", err.Error(), cname),
 		}
 	}
-	// if err == app.ErrCertIssuerAlreadyExist {
-	// 	return &errors.HTTP{
-	// 		Code:    http.StatusBadRequest,
-	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
-	// 	}
-	// }
 	if err == app.ErrCertIssuerNotAllowedByPoolConstraints {
 		return &errors.HTTP{
 			Code:    http.StatusBadRequest,

--- a/api/app.go
+++ b/api/app.go
@@ -2134,12 +2134,23 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			Message: fmt.Sprintf("%s (%s)", err.Error(), cname),
 		}
 	}
-	if err == app.ErrCertIssuerAlreadyExist { // error to alert the user that the issuer already exists based on the above error
-		return &errors.HTTP{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
-		}
-	}
+	// *new errors to alert the user.
+
+	// The issuer already exists...
+	// if err == app.ErrCertIssuerAlreadyExist {
+	// 	return &errors.HTTP{
+	// 		Code:    http.StatusBadRequest,
+	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
+	// 	}
+	// }
+
+	// Issuer not allowed by pool constraints
+	// if err == app.ErrCertIssuerNotFoundInPoolConstraints {
+	// 	return &errors.HTTP{
+	// 		Code:    http.StatusBadRequest,
+	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
+	// 	}
+	// }
 	return err
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -2134,6 +2134,12 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			Message: fmt.Sprintf("%s (%s)", err.Error(), cname),
 		}
 	}
+	if err == app.ErrCertIssuerAlreadyExist { // error to alert the user that the issuer already exists based on the above error
+		return &errors.HTTP{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
+		}
+	}
 	return err
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -2134,20 +2134,18 @@ func setCertIssuer(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			Message: fmt.Sprintf("%s (%s)", err.Error(), cname),
 		}
 	}
-	// The issuer already exists...
 	// if err == app.ErrCertIssuerAlreadyExist {
 	// 	return &errors.HTTP{
 	// 		Code:    http.StatusBadRequest,
 	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
 	// 	}
 	// }
-	// Issuer not allowed by pool constraints
-	// if err == app.ErrCertIssuerNotFoundInPoolConstraints {
-	// 	return &errors.HTTP{
-	// 		Code:    http.StatusBadRequest,
-	// 		Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
-	// 	}
-	// }
+	if err == app.ErrCertIssuerNotAllowedByPoolConstraints {
+		return &errors.HTTP{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("%s (%s)", err.Error(), issuer),
+		}
+	}
 	return err
 }
 

--- a/app/actions.go
+++ b/app/actions.go
@@ -699,45 +699,51 @@ var checkSingleCNameExists = action.Action{
 	},
 }
 
-// New action: Validate if issuer already exist in the cluster
-var checkCertIssuerAlreadyExists = action.Action{
-	Name: "issuer-already-exists",
-	Forward: func(ctx action.FWContext) (action.Result, error) {
-		issuer := ctx.Params[2].(string)
+// *New action: Validate if issuer already exist in the cluster
+// var checkCertIssuerAlreadyExists = action.Action{
+// 	Name: "validate-if-issuer-already-exists",
+// 	Forward: func(ctx action.FWContext) (action.Result, error) {
+// 		issuer := ctx.Params[2].(string)
+// 		// 1. how check the issuer in the cluster?
+// 		// ...
+// 		// 2. if the issuer already exists in the cluster
+// 		exists := false
+// 		if exists {
+// 			return nil, ErrCertIssuerAlreadyExist
+// 		}
+// 		// 3. if  dont, return issuer and nil to continue
+// 		return issuer, nil
+// 	},
+// }
 
-		// como checar se esse issuer existe no cluster?
-		// (talvez) usar o exemplo de acão "var removeCertIssuer = action.Action{"
-		// e adaptar para verificar se o issuer já existe no cluster não no mongo
-
-		// 2. se existir, retorna erro
-		exists := true
-		if exists {
-			return nil, ErrCertIssuerAlreadyExist
-		}
-		// 3. se não existir, retornar
-		return issuer, nil
-	},
-}
-
-// New action: Validate if cert issuer is alloewd by pool constraint
-var checkCertIssuerPoolConstraints = action.Action{
-	Name: "validate-issuer-constraint",
-	Forward: func(ctx action.FWContext) (action.Result, error) {
-		app := ctx.Params[0].(*appTypes.App)
-		certIssuer := ctx.Params[2].(string)
-
-		// 1. função de pool constraints para tipo cert-issuer
-
-		// 2. Se certIssuer não estiver na lista de cert-issuer permitidos, retornar erro
-		alloewd := true
-		if !alloewd {
-			return nil, ErrCertIssuerNotFoundInPoolConstraints
-		}
-
-		// 3. Se não houver constraints, retornar issuer
-		return certIssuer, nil
-	},
-}
+// *New action: Validate if issuer is allowed by app pool constraint
+// var checkCertIssuerPoolConstraints = action.Action{
+// 	Name: "validate-cert-issuer-constraint",
+// 	Forward: func(ctx action.FWContext) (action.Result, error) {
+// 		app := ctx.Params[0].(*appTypes.App)
+// 		issuer := ctx.Params[2].(string)
+// 		// 1. Get cert-issuer constraints from pool.
+// 		pool, err := pool.GetPoolByName(ctx.Context, app.Pool)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		certIssuerConstraints, err := pool.GetCertIssuers(ctx.Context)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		// 2. If there is no constraint, return issuer and nil to continue
+// 		if len(certIssuerConstraints) == 0 {
+// 			return issuer, nil
+// 		}
+// 		// 3. Validate the "issuer" string in the "certIssuerConstraints" slice.
+// 		for _, constraint := range certIssuerConstraints {
+// 			if constraint == issuer {
+// 				return issuer, nil
+// 			}
+// 		}
+// 		return nil, ErrCertIssuerNotFoundInPoolConstraints
+// 	},
+// }
 
 var saveCertIssuer = action.Action{
 	Name: "save-cert-issuer",

--- a/app/actions.go
+++ b/app/actions.go
@@ -699,7 +699,6 @@ var checkSingleCNameExists = action.Action{
 	},
 }
 
-// *New action: Validate if issuer already exist in the cluster
 // var checkCertIssuerAlreadyExists = action.Action{
 // 	Name: "validate-if-issuer-already-exists",
 // 	Forward: func(ctx action.FWContext) (action.Result, error) {
@@ -716,7 +715,6 @@ var checkSingleCNameExists = action.Action{
 // 	},
 // }
 
-// *New action: Validate if issuer is allowed by app pool constraint
 // var checkCertIssuerPoolConstraints = action.Action{
 // 	Name: "validate-cert-issuer-constraint",
 // 	Forward: func(ctx action.FWContext) (action.Result, error) {

--- a/app/actions.go
+++ b/app/actions.go
@@ -33,7 +33,6 @@ import (
 var (
 	ErrAppAlreadyExists                      = errors.New("there is already an app with this name")
 	ErrCNameDoesNotExist                     = errors.New("cname does not exist in app")
-	ErrCertIssuerAlreadyExist                = errors.New("cert issuer already exist in app")
 	ErrCertIssuerNotAllowedByPoolConstraints = errors.New("cert issuer not allowed by constraints of this pool")
 )
 
@@ -699,22 +698,6 @@ var checkSingleCNameExists = action.Action{
 		return cname, nil
 	},
 }
-
-// var checkCertIssuerAlreadyExists = action.Action{
-// 	Name: "validate-if-issuer-already-exists",
-// 	Forward: func(ctx action.FWContext) (action.Result, error) {
-// 		issuer := ctx.Params[2].(string)
-// 		// 1. how check the issuer in the cluster?
-// 		// ...
-// 		// 2. if the issuer already exists in the cluster
-// 		exists := false
-// 		if exists {
-// 			return nil, ErrCertIssuerAlreadyExist
-// 		}
-// 		// 3. if  dont, return issuer and nil to continue
-// 		return issuer, nil
-// 	},
-// }
 
 var checkCertIssuerPoolConstraints = action.Action{
 	Name: "validate-cert-issuer-constraint",

--- a/app/actions.go
+++ b/app/actions.go
@@ -724,7 +724,7 @@ var checkCertIssuerPoolConstraints = action.Action{
 				break
 			}
 		}
-		if certIssuerConstraint.Blacklist == issuerMatchValues {
+		if !issuerMatchValues || certIssuerConstraint.Blacklist {
 			return nil, ErrCertIssuerNotAllowedByPoolConstraints
 		}
 		return issuer, nil

--- a/app/app.go
+++ b/app/app.go
@@ -1632,7 +1632,6 @@ func RemoveCName(ctx context.Context, app *appTypes.App, cnames ...string) error
 func SetCertIssuer(ctx context.Context, app *appTypes.App, cname, certIssuer string) error {
 	actions := []*action.Action{
 		&checkSingleCNameExists,
-		// &checkCertIssuerAlreadyExists,
 		&checkCertIssuerPoolConstraints,
 		&saveCertIssuer,
 		&rebuildRoutes,

--- a/app/app.go
+++ b/app/app.go
@@ -1632,6 +1632,8 @@ func RemoveCName(ctx context.Context, app *appTypes.App, cnames ...string) error
 func SetCertIssuer(ctx context.Context, app *appTypes.App, cname, certIssuer string) error {
 	actions := []*action.Action{
 		&checkSingleCNameExists,
+		&checkCertIssuerAlreadyExists,   // check if certIssuer already exists in the cluster
+		&checkCertIssuerPoolConstraints, // check if issuer is allowed by pool constraints
 		&saveCertIssuer,
 		&rebuildRoutes,
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -1632,9 +1632,7 @@ func RemoveCName(ctx context.Context, app *appTypes.App, cnames ...string) error
 func SetCertIssuer(ctx context.Context, app *appTypes.App, cname, certIssuer string) error {
 	actions := []*action.Action{
 		&checkSingleCNameExists,
-		// check if certIssuer already exists in the cluster
 		// &checkCertIssuerAlreadyExists,
-		// check if issuer is allowed by pool constraints
 		// &checkCertIssuerPoolConstraints,
 		&saveCertIssuer,
 		&rebuildRoutes,

--- a/app/app.go
+++ b/app/app.go
@@ -1632,8 +1632,10 @@ func RemoveCName(ctx context.Context, app *appTypes.App, cnames ...string) error
 func SetCertIssuer(ctx context.Context, app *appTypes.App, cname, certIssuer string) error {
 	actions := []*action.Action{
 		&checkSingleCNameExists,
-		&checkCertIssuerAlreadyExists,   // check if certIssuer already exists in the cluster
-		&checkCertIssuerPoolConstraints, // check if issuer is allowed by pool constraints
+		// check if certIssuer already exists in the cluster
+		// &checkCertIssuerAlreadyExists,
+		// check if issuer is allowed by pool constraints
+		// &checkCertIssuerPoolConstraints,
 		&saveCertIssuer,
 		&rebuildRoutes,
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -1633,7 +1633,7 @@ func SetCertIssuer(ctx context.Context, app *appTypes.App, cname, certIssuer str
 	actions := []*action.Action{
 		&checkSingleCNameExists,
 		// &checkCertIssuerAlreadyExists,
-		// &checkCertIssuerPoolConstraints,
+		&checkCertIssuerPoolConstraints,
 		&saveCertIssuer,
 		&rebuildRoutes,
 	}

--- a/provision/pool/constraint.go
+++ b/provision/pool/constraint.go
@@ -31,7 +31,7 @@ const (
 	ConstraintTypeService    = PoolConstraintType("service")
 	ConstraintTypePlan       = PoolConstraintType("plan")
 	ConstraintTypeVolumePlan = PoolConstraintType("volume-plan")
-	ConstraintTypeCertIssuer = PoolConstraintType("cert-issuer") // new pool constraint type for cert-issuers
+	ConstraintTypeCertIssuer = PoolConstraintType("cert-issuer")
 )
 
 type regexpCache struct {

--- a/provision/pool/constraint.go
+++ b/provision/pool/constraint.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	ErrInvalidConstraintType = errors.Errorf("invalid constraint type. Valid types are: %s", validConstraintTypes)
-	validConstraintTypes     = []PoolConstraintType{ConstraintTypeTeam, ConstraintTypeService, ConstraintTypeRouter, ConstraintTypePlan, ConstraintTypeVolumePlan}
+	validConstraintTypes     = []PoolConstraintType{ConstraintTypeTeam, ConstraintTypeService, ConstraintTypeRouter, ConstraintTypePlan, ConstraintTypeVolumePlan, ConstraintTypeCertIssuer} // new pool constraint type for cert-issuers
 )
 
 type PoolConstraintType string
@@ -31,6 +31,7 @@ const (
 	ConstraintTypeService    = PoolConstraintType("service")
 	ConstraintTypePlan       = PoolConstraintType("plan")
 	ConstraintTypeVolumePlan = PoolConstraintType("volume-plan")
+	ConstraintTypeCertIssuer = PoolConstraintType("cert-issuer") // new pool constraint type for cert-issuers
 )
 
 type regexpCache struct {

--- a/provision/pool/constraint.go
+++ b/provision/pool/constraint.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	ErrInvalidConstraintType = errors.Errorf("invalid constraint type. Valid types are: %s", validConstraintTypes)
-	validConstraintTypes     = []PoolConstraintType{ConstraintTypeTeam, ConstraintTypeService, ConstraintTypeRouter, ConstraintTypePlan, ConstraintTypeVolumePlan, ConstraintTypeCertIssuer} // new pool constraint type for cert-issuers
+	validConstraintTypes     = []PoolConstraintType{ConstraintTypeTeam, ConstraintTypeService, ConstraintTypeRouter, ConstraintTypePlan, ConstraintTypeVolumePlan, ConstraintTypeCertIssuer}
 )
 
 type PoolConstraintType string

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -39,6 +39,7 @@ var (
 	ErrPoolHasNoService               = errors.New("no service found for pool")
 	ErrPoolHasNoPlan                  = errors.New("no plan found for pool")
 	ErrPoolHasNoVolumePlan            = errors.New("no volume-plan found for pool")
+	ErrPoolHasNoCertIssuer            = errors.New("no cert-issuer found for pool") // new error for cert-issuers
 )
 
 const (
@@ -106,6 +107,18 @@ func (p *Pool) GetTeams(ctx context.Context) ([]string, error) {
 		return c, nil
 	}
 	return nil, ErrPoolHasNoTeam
+}
+
+// uma nova função para cert-issuers constraits de um pool
+func (p *Pool) GetCertIssuers(ctx context.Context) ([]string, error) {
+	allowedValues, err := p.allowedValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if c := allowedValues[ConstraintTypeCertIssuer]; len(c) > 0 {
+		return c, nil
+	}
+	return nil, ErrPoolHasNoCertIssuer
 }
 
 func (p *Pool) GetRouters(ctx context.Context) ([]string, error) {

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -39,7 +39,7 @@ var (
 	ErrPoolHasNoService               = errors.New("no service found for pool")
 	ErrPoolHasNoPlan                  = errors.New("no plan found for pool")
 	ErrPoolHasNoVolumePlan            = errors.New("no volume-plan found for pool")
-	ErrPoolHasNoCertIssuer            = errors.New("no cert-issuer found for pool") // new error for cert-issuers
+	ErrPoolHasNoCertIssuer            = errors.New("no cert-issuer found for pool")
 )
 
 const (
@@ -280,13 +280,11 @@ func (p *Pool) allowedValues(ctx context.Context) (map[PoolConstraintType][]stri
 		return nil, err
 	}
 	for k, v := range constraints {
-		// for cert-issuers, we apply the constraint directly to the Kubernetes cluster.
-		// and there is no service on Tsuru to list them
+		// for cert-issuers, we apply the constraint directly to the cluster provider. There is no service on Tsuru to list this constraint type
 		if k == ConstraintTypeCertIssuer {
 			resolved[k] = v.Values
 			continue
 		}
-		// for other types, we apply the filtering logic here
 		names := resolved[k]
 		var validNames []string
 		for _, n := range names {

--- a/provision/pool/pool.go
+++ b/provision/pool/pool.go
@@ -39,7 +39,7 @@ var (
 	ErrPoolHasNoService               = errors.New("no service found for pool")
 	ErrPoolHasNoPlan                  = errors.New("no plan found for pool")
 	ErrPoolHasNoVolumePlan            = errors.New("no volume-plan found for pool")
-	ErrPoolHasNoCertIssuer            = errors.New("no cert-issuer found for pool")
+	ErrPoolHasNoCertIssuerConstraint  = errors.New("no cert-issuer constraints found for pool")
 )
 
 const (
@@ -120,16 +120,16 @@ func (p *Pool) GetRouters(ctx context.Context) ([]string, error) {
 	return nil, ErrPoolHasNoRouter
 }
 
-func (p *Pool) GetCertIssuers(ctx context.Context) ([]string, error) {
+func (p *Pool) GetCertIssuers(ctx context.Context) (*PoolConstraint, error) {
 	constraints, err := getConstraintsForPool(ctx, p.Name, ConstraintTypeCertIssuer)
 	if err != nil {
 		return nil, err
 	}
 	certIssuerConstraint, exists := constraints[ConstraintTypeCertIssuer]
 	if !exists || len(certIssuerConstraint.Values) == 0 {
-		return nil, ErrPoolHasNoCertIssuer
+		return nil, ErrPoolHasNoCertIssuerConstraint
 	}
-	return certIssuerConstraint.Values, nil
+	return certIssuerConstraint, nil
 }
 
 func (p *Pool) GetVolumePlans(ctx context.Context) ([]string, error) {

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -818,8 +818,6 @@ func (s *S) TestPoolAllowedValues(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = SetPoolConstraint(context.TODO(), &PoolConstraint{PoolExpr: "pool1", Field: ConstraintTypeVolumePlan, Values: []string{"nfs"}})
 	c.Assert(err, check.IsNil)
-	err = SetPoolConstraint(context.TODO(), &PoolConstraint{PoolExpr: "pool1", Field: ConstraintTypeCertIssuer, Values: []string{"internal-ca"}})
-	c.Assert(err, check.IsNil)
 	constraints, err := pool.allowedValues(context.TODO())
 	c.Assert(err, check.IsNil)
 	c.Assert(constraints, check.DeepEquals, map[PoolConstraintType][]string{

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -684,10 +684,11 @@ func (s *S) TestGetCertIssuers(c *check.C) {
 	c.Assert(err, check.IsNil)
 	issuers, err := pool.GetCertIssuers(context.TODO())
 	c.Assert(err, check.IsNil)
-	c.Assert(issuers, check.DeepEquals, []string{"letsencrypt-prod", "internal-ca"})
+	c.Assert(issuers.Values, check.DeepEquals, []string{"letsencrypt-prod", "internal-ca"})
+	c.Assert(issuers.Blacklist, check.Equals, false)
 	pool.Name = "other-pool"
 	_, err = pool.GetCertIssuers(context.TODO())
-	c.Assert(err, check.Equals, ErrPoolHasNoCertIssuer)
+	c.Assert(err, check.Equals, ErrPoolHasNoCertIssuerConstraint)
 }
 
 func (s *S) TestGetVolumePlans(c *check.C) {

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -827,7 +827,6 @@ func (s *S) TestPoolAllowedValues(c *check.C) {
 		ConstraintTypeService:    nil,
 		ConstraintTypePlan:       {"plan1", "plan2"},
 		ConstraintTypeVolumePlan: {"nfs"},
-		ConstraintTypeCertIssuer: {"internal-ca"},
 	})
 	pool.Name = "other"
 	constraints, err = pool.allowedValues(context.TODO())


### PR DESCRIPTION
The tsuru API currently does not validate whether the certificate issuer exists in the cluster when managing apps.

Proposed Solution:
This MR introduces validations steps to check if the certificate issuer already exists in the cluster for the app before execute any action and if the pool's app have some constraints for certificates issuers.

The validation leverages the [constraints API](https://github.com/tsuru/tsuru/blob/main/provision/pool/constraint.go) to simplify the implementation and ensure consistency with existing cluster policies.

Key Changes:
- Added issuer validation during app creation and updates;
- Integrated with the constraints API for efficient checks;
- Improved error handling with clear feedback for missing issuers;

ToDo:

1. API - Make the endpoint "**[/apps/{app}/certissuer](https://github.com/tsuru/tsuru/blob/main/api/app.go#L2083)**" :
- [x]  New type of pool constraint to set cert-issuers;
- [ ]  check if the cert issuer exist in the cluster before create a new one for the App;
- [x]  check if the issuer is allowed when the Pool's App have any **constraint** of the type _cert-issuer_.

2. Tsuru CLI [MR #237](https://github.com/tsuru/tsuru-client/pull/237):
- [x]  tsuru-client deal with new pool-constraint type for cert issuers;
- [x]  tsuru-client deal with pools-constraints when create a new cert-issuer for a Tsuru app;
- [ ]  tsuru-client deal with error when create a new cert-issuer for a App when the issuer already exist.

3. Update documentation.