### PR TITLE
ServiceAPI with json encoding support

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -82,6 +82,7 @@ type serviceInput struct {
 	Password  string            `json:"password" form:"password"`
 	Endpoints map[string]string `json:"endpoints" form:"endpoints"`
 	Endpoint  string            `json:"endpoint" form:"endpoint"`
+	Encoding  string            `json:"encoding" form:"encoding"`
 }
 
 func parseService(r *http.Request) (service.Service, error) {
@@ -104,6 +105,13 @@ func parseService(r *http.Request) (service.Service, error) {
 	multiCluster, err := strconv.ParseBool(InputValue(r, "multi-cluster"))
 	if err == nil {
 		s.IsMultiCluster = multiCluster
+	}
+	if inputSvc.Encoding != "" {
+		enc := service.ServiceEncoding(inputSvc.Encoding)
+		if enc != service.ServiceEncodingForm && enc != service.ServiceEncodingJSON {
+			return s, &errors.HTTP{Code: http.StatusBadRequest, Message: fmt.Sprintf("Invalid encoding %q, valid options are: form, json", inputSvc.Encoding)}
+		}
+		s.Encoding = enc
 	}
 	team := InputValue(r, "team")
 	if team != "" {
@@ -219,6 +227,9 @@ func serviceUpdate(w http.ResponseWriter, r *http.Request, t auth.Token) (err er
 	s.Endpoint = d.Endpoint
 	s.Password = d.Password
 	s.Username = d.Username
+	if d.Encoding != "" {
+		s.Encoding = d.Encoding
+	}
 	if len(d.OwnerTeams) != 0 {
 		s.OwnerTeams = d.OwnerTeams
 	}

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -341,6 +341,72 @@ func (s *ProvisionSuite) TestServiceCreateWithMultiClusterEnabled(c *check.C) {
 	c.Assert(rService.IsMultiCluster, check.Equals, true)
 }
 
+func (s *ProvisionSuite) TestServiceCreateWithJSONEncoding(c *check.C) {
+	v := url.Values{}
+	v.Set("id", "json-service")
+	v.Set("username", "user")
+	v.Set("password", "password")
+	v.Set("endpoint", "http://json.service.example.com")
+	v.Set("encoding", "json")
+	recorder, request := s.makeRequest(http.MethodPost, "/services", v.Encode(), c)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusCreated)
+	query := mongoBSON.M{"_id": "json-service"}
+	var rService service.Service
+
+	servicesCollection, err := storagev2.ServicesCollection()
+	c.Assert(err, check.IsNil)
+
+	err = servicesCollection.FindOne(context.TODO(), query).Decode(&rService)
+	c.Assert(err, check.IsNil)
+	c.Assert(rService.Endpoint["production"], check.Equals, "http://json.service.example.com")
+	c.Assert(rService.Username, check.Equals, "user")
+	c.Assert(rService.Password, check.Equals, "password")
+	c.Assert(rService.Encoding, check.Equals, service.ServiceEncodingJSON)
+}
+
+func (s *ProvisionSuite) TestServiceCreateWithInvalidEncoding(c *check.C) {
+	v := url.Values{}
+	v.Set("id", "bad-service")
+	v.Set("username", "user")
+	v.Set("password", "password")
+	v.Set("endpoint", "http://bad.service.example.com")
+	v.Set("encoding", "xml")
+	recorder, request := s.makeRequest(http.MethodPost, "/services", v.Encode(), c)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusBadRequest)
+	c.Assert(recorder.Body.String(), check.Matches, `(?s).*Invalid encoding "xml".*`)
+}
+
+func (s *ProvisionSuite) TestServiceUpdateEncoding(c *check.C) {
+	srv := service.Service{
+		Name:       "mysqlapi",
+		Endpoint:   map[string]string{"production": "sqlapi.com"},
+		OwnerTeams: []string{s.team.Name},
+		Password:   "oldold",
+	}
+	err := service.Create(context.TODO(), srv)
+	c.Assert(err, check.IsNil)
+	v := url.Values{}
+	v.Set("username", "mysqltest")
+	v.Set("password", "yyyy")
+	v.Set("endpoint", "mysqlapi.com")
+	v.Set("encoding", "json")
+	recorder, request := s.makeRequest(http.MethodPut, "/services/mysqlapi", v.Encode(), c)
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.testServer.ServeHTTP(recorder, request)
+	c.Assert(recorder.Code, check.Equals, http.StatusOK)
+
+	servicesCollection, err := storagev2.ServicesCollection()
+	c.Assert(err, check.IsNil)
+
+	err = servicesCollection.FindOne(context.TODO(), mongoBSON.M{"_id": srv.Name}).Decode(&srv)
+	c.Assert(err, check.IsNil)
+	c.Assert(srv.Encoding, check.Equals, service.ServiceEncodingJSON)
+}
+
 func (s *ProvisionSuite) TestServiceUpdate(c *check.C) {
 	srv := service.Service{
 		Name:       "mysqlapi",

--- a/docs/reference/service_api.yaml
+++ b/docs/reference/service_api.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.0
 info:
   title: Tsuru Service Provider API
   description: Provider-side API consumed by tsuru service integrations.
-  version: "1.1.0"
+  version: "1.2.0"
 
 tags:
 - name: Plans
@@ -70,15 +70,20 @@ paths:
       description: |
         Creates a new service instance.
 
-        Requests are sent as `application/x-www-form-urlencoded`.
-        Besides the documented fields below, tsuru may send `parameters.*` fields
-        derived from arbitrary instance parameters.
+        The request content type depends on the service encoding configuration:
+        - `application/x-www-form-urlencoded` (default): parameters are sent as
+          form fields, with nested parameters encoded as `parameters.<key>=<value>`.
+        - `application/json`: parameters are sent as a JSON object with camelCase
+          field names and a nested `parameters` object.
       requestBody:
         required: true
         content:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/InstanceCreateRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InstanceCreateRequestJSON"
       responses:
         "201":
           description: Instance created
@@ -150,15 +155,20 @@ paths:
       description: |
         Updates a service instance.
 
-        Requests are sent as `application/x-www-form-urlencoded`.
-        Besides the documented fields below, tsuru may send `parameters.*` fields
-        derived from arbitrary instance parameters.
+        The request content type depends on the service encoding configuration:
+        - `application/x-www-form-urlencoded` (default): parameters are sent as
+          form fields, with nested parameters encoded as `parameters.<key>=<value>`.
+        - `application/json`: parameters are sent as a JSON object with camelCase
+          field names and a nested `parameters` object.
       requestBody:
         required: true
         content:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/InstanceUpdateRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InstanceUpdateRequestJSON"
       responses:
         "200":
           description: Instance updated
@@ -183,10 +193,12 @@ paths:
       description: |
         Removes the service instance.
 
-        Tsuru sends this request with a form-encoded body containing `user` and
-        `eventid`, but that body is intentionally not modeled as an OpenAPI
-        `requestBody` because DELETE request bodies are not well-defined across
-        tooling.
+        Tsuru sends a body containing `user` and `eventid`. The content type
+        depends on the service encoding configuration (`application/x-www-form-urlencoded`
+        by default, or `application/json`).
+
+        Note: DELETE request bodies are not well-defined across tooling, but tsuru
+        sends them for backward compatibility.
       responses:
         "200":
           description: Instance removed
@@ -220,9 +232,11 @@ paths:
       description: |
         Binds an app to a service instance.
 
-        Requests are sent as `application/x-www-form-urlencoded`. Besides the
-        documented fields below, tsuru may send `parameters.*` fields derived
-        from arbitrary bind parameters.
+        The request content type depends on the service encoding configuration:
+        - `application/x-www-form-urlencoded` (default): parameters are sent as
+          form fields, with bind parameters encoded as `parameters.<key>=<value>`.
+        - `application/json`: parameters are sent as a JSON object with camelCase
+          field names and a nested `parameters` object.
 
         For backward compatibility, tsuru falls back to `POST /resources/{name}/bind`
         if this endpoint returns `404`.
@@ -232,6 +246,9 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/AppBindRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppBindRequestJSON"
       responses:
         "200":
           description: App bound successfully
@@ -268,10 +285,12 @@ paths:
       description: |
         Unbinds an app from a service instance.
 
-        Tsuru sends this request with a form-encoded body containing `app-name`,
-        `app-host`, repeated `app-hosts`, `user`, and `eventid`, but that body is
-        intentionally not modeled as an OpenAPI `requestBody` because DELETE
-        request bodies are not well-defined across tooling.
+        Tsuru sends a body containing app information, user, and event ID.
+        The content type depends on the service encoding configuration
+        (`application/x-www-form-urlencoded` by default, or `application/json`).
+
+        Note: DELETE request bodies are not well-defined across tooling, but tsuru
+        sends them for backward compatibility.
       responses:
         "200":
           description: App unbound successfully
@@ -314,6 +333,9 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/AppBindRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppBindRequestJSON"
       responses:
         "200":
           description: App bound successfully
@@ -365,13 +387,18 @@ paths:
       description: |
         Binds a job to a service instance.
 
-        Requests are sent as `application/x-www-form-urlencoded`.
+        The request content type depends on the service encoding configuration:
+        - `application/x-www-form-urlencoded` (default): parameters are sent as form fields.
+        - `application/json`: parameters are sent as a JSON object with camelCase field names.
       requestBody:
         required: true
         content:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/JobBindRequest"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JobBindRequestJSON"
       responses:
         "200":
           description: Job bound successfully
@@ -405,7 +432,15 @@ paths:
       tags:
       - Job Binding
       summary: Unbind a job from a service instance
-      description: Unbinds a job from a service instance.
+      description: |
+        Unbinds a job from a service instance.
+
+        Tsuru sends a body containing `user` and `eventID`. The content type
+        depends on the service encoding configuration (`application/x-www-form-urlencoded`
+        by default, or `application/json`).
+
+        Note: DELETE request bodies are not well-defined across tooling, but tsuru
+        sends them for backward compatibility.
       responses:
         "200":
           description: Job unbound successfully
@@ -716,8 +751,13 @@ components:
       - label
       - value
 
+    # ──────────────────────────────────────────────
+    # Form-encoded schemas (legacy / default)
+    # ──────────────────────────────────────────────
+
     InstanceCreateRequest:
       type: object
+      description: Form-encoded instance creation request.
       properties:
         name:
           type: string
@@ -755,6 +795,7 @@ components:
 
     InstanceUpdateRequest:
       type: object
+      description: Form-encoded instance update request.
       properties:
         plan:
           type: string
@@ -785,6 +826,7 @@ components:
 
     AppBindRequest:
       type: object
+      description: Form-encoded app bind request.
       properties:
         app-name:
           type: string
@@ -836,6 +878,7 @@ components:
 
     JobBindRequest:
       type: object
+      description: Form-encoded job bind request.
       properties:
         job-name:
           type: string
@@ -854,6 +897,148 @@ components:
           description: Tsuru event identifier
       required:
       - job-name
+
+    # ──────────────────────────────────────────────
+    # JSON schemas (encoding: json)
+    # ──────────────────────────────────────────────
+
+    InstanceCreateRequestJSON:
+      type: object
+      description: JSON instance creation request. Sent when the service encoding is `json`.
+      properties:
+        name:
+          type: string
+          description: Instance name
+        plan:
+          type: string
+          description: Plan name
+        team:
+          type: string
+          description: Team owner name
+        user:
+          type: string
+          description: User email or name
+        eventID:
+          type: string
+          description: Tsuru event identifier
+        description:
+          type: string
+          description: Instance description
+        tags:
+          type: array
+          description: Service instance tags
+          items:
+            type: string
+        parameters:
+          type: object
+          description: Arbitrary parameter bag as a nested JSON object.
+          additionalProperties: true
+      required:
+      - name
+      - team
+      - user
+
+    InstanceUpdateRequestJSON:
+      type: object
+      description: JSON instance update request. Sent when the service encoding is `json`.
+      properties:
+        description:
+          type: string
+          description: Instance description
+        plan:
+          type: string
+          description: Plan name
+        team:
+          type: string
+          description: Team owner name
+        user:
+          type: string
+          description: User email or name
+        eventID:
+          type: string
+          description: Tsuru event identifier
+        tags:
+          type: array
+          description: Service instance tags
+          items:
+            type: string
+        parameters:
+          type: object
+          description: Arbitrary parameter bag as a nested JSON object.
+          additionalProperties: true
+
+    AppBindRequestJSON:
+      type: object
+      description: JSON app bind request. Sent when the service encoding is `json`.
+      properties:
+        appName:
+          type: string
+          description: App name
+        appHosts:
+          type: array
+          description: App external hosts
+          items:
+            type: string
+        appInternalHosts:
+          type: array
+          description: Internal bindable app hosts
+          items:
+            type: string
+        appPoolName:
+          type: string
+          description: App pool name
+        appPoolProvisioner:
+          type: string
+          description: App pool provisioner
+        appClusterName:
+          type: string
+          description: App cluster name
+        appClusterProvisioner:
+          type: string
+          description: App cluster provisioner
+        appClusterAddresses:
+          type: array
+          description: App cluster addresses
+          items:
+            type: string
+        user:
+          type: string
+          description: User email or name
+        eventID:
+          type: string
+          description: Tsuru event identifier
+        parameters:
+          type: object
+          description: Arbitrary bind parameter bag as a nested JSON object.
+          additionalProperties: true
+      required:
+      - appName
+
+    JobBindRequestJSON:
+      type: object
+      description: JSON job bind request. Sent when the service encoding is `json`.
+      properties:
+        jobName:
+          type: string
+          description: Job name
+        jobPoolName:
+          type: string
+          description: Job pool name
+        jobClusterName:
+          type: string
+          description: Job cluster name
+        user:
+          type: string
+          description: User email or name
+        eventID:
+          type: string
+          description: Tsuru event identifier
+      required:
+      - jobName
+
+    # ──────────────────────────────────────────────
+    # Shared schemas
+    # ──────────────────────────────────────────────
 
     EnvVars:
       type: object

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cezarsa/form"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tsuru/config"
@@ -68,32 +68,29 @@ type endpointClient struct {
 	endpoint    string
 	username    string
 	password    string
+	encoding    ServiceEncoding
 }
 
 func (c *endpointClient) Create(ctx context.Context, instance *ServiceInstance, evt *event.Event, requestID string) error {
 	var err error
 	var resp *http.Response
-	params := map[string][]string{
-		"name":    {instance.Name},
-		"team":    {instance.TeamOwner},
-		"user":    {evt.OwnerEmail()},
-		"eventid": {evt.UniqueID.Hex()},
-		"tags":    instance.Tags,
+	payload := &createServicePayload{
+		Name:        instance.Name,
+		Team:        instance.TeamOwner,
+		Description: instance.Description,
+		Plan:        instance.PlanName,
+		Tags:        instance.Tags,
+		EventID:     evt.UniqueID.Hex(),
+		User:        evt.OwnerEmail(),
+		Parameters:  instance.Parameters,
 	}
 
-	if instance.PlanName != "" {
-		params["plan"] = []string{instance.PlanName}
-	}
-	if instance.Description != "" {
-		params["description"] = []string{instance.Description}
-	}
-	addParameters(params, instance.Parameters)
-	log.Debugf("Attempting to call creation of service instance for %q, params: %#v", instance.ServiceName, params)
+	log.Debugf("Attempting to call creation of service instance for %q, params: %#v", instance.ServiceName, payload.Form())
 	header, err := baseHeader(ctx, evt, instance, requestID)
 	if err != nil {
 		return err
 	}
-	resp, err = c.issueRequest(ctx, "/resources", "POST", params, header)
+	resp, err = c.issueRequest(ctx, "/resources", "POST", payload, header)
 	if err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode < 300 {
@@ -109,21 +106,21 @@ func (c *endpointClient) Create(ctx context.Context, instance *ServiceInstance, 
 
 func (c *endpointClient) Update(ctx context.Context, instance *ServiceInstance, evt *event.Event, requestID string) error {
 	log.Debugf("Attempting to call update of service instance %q at %q api", instance.Name, instance.ServiceName)
-	params := map[string][]string{
-		"description": {instance.Description},
-		"team":        {instance.TeamOwner},
-		"tags":        instance.Tags,
-		"plan":        {instance.PlanName},
-		"user":        {evt.OwnerEmail()},
-		"eventid":     {evt.UniqueID.Hex()},
+	payload := &updateServicePayload{
+		Description: instance.Description,
+		Team:        instance.TeamOwner,
+		Tags:        instance.Tags,
+		Plan:        instance.PlanName,
+		User:        evt.OwnerEmail(),
+		EventID:     evt.UniqueID.Hex(),
+		Parameters:  instance.Parameters,
 	}
 
-	addParameters(params, instance.Parameters)
 	header, err := baseHeader(ctx, evt, instance, requestID)
 	if err != nil {
 		return err
 	}
-	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier(), "PUT", params, header)
+	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier(), "PUT", payload, header)
 	if err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode > 299 {
@@ -139,16 +136,16 @@ func (c *endpointClient) Update(ctx context.Context, instance *ServiceInstance, 
 
 func (c *endpointClient) Destroy(ctx context.Context, instance *ServiceInstance, evt *event.Event, requestID string) error {
 	log.Debugf("Attempting to call destroy of service instance %q at %q api", instance.Name, instance.ServiceName)
-	params := map[string][]string{
-		"user":    {evt.OwnerEmail()},
-		"eventid": {evt.UniqueID.Hex()},
+	payload := &destroyServicePayload{
+		User:    evt.OwnerEmail(),
+		EventID: evt.UniqueID.Hex(),
 	}
 
 	header, err := baseHeader(ctx, evt, instance, requestID)
 	if err != nil {
 		return err
 	}
-	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier(), "DELETE", params, header)
+	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier(), "DELETE", payload, header)
 	if err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode > 299 {
@@ -165,7 +162,7 @@ func (c *endpointClient) Destroy(ctx context.Context, instance *ServiceInstance,
 func (c *endpointClient) BindApp(ctx context.Context, instance *ServiceInstance, app *appTypes.App, bindParams BindAppParameters, evt *event.Event, requestID string) (map[string]string, error) {
 	log.Debugf("Calling bind of instance %q and %q app at %q API",
 		instance.Name, app.Name, instance.ServiceName)
-	params, err := buildBindAppParams(ctx, evt, app, bindParams)
+	payload, err := buildBindAppPayload(ctx, evt, app, bindParams)
 	if err != nil {
 		log.Errorf("Ignoring some errors found while building the bind app parameters: %v", err)
 		return nil, err
@@ -174,13 +171,13 @@ func (c *endpointClient) BindApp(ctx context.Context, instance *ServiceInstance,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/bind-app", "POST", params, header)
+	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/bind-app", "POST", payload, header)
 	if err != nil {
 		return nil, log.WrapError(errors.Wrapf(err, `Failed to bind app %q to service instance "%s/%s"`, app.Name, instance.ServiceName, instance.Name))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		resp, err = c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/bind", "POST", params, header)
+		resp, err = c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/bind", "POST", payload, header)
 	}
 	if err != nil {
 		return nil, log.WrapError(errors.Wrapf(err, `Failed to bind app %q to service instance "%s/%s"`, app.Name, instance.ServiceName, instance.Name))
@@ -251,21 +248,18 @@ func (c *endpointClient) UnbindApp(ctx context.Context, instance *ServiceInstanc
 		return err
 	}
 	url := "/resources/" + instance.GetIdentifier() + "/bind-app"
-	params := map[string][]string{
-		"app-hosts": appAddrs,
-		"app-name":  {app.Name},
-		"user":      {evt.OwnerEmail()},
-		"eventid":   {evt.UniqueID.Hex()},
+	payload := &unbindAppPayload{
+		AppHosts: appAddrs,
+		AppName:  app.Name,
+		User:     evt.OwnerEmail(),
+		EventID:  evt.UniqueID.Hex(),
 	}
 
-	if len(appAddrs) > 0 {
-		params["app-host"] = []string{appAddrs[0]}
-	}
 	header, err := baseHeader(ctx, evt, instance, requestID)
 	if err != nil {
 		return err
 	}
-	resp, err := c.issueRequest(ctx, url, "DELETE", params, header)
+	resp, err := c.issueRequest(ctx, url, "DELETE", payload, header)
 	if err == nil {
 		defer resp.Body.Close()
 		if resp.StatusCode > 299 {
@@ -464,16 +458,24 @@ func (c *endpointClient) buildErrorMessage(err error, resp *http.Response) error
 	return nil
 }
 
-func (c *endpointClient) issueRequest(ctx context.Context, path, method string, params map[string][]string, header http.Header) (*http.Response, error) {
+func (c *endpointClient) issueRequest(ctx context.Context, path, method string, payload Payload, header http.Header) (*http.Response, error) {
 	var suffix string
 	var body io.Reader = nil
 
-	if params != nil {
-		v := url.Values(params)
-
+	if payload != nil {
 		if method == "GET" {
+			v := payload.Form()
 			suffix = "?" + v.Encode()
-		} else {
+		} else if c.encoding == ServiceEncodingJSON {
+			var buf bytes.Buffer
+			body = &buf
+			err := json.NewEncoder(&buf).Encode(payload)
+			if err != nil {
+				log.Errorf("Got error while encoding service json: %s", err)
+				return nil, err
+			}
+		} else if c.encoding == ServiceEncodingForm || c.encoding == ServiceEncodingDefault {
+			v := payload.Form()
 			body = strings.NewReader(v.Encode())
 		}
 	}
@@ -512,19 +514,6 @@ func (c *endpointClient) jsonFromResponse(resp *http.Response, v interface{}) er
 	return nil
 }
 
-func addParameters(dst url.Values, params map[string]interface{}) {
-	if params == nil || dst == nil {
-		return
-	}
-	encoded, err := form.EncodeToValues(params)
-	if err != nil {
-		errors.Wrapf(err, "unable to encode parameters")
-	}
-	for key, value := range encoded {
-		dst["parameters."+key] = value
-	}
-}
-
 func baseHeader(ctx context.Context, evt *event.Event, si *ServiceInstance, requestID string) (http.Header, error) {
 	header := make(http.Header)
 	if evt != nil {
@@ -543,84 +532,84 @@ func baseHeader(ctx context.Context, evt *event.Event, si *ServiceInstance, requ
 	return poolMultiCluster.Header(ctx, si.Pool, header)
 }
 
-func buildBindAppParams(ctx context.Context, evt *event.Event, app *appTypes.App, bindParams BindAppParameters) (url.Values, error) {
+func buildBindAppPayload(ctx context.Context, evt *event.Event, app *appTypes.App, bindParams BindAppParameters) (*bindAppPayload, error) {
 	if app == nil {
 		return nil, errors.New("app cannot be nil")
 	}
-	params := url.Values{}
-	addParameters(params, bindParams)
-	params.Set("app-name", app.Name)
+	payload := &bindAppPayload{
+		AppName:    app.Name,
+		Parameters: bindParams,
+	}
+
 	if evt != nil {
-		params.Set("user", evt.OwnerEmail())
-		params.Set("eventid", evt.UniqueID.Hex())
+		payload.User = evt.OwnerEmail()
+		payload.EventID = evt.UniqueID.Hex()
 	}
 	appAddrs, err := servicemanager.App.GetAddresses(ctx, app)
 	if err != nil {
 		return nil, err
 	}
-	params["app-hosts"] = appAddrs
-	if len(appAddrs) > 0 {
-		params.Set("app-host", appAddrs[0])
-	}
+	payload.AppHosts = appAddrs
+
 	internalAddrs, err := servicemanager.App.GetInternalBindableAddresses(ctx, app)
 	if err != nil {
 		return nil, err
 	}
-	params["app-internal-hosts"] = internalAddrs
+	payload.AppInternalHosts = internalAddrs
 
 	p, err := servicemanager.Pool.FindByName(ctx, app.Pool)
 	if err != nil {
 		if err == provTypes.ErrPoolNotFound {
-			return params, nil
+			return payload, nil
 		}
 		return nil, err
 	}
 	if p == nil {
-		return params, nil
+		return payload, nil
 	}
-	params.Set("app-pool-name", p.Name)
-	params.Set("app-pool-provisioner", p.Provisioner)
+	payload.AppPoolName = p.Name
+	payload.AppPoolProvisioner = p.Provisioner
 	c, err := servicemanager.Cluster.FindByPool(ctx, p.Provisioner, p.Name)
 	if err != nil || c == nil {
-		return params, nil
+		return payload, nil
 	}
-	params.Set("app-cluster-name", c.Name)
-	params.Set("app-cluster-provisioner", c.Provisioner)
-	for _, addr := range c.Addresses {
-		params.Add("app-cluster-addresses", addr)
-	}
-	return params, nil
+	payload.AppClusterName = c.Name
+	payload.AppClusterProvisioner = c.Provisioner
+	payload.AppClusterAddresses = c.Addresses
+	return payload, nil
 }
 
-func buildBindJobParams(ctx context.Context, evt *event.Event, job *jobTypes.Job) (url.Values, error) {
+func buildBindJobParams(ctx context.Context, evt *event.Event, job *jobTypes.Job) (*bindJobPayload, error) {
 	if job == nil {
 		return nil, errors.New("job cannot be nil")
 	}
 
-	params := url.Values{}
-	params.Set("job-name", job.Name)
+	payload := &bindJobPayload{
+		JobName: job.Name,
+	}
+
 	if evt != nil {
-		params.Set("user", evt.OwnerEmail())
-		params.Set("eventid", evt.UniqueID.Hex())
+		payload.User = evt.OwnerEmail()
+		payload.EventID = evt.UniqueID.Hex()
 	}
 
 	p, err := servicemanager.Pool.FindByName(ctx, job.Pool)
 	if err != nil {
 		if err == provTypes.ErrPoolNotFound {
-			return params, nil
+			return payload, nil
 		}
 		return nil, err
 	}
 	if p == nil {
-		return params, nil
+		return payload, nil
 	}
-	params.Set("job-pool-name", p.Name)
+	payload.JobPoolName = p.Name
 
 	c, err := servicemanager.Cluster.FindByPool(ctx, p.Provisioner, p.Name)
 	if err != nil || c == nil {
-		return params, nil
+		return payload, nil
 	}
-	params.Set("job-cluster-name", c.Name)
+	payload.JobClusterName = c.Name
 
-	return params, nil
+	return payload, nil
 }

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -205,7 +205,7 @@ func (c *endpointClient) BindJob(ctx context.Context, instance *ServiceInstance,
 	log.Debugf("Calling bind of instance %q and %q job at %q API",
 		instance.Name, job.Name, instance.ServiceName)
 
-	params, err := buildBindJobParams(ctx, evt, job)
+	payload, err := buildBindJobParams(ctx, evt, job)
 	if err != nil {
 		log.Errorf("Errors found while building the bind job parameters: %v", err)
 		return nil, err
@@ -215,7 +215,7 @@ func (c *endpointClient) BindJob(ctx context.Context, instance *ServiceInstance,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/binds/jobs/"+job.Name, http.MethodPut, params, header)
+	resp, err := c.issueRequest(ctx, "/resources/"+instance.GetIdentifier()+"/binds/jobs/"+job.Name, http.MethodPut, payload, header)
 	if err != nil {
 		return nil, log.WrapError(errors.Wrapf(err, `Failed to bind job %q to service instance "%s/%s"`, job.Name, instance.ServiceName, instance.Name))
 	}
@@ -277,13 +277,17 @@ func (c *endpointClient) UnbindJob(ctx context.Context, instance *ServiceInstanc
 	log.Debugf("Calling unbind of service instance %q and job %q at %q", instance.Name, job.Name, instance.ServiceName)
 
 	url := "/resources/" + instance.GetIdentifier() + "/binds/jobs/" + job.Name
+	payload := &unbindJobPayload{
+		User:    evt.OwnerEmail(),
+		EventID: evt.UniqueID.Hex(),
+	}
 
 	header, err := baseHeader(ctx, evt, instance, requestID)
 	if err != nil {
 		return err
 	}
 
-	resp, err := c.issueRequest(ctx, url, http.MethodDelete, nil, header)
+	resp, err := c.issueRequest(ctx, url, http.MethodDelete, payload, header)
 	if err != nil {
 		return err
 	}
@@ -492,7 +496,11 @@ func (c *endpointClient) issueRequest(ctx context.Context, path, method string, 
 	req.Header = header
 	req.Header.Set("Accept", "application/json")
 	if method != "GET" && method != "HEAD" && method != "OPTIONS" {
-		header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if c.encoding == ServiceEncodingJSON {
+			header.Set("Content-Type", "application/json")
+		} else {
+			header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
 	}
 	req.SetBasicAuth(c.username, c.password)
 	req.Close = true

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -7,6 +7,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -147,6 +148,227 @@ func (s *S) TestEndpointCreate(c *check.C) {
 	c.Assert("application/json", check.Equals, h.request.Header.Get("Accept"))
 	c.Assert("Basic dXNlcjphYmNkZQ==", check.Equals, h.request.Header.Get("Authorization"))
 	c.Assert("close", check.Equals, h.request.Header.Get("Connection"))
+}
+
+func (s *S) TestEndpointCreateJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	instance := ServiceInstance{
+		Name:        "my-redis",
+		ServiceName: "redis",
+		TeamOwner:   "theteam",
+		Description: "xyz",
+		Tags:        []string{"tag 1", "tag 2"},
+		Parameters: map[string]interface{}{
+			"p1": "v1",
+			"p2": map[string]interface{}{
+				"complex1": "complexvalue1",
+			},
+		},
+	}
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	err := client.Create(context.TODO(), &instance, evt, "")
+	c.Assert(err, check.IsNil)
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(h.url, check.Equals, "/resources")
+	c.Assert(h.method, check.Equals, http.MethodPost)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	c.Assert(h.request.Header.Get("Accept"), check.Equals, "application/json")
+	var result createServicePayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.Name, check.Equals, "my-redis")
+	c.Assert(result.Team, check.Equals, "theteam")
+	c.Assert(result.Description, check.Equals, "xyz")
+	c.Assert(result.Tags, check.DeepEquals, []string{"tag 1", "tag 2"})
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
+	c.Assert(result.Parameters, check.DeepEquals, map[string]any{
+		"p1": "v1",
+		"p2": map[string]any{
+			"complex1": "complexvalue1",
+		},
+	})
+}
+
+func (s *S) TestEndpointUpdateJSON(c *check.C) {
+	var requests int32
+	instance := ServiceInstance{
+		Name:        "his-redis",
+		ServiceName: "redis",
+		TeamOwner:   "team-owner",
+		Description: "my service",
+		Tags:        []string{"tag1", "tag2"},
+		PlanName:    "small",
+		Parameters: map[string]interface{}{
+			"p1": "v1",
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		c.Check(r.Method, check.Equals, http.MethodPut)
+		c.Check(r.URL.Path, check.Equals, "/resources/"+instance.Name)
+		c.Check(r.Header.Get("Content-Type"), check.Equals, "application/json")
+		var result updateServicePayload
+		err := json.NewDecoder(r.Body).Decode(&result)
+		c.Assert(err, check.IsNil)
+		c.Check(result.Description, check.Equals, instance.Description)
+		c.Check(result.Team, check.Equals, instance.TeamOwner)
+		c.Check(result.Plan, check.Equals, instance.PlanName)
+		c.Check(result.Tags, check.DeepEquals, instance.Tags)
+		c.Check(result.Parameters, check.DeepEquals, map[string]any{"p1": "v1"})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	err := client.Update(context.TODO(), &instance, evt, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
+}
+
+func (s *S) TestEndpointDestroyJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	instance := ServiceInstance{Name: "his-redis", ServiceName: "redis"}
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	err := client.Destroy(context.TODO(), &instance, evt, "")
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Assert(h.url, check.Equals, "/resources/"+instance.Name)
+	c.Assert(h.method, check.Equals, http.MethodDelete)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	var result destroyServicePayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
+}
+
+func (s *S) TestEndpointBindAppJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	s.mockService.Pool.OnFindByName = func(name string) (*provTypes.Pool, error) {
+		return &provTypes.Pool{Name: "her-pool", Provisioner: "kubernetes"}, nil
+	}
+	s.mockService.Cluster.OnFindByPool = func(provisioner, pool string) (*provTypes.Cluster, error) {
+		return &provTypes.Cluster{
+			Name:        "her-cluster",
+			Provisioner: "kubernetes",
+			Addresses:   []string{"https://kubernetes.example.com"},
+		}, nil
+	}
+	instance := ServiceInstance{Name: "her-redis", ServiceName: "redis"}
+	a := provisiontest.NewFakeAppWithPool("her-app", "python", "her-pool", 1)
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	bindParams := map[string]interface{}{"p1": "v1"}
+	_, err := client.BindApp(context.TODO(), &instance, a, bindParams, evt, "")
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Assert(h.url, check.Equals, "/resources/"+instance.Name+"/bind-app")
+	c.Assert(h.method, check.Equals, http.MethodPost)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	var result bindAppPayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.AppName, check.Equals, "her-app")
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
+	c.Assert(result.AppPoolName, check.Equals, "her-pool")
+	c.Assert(result.AppPoolProvisioner, check.Equals, "kubernetes")
+	c.Assert(result.AppClusterName, check.Equals, "her-cluster")
+	c.Assert(result.AppClusterProvisioner, check.Equals, "kubernetes")
+	c.Assert(result.AppClusterAddresses, check.DeepEquals, []string{"https://kubernetes.example.com"})
+	c.Assert(result.Parameters, check.DeepEquals, map[string]any{"p1": "v1"})
+}
+
+func (s *S) TestEndpointUnbindAppJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	instance := ServiceInstance{Name: "heaven-can-wait", ServiceName: "heaven"}
+	a := provisiontest.NewFakeApp("arch-enemy", "python", 1)
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	err := client.UnbindApp(context.TODO(), &instance, a, evt, "")
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Assert(h.url, check.Equals, "/resources/heaven-can-wait/bind-app")
+	c.Assert(h.method, check.Equals, http.MethodDelete)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	var result unbindAppPayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.AppName, check.Equals, "arch-enemy")
+	c.Assert(result.AppHosts, check.DeepEquals, []string{"arch-enemy.fakerouter.com"})
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
+}
+
+func (s *S) TestEndpointBindJobJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	s.mockService.Pool.OnFindByName = func(name string) (*provTypes.Pool, error) {
+		return &provTypes.Pool{Name: "test-pool", Provisioner: "kubernetes"}, nil
+	}
+	s.mockService.Cluster.OnFindByPool = func(provisioner, pool string) (*provTypes.Cluster, error) {
+		return &provTypes.Cluster{
+			Name:        "test-cluster",
+			Provisioner: "kubernetes",
+		}, nil
+	}
+	instance := ServiceInstance{Name: "job-redis", ServiceName: "redis"}
+	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	_, err := client.BindJob(context.TODO(), &instance, job, evt, "")
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Assert(h.url, check.Equals, "/resources/"+instance.Name+"/binds/jobs/"+job.Name)
+	c.Assert(h.method, check.Equals, http.MethodPut)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	var result bindJobPayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.JobName, check.Equals, "test-job")
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
+	c.Assert(result.JobPoolName, check.Equals, "test-pool")
+	c.Assert(result.JobClusterName, check.Equals, "test-cluster")
+}
+
+func (s *S) TestEndpointUnbindJobJSON(c *check.C) {
+	h := TestHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+	instance := ServiceInstance{Name: "test-redis", ServiceName: "redis"}
+	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
+	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
+	evt := createEvt(c)
+	err := client.UnbindJob(context.TODO(), &instance, job, evt, "")
+	h.Lock()
+	defer h.Unlock()
+	c.Assert(err, check.IsNil)
+	c.Assert(h.url, check.Equals, "/resources/test-redis/binds/jobs/test-job")
+	c.Assert(h.method, check.Equals, http.MethodDelete)
+	c.Assert(h.request.Header.Get("Content-Type"), check.Equals, "application/json")
+	var result unbindJobPayload
+	err = json.Unmarshal(h.body, &result)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.User, check.Equals, "my@user")
+	c.Assert(result.EventID, check.Equals, evt.UniqueID.Hex())
 }
 
 func (s *S) TestEndpointCreateEndpointDown(c *check.C) {
@@ -785,7 +1007,13 @@ func (s *S) TestUnbindJob(c *check.C) {
 	c.Assert(h.url, check.Equals, "/resources/test-redis/binds/jobs/test-job")
 	c.Assert(h.method, check.Equals, http.MethodDelete)
 	c.Assert("Basic dXNlcjphYmNkZQ==", check.Equals, h.request.Header.Get("Authorization"))
-	c.Assert(string(h.body), check.Equals, "")
+	v, err := url.ParseQuery(string(h.body))
+	c.Assert(err, check.IsNil)
+	expected := map[string][]string{
+		"user":    {"my@user"},
+		"eventid": {evt.UniqueID.Hex()},
+	}
+	c.Assert(map[string][]string(v), check.DeepEquals, expected)
 }
 
 func (s *S) TestUnbindJobRequestFailure(c *check.C) {

--- a/service/payloads.go
+++ b/service/payloads.go
@@ -1,0 +1,215 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+import (
+	"net/url"
+
+	"github.com/cezarsa/form"
+	"github.com/pkg/errors"
+)
+
+type Payload interface {
+	// Form is used to convert to the legacy well known format
+	Form() url.Values
+}
+
+var (
+	_ Payload = &createServicePayload{}
+	_ Payload = &updateServicePayload{}
+	_ Payload = &destroyServicePayload{}
+	_ Payload = &bindAppPayload{}
+	_ Payload = &unbindAppPayload{}
+	_ Payload = &bindJobPayload{}
+)
+
+type createServicePayload struct {
+	Name        string         `json:"name"`
+	Team        string         `json:"team"`
+	Description string         `json:"description,omitempty"`
+	Plan        string         `json:"plan,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	EventID     string         `json:"eventID"`
+	User        string         `json:"user"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+func (r *createServicePayload) Form() url.Values {
+	params := url.Values{
+		"name":    {r.Name},
+		"team":    {r.Team},
+		"user":    {r.User},
+		"eventid": {r.EventID},
+		"tags":    r.Tags,
+	}
+
+	if r.Plan != "" {
+		params["plan"] = []string{r.Plan}
+	}
+	if r.Description != "" {
+		params["description"] = []string{r.Description}
+	}
+	addParameters(params, r.Parameters)
+
+	return params
+}
+
+type updateServicePayload struct {
+	Description string         `json:"description,omitempty"`
+	Team        string         `json:"team"`
+	Plan        string         `json:"plan,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	EventID     string         `json:"eventID"`
+	User        string         `json:"user"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+func (r *updateServicePayload) Form() url.Values {
+	params := url.Values{
+		"description": {r.Description},
+		"team":        {r.Team},
+		"tags":        r.Tags,
+		"plan":        {r.Plan},
+		"user":        {r.User},
+		"eventid":     {r.EventID},
+	}
+
+	addParameters(params, r.Parameters)
+
+	return params
+}
+
+type destroyServicePayload struct {
+	EventID string `json:"eventID"`
+	User    string `json:"user"`
+}
+
+func (r *destroyServicePayload) Form() url.Values {
+	return url.Values{
+		"user":    {r.User},
+		"eventid": {r.EventID},
+	}
+}
+
+type unbindAppPayload struct {
+	AppHosts []string `json:"appHosts"`
+	AppName  string   `json:"appName"`
+	User     string   `json:"user"`
+	EventID  string   `json:"eventID"`
+}
+
+func (r *unbindAppPayload) Form() url.Values {
+	params := url.Values{
+		"app-hosts": r.AppHosts,
+		"app-name":  {r.AppName},
+		"user":      {r.User},
+		"eventid":   {r.EventID},
+	}
+
+	if len(r.AppHosts) > 0 {
+		params["app-host"] = []string{r.AppHosts[0]}
+	}
+
+	return params
+}
+
+func addParameters(dst url.Values, params map[string]interface{}) {
+	if params == nil || dst == nil {
+		return
+	}
+	encoded, err := form.EncodeToValues(params)
+	if err != nil {
+		errors.Wrapf(err, "unable to encode parameters")
+	}
+	for key, value := range encoded {
+		dst["parameters."+key] = value
+	}
+}
+
+type bindAppPayload struct {
+	AppName               string         `json:"appName"`
+	Parameters            map[string]any `json:"parameters,omitempty"`
+	User                  string         `json:"user,omitempty"`
+	EventID               string         `json:"eventID,omitempty"`
+	AppHosts              []string       `json:"appHosts,omitempty"`
+	AppInternalHosts      []string       `json:"appInternalHosts,omitempty"`
+	AppPoolName           string         `json:"appPoolName,omitempty"`
+	AppPoolProvisioner    string         `json:"appPoolProvisioner,omitempty"`
+	AppClusterName        string         `json:"appClusterName,omitempty"`
+	AppClusterProvisioner string         `json:"appClusterProvisioner,omitempty"`
+	AppClusterAddresses   []string       `json:"appClusterAddresses,omitempty"`
+}
+
+func (r *bindAppPayload) Form() url.Values {
+	params := url.Values{
+		"app-name": {r.AppName},
+	}
+	addParameters(params, r.Parameters)
+
+	if r.User != "" {
+		params.Set("user", r.User)
+	}
+	if r.EventID != "" {
+		params.Set("eventid", r.EventID)
+	}
+
+	params["app-hosts"] = r.AppHosts
+	if len(r.AppHosts) > 0 {
+		params.Set("app-host", r.AppHosts[0])
+	}
+
+	params["app-internal-hosts"] = r.AppInternalHosts
+
+	if r.AppPoolName != "" {
+		params.Set("app-pool-name", r.AppPoolName)
+	}
+
+	if r.AppPoolProvisioner != "" {
+		params.Set("app-pool-provisioner", r.AppPoolProvisioner)
+	}
+	if r.AppClusterName != "" {
+
+		params.Set("app-cluster-name", r.AppClusterName)
+	}
+
+	if r.AppClusterProvisioner != "" {
+		params.Set("app-cluster-provisioner", r.AppClusterProvisioner)
+	}
+	for _, addr := range r.AppClusterAddresses {
+		params.Add("app-cluster-addresses", addr)
+	}
+	return params
+}
+
+type bindJobPayload struct {
+	JobName string `json:"jobName"`
+	User    string `json:"user,omitempty"`
+	EventID string `json:"eventID,omitempty"`
+
+	JobPoolName    string `json:"jobPoolName,omitempty"`
+	JobClusterName string `json:"jobClusterName,omitempty"`
+}
+
+func (r *bindJobPayload) Form() url.Values {
+	params := url.Values{
+		"job-name": {r.JobName},
+	}
+
+	if r.User != "" {
+		params.Set("user", r.User)
+	}
+
+	if r.EventID != "" {
+		params.Set("eventid", r.EventID)
+	}
+
+	if r.JobPoolName != "" {
+		params.Set("job-pool-name", r.JobPoolName)
+	}
+	if r.JobClusterName != "" {
+		params.Set("job-cluster-name", r.JobClusterName)
+	}
+	return params
+}

--- a/service/payloads.go
+++ b/service/payloads.go
@@ -23,6 +23,7 @@ var (
 	_ Payload = &bindAppPayload{}
 	_ Payload = &unbindAppPayload{}
 	_ Payload = &bindJobPayload{}
+	_ Payload = &unbindJobPayload{}
 )
 
 type createServicePayload struct {
@@ -190,6 +191,18 @@ type bindJobPayload struct {
 
 	JobPoolName    string `json:"jobPoolName,omitempty"`
 	JobClusterName string `json:"jobClusterName,omitempty"`
+}
+
+type unbindJobPayload struct {
+	User    string `json:"user"`
+	EventID string `json:"eventID"`
+}
+
+func (r *unbindJobPayload) Form() url.Values {
+	return url.Values{
+		"user":    {r.User},
+		"eventid": {r.EventID},
+	}
 }
 
 func (r *bindJobPayload) Form() url.Values {

--- a/service/payloads_test.go
+++ b/service/payloads_test.go
@@ -1,12 +1,13 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormEncode(t *testing.T) {
+func TestCreateServicePayloadForm(t *testing.T) {
 	tests := []struct {
 		name     string
 		req      createServicePayload
@@ -68,4 +69,195 @@ func TestFormEncode(t *testing.T) {
 			assert.Equal(t, tt.expected, values.Encode())
 		})
 	}
+}
+
+func TestUpdateServicePayloadForm(t *testing.T) {
+	payload := &updateServicePayload{
+		Description: "updated",
+		Team:        "my-team",
+		Plan:        "large",
+		Tags:        []string{"a", "b"},
+		EventID:     "evt-1",
+		User:        "user",
+		Parameters:  map[string]any{"k": "v"},
+	}
+	v := payload.Form()
+	assert.Equal(t, "updated", v.Get("description"))
+	assert.Equal(t, "my-team", v.Get("team"))
+	assert.Equal(t, "large", v.Get("plan"))
+	assert.Equal(t, []string{"a", "b"}, v["tags"])
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "v", v.Get("parameters.k"))
+}
+
+func TestDestroyServicePayloadForm(t *testing.T) {
+	payload := &destroyServicePayload{
+		User:    "user",
+		EventID: "evt-1",
+	}
+	v := payload.Form()
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+}
+
+func TestUnbindAppPayloadForm(t *testing.T) {
+	payload := &unbindAppPayload{
+		AppHosts: []string{"host1", "host2"},
+		AppName:  "myapp",
+		User:     "user",
+		EventID:  "evt-1",
+	}
+	v := payload.Form()
+	assert.Equal(t, "myapp", v.Get("app-name"))
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+	assert.Equal(t, []string{"host1", "host2"}, v["app-hosts"])
+	assert.Equal(t, "host1", v.Get("app-host"))
+}
+
+func TestUnbindAppPayloadFormNoHosts(t *testing.T) {
+	payload := &unbindAppPayload{
+		AppName: "myapp",
+		User:    "user",
+		EventID: "evt-1",
+	}
+	v := payload.Form()
+	_, hasAppHost := v["app-host"]
+	assert.False(t, hasAppHost)
+}
+
+func TestBindAppPayloadForm(t *testing.T) {
+	payload := &bindAppPayload{
+		AppName:               "myapp",
+		Parameters:            map[string]any{"k": "v"},
+		User:                  "user",
+		EventID:               "evt-1",
+		AppHosts:              []string{"host1"},
+		AppInternalHosts:      []string{"internal1"},
+		AppPoolName:           "pool1",
+		AppPoolProvisioner:    "kubernetes",
+		AppClusterName:        "cluster1",
+		AppClusterProvisioner: "kubernetes",
+		AppClusterAddresses:   []string{"addr1", "addr2"},
+	}
+	v := payload.Form()
+	assert.Equal(t, "myapp", v.Get("app-name"))
+	assert.Equal(t, "v", v.Get("parameters.k"))
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+	assert.Equal(t, []string{"host1"}, v["app-hosts"])
+	assert.Equal(t, "host1", v.Get("app-host"))
+	assert.Equal(t, []string{"internal1"}, v["app-internal-hosts"])
+	assert.Equal(t, "pool1", v.Get("app-pool-name"))
+	assert.Equal(t, "kubernetes", v.Get("app-pool-provisioner"))
+	assert.Equal(t, "cluster1", v.Get("app-cluster-name"))
+	assert.Equal(t, "kubernetes", v.Get("app-cluster-provisioner"))
+	assert.Equal(t, []string{"addr1", "addr2"}, v["app-cluster-addresses"])
+}
+
+func TestBindJobPayloadForm(t *testing.T) {
+	payload := &bindJobPayload{
+		JobName:        "myjob",
+		User:           "user",
+		EventID:        "evt-1",
+		JobPoolName:    "pool1",
+		JobClusterName: "cluster1",
+	}
+	v := payload.Form()
+	assert.Equal(t, "myjob", v.Get("job-name"))
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+	assert.Equal(t, "pool1", v.Get("job-pool-name"))
+	assert.Equal(t, "cluster1", v.Get("job-cluster-name"))
+}
+
+func TestUnbindJobPayloadForm(t *testing.T) {
+	payload := &unbindJobPayload{
+		User:    "user",
+		EventID: "evt-1",
+	}
+	v := payload.Form()
+	assert.Equal(t, "user", v.Get("user"))
+	assert.Equal(t, "evt-1", v.Get("eventid"))
+}
+
+func TestCreateServicePayloadJSON(t *testing.T) {
+	payload := &createServicePayload{
+		Name:        "my-service",
+		Team:        "my-team",
+		Description: "a service",
+		Plan:        "small",
+		Tags:        []string{"foo", "bar"},
+		EventID:     "event-1",
+		User:        "user@example.com",
+		Parameters:  map[string]any{"key": "value"},
+	}
+	data, err := json.Marshal(payload)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-service", result["name"])
+	assert.Equal(t, "my-team", result["team"])
+	assert.Equal(t, "a service", result["description"])
+	assert.Equal(t, "small", result["plan"])
+	assert.Equal(t, []any{"foo", "bar"}, result["tags"])
+	assert.Equal(t, "event-1", result["eventID"])
+	assert.Equal(t, "user@example.com", result["user"])
+	assert.Equal(t, map[string]any{"key": "value"}, result["parameters"])
+}
+
+func TestCreateServicePayloadJSONOmitsEmpty(t *testing.T) {
+	payload := &createServicePayload{
+		Name:    "my-service",
+		Team:    "my-team",
+		EventID: "event-1",
+		User:    "user",
+	}
+	data, err := json.Marshal(payload)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	_, hasDescription := result["description"]
+	_, hasPlan := result["plan"]
+	_, hasTags := result["tags"]
+	_, hasParameters := result["parameters"]
+	assert.False(t, hasDescription)
+	assert.False(t, hasPlan)
+	assert.False(t, hasTags)
+	assert.False(t, hasParameters)
+}
+
+func TestBindAppPayloadJSON(t *testing.T) {
+	payload := &bindAppPayload{
+		AppName:               "myapp",
+		Parameters:            map[string]any{"p1": "v1"},
+		User:                  "user",
+		EventID:               "evt-1",
+		AppHosts:              []string{"host1"},
+		AppInternalHosts:      []string{"internal1"},
+		AppPoolName:           "pool1",
+		AppPoolProvisioner:    "kubernetes",
+		AppClusterName:        "cluster1",
+		AppClusterProvisioner: "kubernetes",
+		AppClusterAddresses:   []string{"addr1"},
+	}
+	data, err := json.Marshal(payload)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "myapp", result["appName"])
+	assert.Equal(t, map[string]any{"p1": "v1"}, result["parameters"])
+	assert.Equal(t, "user", result["user"])
+	assert.Equal(t, "evt-1", result["eventID"])
+	assert.Equal(t, "pool1", result["appPoolName"])
+	assert.Equal(t, "kubernetes", result["appPoolProvisioner"])
+	assert.Equal(t, "cluster1", result["appClusterName"])
+	assert.Equal(t, "kubernetes", result["appClusterProvisioner"])
 }

--- a/service/payloads_test.go
+++ b/service/payloads_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormEncode(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      createServicePayload
+		expected string
+	}{
+		{
+			name:     "empty request",
+			req:      createServicePayload{},
+			expected: "eventid=&name=&team=&user=",
+		},
+		{
+			name: "required fields only",
+			req: createServicePayload{
+				Name:    "my-service",
+				Team:    "my-team",
+				EventID: "event-1",
+				User:    "user@example.com",
+			},
+			expected: "eventid=event-1&name=my-service&team=my-team&user=user%40example.com",
+		},
+		{
+			name: "with description and plan",
+			req: createServicePayload{
+				Name:        "my-service",
+				Team:        "my-team",
+				Description: "a service",
+				Plan:        "small",
+				EventID:     "event-1",
+				User:        "user",
+			},
+			expected: "description=a+service&eventid=event-1&name=my-service&plan=small&team=my-team&user=user",
+		},
+		{
+			name: "with tags",
+			req: createServicePayload{
+				Name:    "my-service",
+				Team:    "my-team",
+				Tags:    []string{"foo", "bar"},
+				EventID: "event-1",
+				User:    "user",
+			},
+			expected: "eventid=event-1&name=my-service&tags=foo&tags=bar&team=my-team&user=user",
+		},
+		{
+			name: "with parameters",
+			req: createServicePayload{
+				Name:       "my-service",
+				Team:       "my-team",
+				Parameters: map[string]any{"key": "value"},
+				EventID:    "event-1",
+				User:       "user",
+			},
+			expected: "eventid=event-1&name=my-service&parameters.key=value&team=my-team&user=user",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := tt.req.Form()
+			assert.Equal(t, tt.expected, values.Encode())
+		})
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -24,6 +24,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+type ServiceEncoding string
+
+var (
+	ServiceEncodingDefault = ServiceEncoding("") // default is form
+	ServiceEncodingForm    = ServiceEncoding("form")
+	ServiceEncodingJSON    = ServiceEncoding("json")
+)
+
 type Service struct {
 	Name         string `bson:"_id"`
 	Username     string
@@ -39,6 +47,10 @@ type Service struct {
 	//
 	// This field is immutable (after creating Service).
 	IsMultiCluster bool `bson:"is_multi_cluster"`
+
+	// Encoding defines how modern is the backend
+	// Tsuru started with a form encoding, but some services may support a more modern JSON encoding.
+	Encoding ServiceEncoding `bson:"encoding"`
 }
 
 type BindAppParameters map[string]interface{}
@@ -325,7 +337,13 @@ func (s *Service) getClient(endpoints ...string) (ServiceClient, error) {
 			if p := schemeRegexp.MatchString(e); !p {
 				e = "http://" + e
 			}
-			cli := &endpointClient{serviceName: s.Name, endpoint: e, username: s.getUsername(), password: s.Password}
+			cli := &endpointClient{
+				serviceName: s.Name,
+				endpoint:    e,
+				username:    s.getUsername(),
+				password:    s.Password,
+				encoding:    s.Encoding,
+			}
 			return cli, nil
 		} else {
 			err = errors.New("Unknown endpoint: " + endpoint)


### PR DESCRIPTION
Nowadays encoding with json is the default for major API frameworks. Allowing to encode as JSON is a path of modernization of Service API.