### PR TITLE
feat: add timeout to app run and make it cancellable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ generate-test-certs:
 DOCKER ?= docker
 
 # Kubernetes version used with minikube
-K8S_VERSION = v1.30.0
+K8S_VERSION = v1.32.0
 
 # Tsuru local host
 # This is used to configure the insecure registry in minikube as well as in the

--- a/api/app.go
+++ b/api/app.go
@@ -44,6 +44,8 @@ import (
 	tagTypes "github.com/tsuru/tsuru/types/tag"
 )
 
+var appRunMaxDuration = 10 * time.Minute
+
 var (
 	logsAppTail = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "tsuru_logs_app_tail_current",
@@ -971,17 +973,23 @@ func runCommand(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 		return permission.ErrUnauthorized
 	}
 	evt, err := event.New(ctx, &event.Opts{
-		Target:     appTarget(appName),
-		Kind:       permission.PermAppRun,
-		Owner:      t,
-		RemoteAddr: r.RemoteAddr,
-		CustomData: event.FormToCustomData(InputFields(r)),
-		Allowed:    event.Allowed(permission.PermAppReadEvents, contextsForApp(a)...),
+		Target:        appTarget(appName),
+		Kind:          permission.PermAppRun,
+		Owner:         t,
+		RemoteAddr:    r.RemoteAddr,
+		CustomData:    event.FormToCustomData(InputFields(r)),
+		Allowed:       event.Allowed(permission.PermAppReadEvents, contextsForApp(a)...),
+		Cancelable:    true,
+		AllowedCancel: event.Allowed(permission.PermAppRun, contextsForApp(a)...),
 	})
 	if err != nil {
 		return err
 	}
 	defer func() { evt.Done(ctx, err) }()
+	ctx, cancel := evt.CancelableContext(ctx)
+	defer cancel()
+	ctx, cancelTimeout := stdContext.WithTimeout(ctx, appRunMaxDuration)
+	defer cancelTimeout()
 	w.Header().Set("Content-Type", "application/x-json-stream")
 	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
 	defer keepAliveWriter.Stop()

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -3197,6 +3197,57 @@ func (s *S) TestRunAppDoesNotExist(c *check.C) {
 	c.Assert(recorder.Body.String(), check.Equals, "App unknown not found.\n")
 }
 
+func (s *S) TestRunEventIsCancelable(c *check.C) {
+	s.provisioner.PrepareOutput([]byte("output"))
+	a := appTypes.App{Name: "secrets", Platform: "zend", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	s.provisioner.AddUnits(context.TODO(), &a, 1, "web", nil, nil)
+	url := fmt.Sprintf("/apps/%s/run", a.Name)
+	request, err := http.NewRequest("POST", url, strings.NewReader("command=ls"))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+	collection, err := storagev2.EventsCollection()
+	c.Assert(err, check.IsNil)
+	var evt struct {
+		Cancelable bool `bson:"cancelable"`
+	}
+	err = collection.FindOne(context.TODO(), mongoBSON.M{"kind.name": "app.run"}).Decode(&evt)
+	c.Assert(err, check.IsNil)
+	c.Assert(evt.Cancelable, check.Equals, true)
+}
+
+func (s *S) TestRunWithMaxDuration(c *check.C) {
+	oldMaxDuration := appRunMaxDuration
+	appRunMaxDuration = 100 * time.Millisecond
+	defer func() { appRunMaxDuration = oldMaxDuration }()
+	a := appTypes.App{Name: "secrets", Platform: "zend", TeamOwner: s.team.Name}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	s.provisioner.AddUnits(context.TODO(), &a, 1, "web", nil, nil)
+	// Don't prepare output — ExecuteCommand will block, but the context
+	// deadline (100ms) should fire first and terminate the command.
+	url := fmt.Sprintf("/apps/%s/run", a.Name)
+	request, err := http.NewRequest("POST", url, strings.NewReader("command=sleep+999"))
+	c.Assert(err, check.IsNil)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Authorization", "b "+s.token.GetValue())
+	recorder := httptest.NewRecorder()
+	s.testServer.ServeHTTP(recorder, request)
+	collection, err := storagev2.EventsCollection()
+	c.Assert(err, check.IsNil)
+	var evt struct {
+		Error string `bson:"error"`
+	}
+	err = collection.FindOne(context.TODO(), mongoBSON.M{"kind.name": "app.run"}).Decode(&evt)
+	c.Assert(err, check.IsNil)
+	c.Assert(evt.Error, check.Not(check.Equals), "")
+}
+
 func (s *S) TestRunUserDoesNotHaveAccessToTheApp(c *check.C) {
 	a := appTypes.App{Name: "secrets", Platform: "zend"}
 	appsCollection, err := storagev2.AppsCollection()

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -621,6 +621,8 @@ func (p *FakeProvisioner) ExecuteCommand(ctx context.Context, opts provision.Exe
 			} else {
 				p.failures <- fail
 			}
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-time.After(2e9):
 			return errors.New("FakeProvisioner timed out waiting for output.")
 		}


### PR DESCRIPTION
Co-authored-by: Ravi ravi.me.professional@hotmail.com

This resolves a issue where app run would hold an app "Hostage" when it had some command that would run indefinitely, not allowing other operations to be done