### PR TITLE
app: allow leading underscore for environment variable names

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -104,6 +104,7 @@ Mayza Oliveira <mayza.deoliveira@gmail.com>
 Michael <hfeeki@gmail.com>
 Mori Reo <reoring@craftsman-software.com>
 Nelson Marcos <nelsonmarcos@gmail.com>
+Nivaldo Melo <nivaldogmelo@tuta.com> <nivaldogmelo@gmail.com>
 Pablo Aguiar <scorphus@gmail.com>
 Paulo Alem <paulo.alem@corp.globo.com>
 Paulo Sousa <paulo.sousa@corp.globo.com> <psousa@morpheu.org>

--- a/app/app.go
+++ b/app/app.go
@@ -83,7 +83,7 @@ var (
 		Name: "tsuru_node_status_not_found",
 		Help: "The number of not found nodes received in tsuru node status.",
 	})
-	envVarNameRegexp = regexp.MustCompile("^[a-zA-Z][-_a-zA-Z0-9]*$")
+	envVarNameRegexp = regexp.MustCompile("^[_a-zA-Z][-_a-zA-Z0-9]*$")
 )
 
 func init() {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1219,7 +1219,7 @@ func (s *S) TestSetEnvsValidation(c *check.C) {
 		{"lowcase", true},
 		{"ENV-WITH-DASHES", true},
 		{"-NO_LEADING_DASH", false},
-		{"_NO_LEADING_UNDERSCORE", false},
+		{"_LEADING_UNDERSCORE", true},
 		{"ENV.WITH.DOTS", false},
 		{"ENV VAR WITH SPACES", false},
 		{"0NO_LEADING_NUMBER", false},


### PR DESCRIPTION
There are some application tooling that can be configured through environment variables, in vite specific these variables need to have a leading underscore (Ex: https://vite.dev/config/server-options#server-allowedhosts). In order to allow those configurations in tsuru apps, the validation regex will allow the leading '_'. Tests updated accordingly.