### PR TITLE
fix(net): remove inherited deadlines from WithoutCancel

### DIFF
--- a/net/context.go
+++ b/net/context.go
@@ -20,18 +20,6 @@ func CancelableParentContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-type withoutCancelContext struct {
-	context.Context
-}
-
-func (*withoutCancelContext) Err() error {
-	return nil
-}
-
-func (*withoutCancelContext) Done() <-chan struct{} {
-	return nil
-}
-
 func WithoutCancel(ctx context.Context) context.Context {
-	return context.WithValue(&withoutCancelContext{Context: ctx}, baseContextValue, ctx)
+	return context.WithValue(context.WithoutCancel(ctx), baseContextValue, ctx)
 }

--- a/net/context_test.go
+++ b/net/context_test.go
@@ -6,6 +6,7 @@ package net
 
 import (
 	"context"
+	"time"
 
 	check "gopkg.in/check.v1"
 )
@@ -23,4 +24,23 @@ func (s *S) TestWithoutCancelContext(c *check.C) {
 	c.Assert(ctx.Err(), check.IsNil)
 	c.Assert(ctx.Done(), check.IsNil)
 	c.Assert(ctx.Value(TSURU_STR), check.Equals, "power")
+}
+
+func (s *S) TestWithoutCancelRemovesDeadline(c *check.C) {
+	parent, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	ctx := WithoutCancel(parent)
+	_, ok := ctx.Deadline()
+
+	c.Assert(ok, check.Equals, false)
+}
+
+func (s *S) TestCancelableParentContext(c *check.C) {
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx := WithoutCancel(parent)
+
+	c.Assert(CancelableParentContext(ctx), check.Equals, parent)
 }


### PR DESCRIPTION
## Summary

`net.WithoutCancel` was still carrying the parent deadline.
So rollback and cleanup paths could still time out after switching to a non-cancelable ctx. Kinda defeats the point.

This swaps it to `context.WithoutCancel(...)` and keeps `CancelableParentContext(...)` working.

## Repro

1. `ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)`
2. `ctx = tsuruNet.WithoutCancel(ctx)`
3. Before this patch, `ctx.Deadline()` still returned `ok=true`.
4. That lets rollback and deferred pod cleanup still hit the original timeout.

## Checks

- `go test ./net -count=1`
- `go test -c ./api`
- `go test -c ./action`
- `go test -c ./provision/servicecommon`
- `go test -c ./provision/kubernetes`

Mongo-backed package tests were not runnable in this local env
