### PR TITLE
Fix/process command fallback to image

### DIFF
--- a/app/version/customdata.go
+++ b/app/version/customdata.go
@@ -174,6 +174,9 @@ func GetProcessesFromProcfile(strProcfile string) map[string][]string {
 	processes := make(map[string][]string, len(procfile))
 	for _, process := range procfile {
 		if p := procfileRegex.FindStringSubmatch(process); p != nil {
+			if p[1] == "" || p[2] == "" {
+				continue
+			}
 			processes[p[1]] = []string{strings.TrimSpace(p[2])}
 		}
 	}
@@ -183,6 +186,9 @@ func GetProcessesFromProcfile(strProcfile string) map[string][]string {
 func GetProcessesFromYamlProcess(yamlProcesses []provTypes.TsuruYamlProcess) map[string][]string {
 	processes := make(map[string][]string, len(yamlProcesses))
 	for _, process := range yamlProcesses {
+		if process.Command == "" {
+			continue
+		}
 		processes[process.Name] = []string{strings.TrimSpace(process.Command)}
 	}
 	return processes

--- a/app/version/customdata_test.go
+++ b/app/version/customdata_test.go
@@ -32,6 +32,8 @@ func (s *S) TestGetProcessesFromProcfile(c *check.C) {
 			"worker":  {"x"},
 			"worker2": {"z"},
 		}},
+		{procfile: "", expected: map[string][]string{}},
+		{procfile: "web:", expected: map[string][]string{}},
 	}
 	for i, t := range tests {
 		v := GetProcessesFromProcfile(t.procfile)
@@ -56,6 +58,12 @@ func (s *S) TestGetProcessesFromYamlProcess(c *check.C) {
 			processes: []provTypes.TsuruYamlProcess{{Name: "web", Command: "python app.py"}, {Name: "worker", Command: "python worker.py"}},
 			expected: map[string][]string{
 				"web":    {"python app.py"},
+				"worker": {"python worker.py"},
+			},
+		},
+		{
+			processes: []provTypes.TsuruYamlProcess{{Name: "web", Command: ""}, {Name: "worker", Command: "python worker.py"}},
+			expected: map[string][]string{
 				"worker": {"python worker.py"},
 			},
 		},

--- a/builder/kubernetes/build.go
+++ b/builder/kubernetes/build.go
@@ -390,7 +390,7 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 		}
 
 		// Default to web process name and entrypoint and cmd from container
-		if shouldDefaultToImageCommands(processes) {
+		if len(processes) == 0 {
 			ic := tc.ImageConfig
 			if ic == nil {
 				ic = new(buildpb.ContainerImageConfig) // covering to avoid panic
@@ -444,24 +444,6 @@ func mergeProcesses(finalProcesses map[string]processCommands, processes map[str
 			definedOn: source,
 		}
 	}
-}
-
-func shouldDefaultToImageCommands(processes map[string]processCommands) bool {
-	if len(processes) == 0 {
-		return true
-	}
-	webProcessCommands, ok := processes[provision.WebProcessName]
-	if !ok {
-		// NOTE(ravilock): web process not found, but a custom processes might be defined
-		return false
-	}
-	if len(webProcessCommands.commands) == 0 {
-		return true
-	}
-	if len(webProcessCommands.commands) == 1 && webProcessCommands.commands[0] == "" {
-		return true
-	}
-	return false
 }
 
 func findDeprecatedHealthcheckData(w io.Writer, tsuruYaml string) {

--- a/builder/kubernetes/build.go
+++ b/builder/kubernetes/build.go
@@ -38,6 +38,11 @@ var (
 	allowedHealthcheckValues = getJSONFieldNames(&provisiontypes.TsuruYamlHealthcheck{})
 )
 
+type processCommands struct {
+	commands  []string
+	definedOn string
+}
+
 type kubernetesBuilder struct{}
 
 func init() {
@@ -347,7 +352,8 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 	}
 
 	if tc != nil {
-		var processes map[string][]string
+		finalProcesses := map[string][]string{}
+		processes := map[string]processCommands{}
 		var customData map[string]any
 		var tsuruYamlData provisiontypes.TsuruYamlData
 		if len(tc.TsuruYaml) > 0 {
@@ -363,23 +369,24 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 			customData = tsuruYamlDataToCustomData(tsuruYamlData)
 		}
 
-		definedOn := ""
 		// Check if it uses new `processes` on YML
 		if len(tsuruYamlData.Processes) > 0 {
 			fmt.Fprintln(w, " ---> Using 'processes' configuration from tsuru.yaml")
 			// If it uses, try to get processes and commands from YML
-			processes = version.GetProcessesFromYamlProcess(tsuruYamlData.Processes)
+			tsuruYamlProcesses := version.GetProcessesFromYamlProcess(tsuruYamlData.Processes)
 			if tsuruYamlData.Healthcheck != nil {
 				fmt.Fprintln(w, " ---> WARNING: Global healthcheck configuration will be IGNORED when YML contains 'processes' configuration")
 			}
+			mergeProcesses(processes, tsuruYamlProcesses, "tsuru.yaml")
 			if len(tc.Procfile) > 0 {
-				fmt.Fprintln(w, " ---> WARNING: Procfile will be IGNORED when YML contains 'processes' configuration")
+				fmt.Fprintln(w, " ---> WARNING: Individual Procfile processes will be IGNORED when YML defines the same process configuration (name and command)")
 			}
-			definedOn = "tsuru.yaml"
-		} else {
+		}
+
+		if len(tc.Procfile) > 0 {
 			// If it does not uses new `processes` on YML, use current implementation
-			processes = version.GetProcessesFromProcfile(tc.Procfile)
-			definedOn = "Procfile"
+			procfileProcesses := version.GetProcessesFromProcfile(tc.Procfile)
+			mergeProcesses(processes, procfileProcesses, "Procfile")
 		}
 
 		// Default to web process name and entrypoint and cmd from container
@@ -394,13 +401,15 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 			if len(cmds) == 0 {
 				return nil, errors.New("neither Procfile nor entrypoint and cmd set")
 			}
-
-			processes[provision.WebProcessName] = cmds
-			definedOn = "dockerfile"
+			processes[provision.WebProcessName] = processCommands{
+				commands:  cmds,
+				definedOn: "dockerfile",
+			}
 		}
 
 		for k, v := range processes {
-			fmt.Fprintf(w, " ---> Process %q found with commands: %q (defined in: %q)\n", k, v, definedOn)
+			fmt.Fprintf(w, " ---> Process %q found with commands: %q (defined in: %q)\n", k, v.commands, v.definedOn)
+			finalProcesses[k] = v.commands
 		}
 
 		var exposedPorts []string
@@ -409,7 +418,7 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 		}
 
 		err = appVersion.AddData(apptypes.AddVersionDataArgs{
-			Processes:    processes,
+			Processes:    finalProcesses,
 			CustomData:   customData,
 			ExposedPorts: exposedPorts,
 		})
@@ -425,7 +434,19 @@ func (b *kubernetesBuilder) buildContainerImage(ctx context.Context, app *apptyp
 	return appVersion, nil
 }
 
-func shouldDefaultToImageCommands(processes map[string][]string) bool {
+func mergeProcesses(finalProcesses map[string]processCommands, processes map[string][]string, source string) {
+	for pName, pCommand := range processes {
+		if _, ok := finalProcesses[pName]; ok {
+			continue
+		}
+		finalProcesses[pName] = processCommands{
+			commands:  pCommand,
+			definedOn: source,
+		}
+	}
+}
+
+func shouldDefaultToImageCommands(processes map[string]processCommands) bool {
 	if len(processes) == 0 {
 		return true
 	}
@@ -434,10 +455,10 @@ func shouldDefaultToImageCommands(processes map[string][]string) bool {
 		// NOTE(ravilock): web process not found, but a custom processes might be defined
 		return false
 	}
-	if len(webProcessCommands) == 0 {
+	if len(webProcessCommands.commands) == 0 {
 		return true
 	}
-	if len(webProcessCommands) == 1 && webProcessCommands[0] == "" {
+	if len(webProcessCommands.commands) == 1 && webProcessCommands.commands[0] == "" {
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR aims to fix an issue where the new `tsuru.yaml` directive `processes` is used, but the `command` of the web process is not defined or is defined as an empty string (`""`).

In those cases, we fallback to use the image command either from `entrypoint` or `cmd`.