### PR TITLE
fix(api): keep follow-mode app log streams alive through idle periods

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -1409,6 +1409,13 @@ func appLog(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if !follow {
 		return nil
 	}
+	// Wrap the writer with a keep-alive ticker so intermediaries (reverse
+	// proxies, load balancers) don't close an idle follow-mode stream when
+	// the app is quiet. The '\n' bytes are skipped as whitespace by the
+	// client's json.Decoder between log batches.
+	keepAliveWriter := tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")
+	defer keepAliveWriter.Stop()
+	encoder = json.NewEncoder(keepAliveWriter)
 	watcher, err := logService.Watch(ctx, listArgs)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

When streaming app logs in follow mode (`tsuru app log -f`), the HTTP response is held open and log batches are flushed as they arrive. If the app is quiet, no bytes cross the wire, and intermediaries (reverse proxies, load balancers, ingress controllers) often close the connection after their idle timeout — dropping the client silently.

This wraps the response writer with `tsuruIo.KeepAliveWriter` (already used elsewhere for similar streaming endpoints) so a `\n` byte is emitted every 30s during idle periods. Newlines are skipped as whitespace by the client's `json.Decoder` between log batches, so no client-side changes are required.

## Change

- `api/app.go`: wrap `w` with `tsuruIo.NewKeepAliveWriter(w, 30*time.Second, "")` and rebind `encoder` to it, right before entering the follow loop.

## Test plan

- [ ] `tsuru app log -a <app> -f` on an idle app stays connected past the proxy idle timeout (previously dropped).
- [ ] Active apps still receive log batches with no duplication or corruption.
- [ ] Non-follow requests (`follow=false`) are unaffected — the keep-alive is only installed on the follow path.