### PR TITLE
feat(plan): add optional RuntimeClassName field

### DIFF
--- a/provision/kubernetes/deploy.go
+++ b/provision/kubernetes/deploy.go
@@ -762,6 +762,11 @@ func createAppDeployment(ctx context.Context, opts *createAppDeploymentOptions) 
 		return false, nil, nil, err
 	}
 
+	var runtimeClassName *string
+	if rcn := plan.GetRuntimeClassName(); rcn != "" {
+		runtimeClassName = &rcn
+	}
+
 	metadata := provision.GetAppMetadata(opts.app, opts.process)
 	podLabels := opts.labels.PodLabels()
 
@@ -841,6 +846,7 @@ func createAppDeployment(ctx context.Context, opts *createAppDeploymentOptions) 
 					Annotations: annotations,
 				},
 				Spec: apiv1.PodSpec{
+					RuntimeClassName:              runtimeClassName,
 					TopologySpreadConstraints:     topologySpreadConstraints,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					EnableServiceLinks:            &serviceLinks,

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -2317,6 +2317,56 @@ func (s *S) TestServiceManagerDeployServiceWithResourceRequirements(c *check.C) 
 	}, dep.Spec.Template.Spec.Containers[0].Resources)
 }
 
+func (s *S) TestServiceManagerDeployServiceWithRuntimeClassName(c *check.C) {
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	a := &appTypes.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), a, s.user)
+	require.NoError(s.t, err)
+	a.Plan = appTypes.Plan{RuntimeClassName: "gvisor"}
+	version := newCommittedVersion(c, a, map[string][]string{"p1": {"cm1"}})
+	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
+		App:     a,
+		Version: version,
+	}, servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	require.NoError(s.t, err)
+	waitDep()
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	require.NoError(s.t, err)
+	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
+	require.NoError(s.t, err)
+	require.NotNil(s.t, dep.Spec.Template.Spec.RuntimeClassName)
+	require.Equal(s.t, "gvisor", *dep.Spec.Template.Spec.RuntimeClassName)
+}
+
+func (s *S) TestServiceManagerDeployServiceWithoutRuntimeClassName(c *check.C) {
+	// Regression: when plan has no RuntimeClassName, PodSpec.RuntimeClassName
+	// must remain nil so the cluster's default runtime handler is used.
+	waitDep := s.mock.DeploymentReactions(c)
+	defer waitDep()
+	m := serviceManager{client: s.clusterClient}
+	a := &appTypes.App{Name: "myapp", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), a, s.user)
+	require.NoError(s.t, err)
+	version := newCommittedVersion(c, a, map[string][]string{"p1": {"cm1"}})
+	err = servicecommon.RunServicePipeline(context.TODO(), &m, 0, provision.DeployArgs{
+		App:     a,
+		Version: version,
+	}, servicecommon.ProcessSpec{
+		"p1": servicecommon.ProcessState{Start: true},
+	})
+	require.NoError(s.t, err)
+	waitDep()
+	ns, err := s.client.AppNamespace(context.TODO(), a)
+	require.NoError(s.t, err)
+	dep, err := s.client.Clientset.AppsV1().Deployments(ns).Get(context.TODO(), "myapp-p1", metav1.GetOptions{})
+	require.NoError(s.t, err)
+	require.Nil(s.t, dep.Spec.Template.Spec.RuntimeClassName)
+}
+
 func (s *S) TestServiceManagerDeployServiceWithClusterWideOvercommitFactor(c *check.C) {
 	waitDep := s.mock.DeploymentReactions(c)
 	defer waitDep()

--- a/storage/mongodb/plan.go
+++ b/storage/mongodb/plan.go
@@ -19,12 +19,13 @@ var _ app.PlanStorage = &PlanStorage{}
 type PlanStorage struct{}
 
 type planOnMongoDB struct {
-	Name     string `bson:"_id"`
-	Memory   int64
-	CPUMilli int
-	CPUBurst *app.CPUBurst
-	Default  bool
-	Override *app.PlanOverride `bson:"-"`
+	Name             string `bson:"_id"`
+	Memory           int64
+	CPUMilli         int
+	CPUBurst         *app.CPUBurst
+	RuntimeClassName string
+	Default          bool
+	Override         *app.PlanOverride `bson:"-"`
 }
 
 func (s *PlanStorage) Insert(ctx context.Context, p app.Plan) error {

--- a/types/app/plan.go
+++ b/types/app/plan.go
@@ -7,18 +7,20 @@ package app
 import "context"
 
 type Plan struct {
-	Name     string        `json:"name"`
-	Memory   int64         `json:"memory"`
-	CPUMilli int           `json:"cpumilli"`
-	CPUBurst *CPUBurst     `json:"cpuBurst,omitempty"`
-	Default  bool          `json:"default,omitempty"`
-	Override *PlanOverride `json:"override,omitempty"`
+	Name             string        `json:"name"`
+	Memory           int64         `json:"memory"`
+	CPUMilli         int           `json:"cpumilli"`
+	CPUBurst         *CPUBurst     `json:"cpuBurst,omitempty"`
+	RuntimeClassName string        `json:"runtimeClassName,omitempty"`
+	Default          bool          `json:"default,omitempty"`
+	Override         *PlanOverride `json:"override,omitempty"`
 }
 
 type PlanOverride struct {
-	Memory   *int64   `json:"memory"`
-	CPUMilli *int     `json:"cpumilli"`
-	CPUBurst *float64 `json:"cpuBurst"`
+	Memory           *int64   `json:"memory"`
+	CPUMilli         *int     `json:"cpumilli"`
+	CPUBurst         *float64 `json:"cpuBurst"`
+	RuntimeClassName *string  `json:"runtimeClassName,omitempty"`
 }
 
 type CPUBurst struct {
@@ -55,6 +57,14 @@ func (p *Plan) MergeOverride(po PlanOverride) {
 		}
 	}
 
+	if po.RuntimeClassName != nil {
+		if *po.RuntimeClassName == "" {
+			newOverride.RuntimeClassName = nil
+		} else {
+			newOverride.RuntimeClassName = po.RuntimeClassName
+		}
+	}
+
 	if (*newOverride == PlanOverride{}) {
 		p.Override = nil
 	} else {
@@ -85,6 +95,16 @@ func (p Plan) GetCPUBurst() float64 {
 	}
 
 	return 0
+}
+
+// GetRuntimeClassName returns the Kubernetes RuntimeClass name that pods
+// provisioned from this plan should use. An empty string means the cluster's
+// default runtime (typically runc) is used.
+func (p Plan) GetRuntimeClassName() string {
+	if p.Override != nil && p.Override.RuntimeClassName != nil {
+		return *p.Override.RuntimeClassName
+	}
+	return p.RuntimeClassName
 }
 
 type PlanService interface {

--- a/types/app/plan_test.go
+++ b/types/app/plan_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlan_GetRuntimeClassName(t *testing.T) {
+	t.Run("empty when unset", func(t *testing.T) {
+		p := Plan{}
+		require.Empty(t, p.GetRuntimeClassName())
+	})
+
+	t.Run("returns plan value when set", func(t *testing.T) {
+		p := Plan{RuntimeClassName: "gvisor"}
+		require.Equal(t, "gvisor", p.GetRuntimeClassName())
+	})
+
+	t.Run("override takes precedence over plan value", func(t *testing.T) {
+		kata := "kata-qemu"
+		p := Plan{
+			RuntimeClassName: "gvisor",
+			Override:         &PlanOverride{RuntimeClassName: &kata},
+		}
+		require.Equal(t, "kata-qemu", p.GetRuntimeClassName())
+	})
+
+	t.Run("override with empty string falls back to plan value", func(t *testing.T) {
+		// An empty-string override should be treated as "not overriding"
+		// via MergeOverride; but if a caller constructs it directly, the
+		// getter returns the (possibly empty) override — we don't try to
+		// distinguish empty override from absent override once stored.
+		empty := ""
+		p := Plan{
+			RuntimeClassName: "gvisor",
+			Override:         &PlanOverride{RuntimeClassName: &empty},
+		}
+		require.Equal(t, "", p.GetRuntimeClassName())
+	})
+}
+
+func TestPlan_MergeOverride_RuntimeClassName(t *testing.T) {
+	t.Run("sets override when non-empty", func(t *testing.T) {
+		p := Plan{}
+		name := "gvisor"
+		p.MergeOverride(PlanOverride{RuntimeClassName: &name})
+		require.NotNil(t, p.Override)
+		require.NotNil(t, p.Override.RuntimeClassName)
+		require.Equal(t, "gvisor", *p.Override.RuntimeClassName)
+	})
+
+	t.Run("clears override when set to empty string", func(t *testing.T) {
+		name := "gvisor"
+		p := Plan{Override: &PlanOverride{RuntimeClassName: &name}}
+		empty := ""
+		p.MergeOverride(PlanOverride{RuntimeClassName: &empty})
+		// After clearing the only override field, Override should be nil.
+		require.Nil(t, p.Override)
+	})
+
+	t.Run("nil leaves existing override untouched", func(t *testing.T) {
+		name := "gvisor"
+		p := Plan{Override: &PlanOverride{RuntimeClassName: &name}}
+		p.MergeOverride(PlanOverride{})
+		require.NotNil(t, p.Override)
+		require.NotNil(t, p.Override.RuntimeClassName)
+		require.Equal(t, "gvisor", *p.Override.RuntimeClassName)
+	})
+}


### PR DESCRIPTION
## Summary

Adds an optional `RuntimeClassName` field to `Plan` so apps can be scheduled under a specific Kubernetes RuntimeClass (e.g. `gvisor`, `kata-qemu`). When set, it's threaded into `PodSpec.RuntimeClassName`; when empty, behaviour is unchanged.

Refs #2857.

## Shape

Mirrors the `CPUBurst` precedent:

- `types/app/plan.go`: `Plan.RuntimeClassName string` (`omitempty`) + `PlanOverride.RuntimeClassName *string` + `GetRuntimeClassName()` with override fallback + `MergeOverride` handles empty-string as clear
- `storage/mongodb/plan.go`: matching field on `planOnMongoDB` so the struct conversion stays valid
- `provision/kubernetes/deploy.go`: when `plan.GetRuntimeClassName()` is non-empty, populate `PodSpec.RuntimeClassName`
- API: `ParseInput` on JSON mode already round-trips the field — no handler changes (same as CPUBurst)

## Tests

- `types/app/plan_test.go` (testify): getter + `MergeOverride` semantics
- `provision/kubernetes/deploy_test.go` (gocheck, matching file style): `PodSpec.RuntimeClassName` is set when plan has the field, and remains `nil` (cluster default) when it doesn't

Local: `go test -race` of the affected packages + `golangci-lint v1.64` are clean.

## Intentionally out of scope

- Pool-level override (can be a follow-up if desired)
- CLI flag on `tsuru plan create` — JSON mode works today; happy to add the form-mode flag in a follow-up if that's preferred
- Validation that the RuntimeClass actually exists in the cluster — kubelet admission will fail fast on unknown names
