### PR TITLE
service: drop unused numeric Id field from ServiceInstance

### DIFF
--- a/docs/reference/api.yaml
+++ b/docs/reference/api.yaml
@@ -5029,8 +5029,6 @@ definitions:
   ServiceInfo:
     type: object
     properties:
-      id:
-        type: string
       name:
         type: string
       pool:

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -51,7 +50,6 @@ var (
 
 type ServiceInstance struct {
 	Name        string                 `json:"name"`
-	Id          int                    `json:"id"`
 	ServiceName string                 `bson:"service_name" json:"service_name"`
 	PlanName    string                 `bson:"plan_name" json:"plan_name"`
 	Apps        []string               `json:"apps"`
@@ -103,14 +101,10 @@ func DeleteInstance(ctx context.Context, si *ServiceInstance, evt *event.Event, 
 }
 
 func (si *ServiceInstance) GetIdentifier() string {
-	if si.Id != 0 {
-		return strconv.Itoa(si.Id)
-	}
 	return si.Name
 }
 
 type ServiceInstanceWithInfo struct {
-	Id          int
 	Name        string
 	Pool        string
 	Teams       []string
@@ -130,7 +124,6 @@ func (si *ServiceInstance) ToInfo(ctx context.Context) (ServiceInstanceWithInfo,
 		info = nil
 	}
 	return ServiceInstanceWithInfo{
-		Id:          si.Id,
 		Name:        si.Name,
 		Pool:        si.Pool,
 		Teams:       si.Teams,

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1356,9 +1355,6 @@ func (s *InstanceSuite) TestGetIdentfier(c *check.C) {
 	srv := ServiceInstance{Name: "mongodb"}
 	identifier := srv.GetIdentifier()
 	c.Assert(identifier, check.Equals, srv.Name)
-	srv.Id = 10
-	identifier = srv.GetIdentifier()
-	c.Assert(identifier, check.Equals, strconv.Itoa(srv.Id))
 }
 
 func (s *InstanceSuite) TestGrantTeamToInstance(c *check.C) {

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -648,7 +648,6 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSON(c *check.C) {
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	expected := map[string]interface{}{
-		"Id":          float64(0),
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,
@@ -677,7 +676,6 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSONWithoutInfo(c *check.C
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	expected := map[string]interface{}{
-		"Id":          float64(0),
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,
@@ -706,7 +704,6 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSONWithoutEndpoint(c *che
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	expected := map[string]interface{}{
-		"Id":          float64(0),
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -493,7 +493,6 @@ func (s *S) TestServiceModelMarshalJSON(c *check.C) {
 			"name":         "my instance",
 			"tags":         []interface{}{"my tag"},
 			"team_owner":   "t1",
-			"id":           float64(0),
 			"teams":        []interface{}{"t1", "t2"},
 			"apps":         []interface{}{"app1", "app2"},
 			"jobs":         []interface{}{"job1"},


### PR DESCRIPTION
The Id field was a legacy integer identifier that was superseded by the Name field. GetIdentifier() already fell through to Name in the common case; removing Id eliminates the fallback branch entirely and keeps the struct leaner. API schema and tests updated accordingly.