### PR TITLE
[chore] Always store unit ID in `app.run.shell` events

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -89,6 +89,7 @@ Magno Torres <magno@corp.globo.com> <magnotorres@gmail.com>
 Manoel Domingues Junior <manoel.domingues.junior@gmail.com> <manoel.junior@corp.globo.com>
 Marc Abramowitz <msabramo@gmail.com> <marc@marc-abramowitz.com>
 Marcelo Jorge Vieira <metal@alucinados.com>
+Márcio Sobel <contact@marciosobel.dev>
 Marco Paulo Ollivier <marcopollivier@gmail.com>
 Marco Sinhoreli <msinhore@gmail.com>
 Marcus Cartágenes <mvcartagenes@gmail.com>

--- a/api/shell.go
+++ b/api/shell.go
@@ -162,12 +162,20 @@ func remoteShellHandler(w http.ResponseWriter, r *http.Request) {
 	width, _ := strconv.Atoi(r.URL.Query().Get("width"))
 	height, _ := strconv.Atoi(r.URL.Query().Get("height"))
 	clientTerm := r.URL.Query().Get("term")
+	units := unitsForShell(ctx, a, unitID, isolated)
+	fields := InputFields(r)
+
+	if unitID == "" && units != nil {
+		unitID = units[0]
+		fields.Add("unit", unitID)
+	}
+
 	evt, err := event.New(ctx, &event.Opts{
 		Target:      appTarget(appName),
 		Kind:        permission.PermAppRunShell,
 		Owner:       token,
 		RemoteAddr:  r.RemoteAddr,
-		CustomData:  event.FormToCustomData(InputFields(r)),
+		CustomData:  event.FormToCustomData(fields),
 		Allowed:     event.Allowed(permission.PermAppReadEvents, contextsForApp(a)...),
 		DisableLock: true,
 	})
@@ -219,7 +227,7 @@ func remoteShellHandler(w http.ResponseWriter, r *http.Request) {
 		Stdin:  conn,
 		Width:  width,
 		Height: height,
-		Units:  unitsForShell(ctx, a, unitID, isolated),
+		Units:  units,
 		Term:   clientTerm,
 		Debug:  debug,
 	}

--- a/api/shell_test.go
+++ b/api/shell_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tsuru/tsuru/app"
+	"github.com/tsuru/tsuru/event"
 	"github.com/tsuru/tsuru/permission"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/tsurutest"
@@ -256,4 +257,113 @@ func (s *S) TestAppShellGenericError(c *check.C) {
 		return result == "Error: App someapp not found.\n"
 	})
 	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestAppShellEventDisplaysUnitID(c *check.C) {
+	a := appTypes.App{
+		Name:      "someapp",
+		Platform:  "zend",
+		TeamOwner: s.team.Name,
+	}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	err = s.provisioner.AddUnits(context.TODO(), &a, 1, "web", nil, nil)
+	c.Assert(err, check.IsNil)
+	units, err := s.provisioner.Units(context.TODO(), &a)
+	c.Assert(err, check.IsNil)
+	c.Assert(units, check.HasLen, 1)
+	unit := units[0]
+	server := httptest.NewServer(s.testServer)
+	defer server.Close()
+	testServerURL, err := url.Parse(server.URL)
+	c.Assert(err, check.IsNil)
+	url := fmt.Sprintf("ws://%s/apps/%s/shell?width=140&height=38&term=xterm&unit=%s", testServerURL.Host, a.Name, unit.ID)
+	config, err := websocket.NewConfig(url, "ws://localhost/")
+	c.Assert(err, check.IsNil)
+	config.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	wsConn, err := websocket.DialConfig(config)
+	c.Assert(err, check.IsNil)
+	defer wsConn.Close()
+	_, err = wsConn.Write([]byte("echo test"))
+	c.Assert(err, check.IsNil)
+	var shells []provision.ExecOptions
+	err = tsurutest.WaitCondition(5*time.Second, func() bool {
+		shells = s.provisioner.Execs(unit.ID)
+		return len(shells) == 1
+	})
+	c.Assert(err, check.IsNil)
+
+	events, err := event.All(context.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(events, check.HasLen, 1)
+
+	var eventData []map[string]string
+	err = events[0].StartData(&eventData)
+	c.Assert(err, check.IsNil)
+
+	hasUnitField := false
+	for _, data := range eventData {
+		if data["name"] == "unit" {
+			c.Assert(data["value"], check.Equals, unit.ID)
+			hasUnitField = true
+			break
+		}
+	}
+	c.Assert(hasUnitField, check.Equals, true)
+}
+
+func (s *S) TestAppShellEventDisplaysAutoSelectedUnitID(c *check.C) {
+	a := appTypes.App{
+		Name:      "someapp",
+		Platform:  "zend",
+		TeamOwner: s.team.Name,
+	}
+	err := app.CreateApp(context.TODO(), &a, s.user)
+	c.Assert(err, check.IsNil)
+	err = s.provisioner.AddUnits(context.TODO(), &a, 1, "web", nil, nil)
+	c.Assert(err, check.IsNil)
+	units, err := s.provisioner.Units(context.TODO(), &a)
+	c.Assert(err, check.IsNil)
+	c.Assert(units, check.HasLen, 1)
+	unit := units[0]
+	server := httptest.NewServer(s.testServer)
+	defer server.Close()
+	testServerURL, err := url.Parse(server.URL)
+	c.Assert(err, check.IsNil)
+	url := fmt.Sprintf("ws://%s/apps/%s/shell?width=140&height=38&term=xterm", testServerURL.Host, a.Name)
+	config, err := websocket.NewConfig(url, "ws://localhost/")
+	c.Assert(err, check.IsNil)
+	config.Header.Set("Authorization", "bearer "+s.token.GetValue())
+	wsConn, err := websocket.DialConfig(config)
+	c.Assert(err, check.IsNil)
+	defer wsConn.Close()
+	_, err = wsConn.Write([]byte("echo test"))
+	c.Assert(err, check.IsNil)
+	var shells []provision.ExecOptions
+	err = tsurutest.WaitCondition(5*time.Second, func() bool {
+		shells = s.provisioner.Execs(unit.ID)
+		return len(shells) == 1
+	})
+	c.Assert(err, check.IsNil)
+
+	events, err := event.All(context.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(events, check.HasLen, 1)
+
+	// Since there is only one unit in this app, then
+	// the automatically selected unit should be one we created.
+	var eventData []map[string]string
+	err = events[0].StartData(&eventData)
+	c.Assert(err, check.IsNil)
+
+	hasUnitField := false
+	for _, data := range eventData {
+		if data["name"] == "unit" {
+			c.Assert(data["value"], check.Equals, unit.ID)
+			hasUnitField = true
+			break
+		}
+	}
+
+	c.Assert(hasUnitField, check.Equals, true)
 }


### PR DESCRIPTION
When running a shell with `tsuru shell`, the automatically chosen ID is also included in the event info. If a unit is provided, the provided ID will be prioritized.

closes #2866