### PR TITLE
fix(log): don't log expected conditions as errors

### DIFF
--- a/app/image/platform.go
+++ b/app/image/platform.go
@@ -55,7 +55,7 @@ func (s *platformImageService) NewImage(ctx context.Context, reg imageTypes.Imag
 func (s *platformImageService) CurrentImage(ctx context.Context, reg imageTypes.ImageRegistry, platformName string) (string, error) {
 	img, err := s.storage.FindByName(ctx, platformName)
 	if err != nil {
-		log.Errorf("Couldn't find images for platform %q, fallback to default image name. Error: %s", platformName, err)
+		log.Debugf("Couldn't find images for platform %q, fallback to default image name. Error: %s", platformName, err)
 		imageNew, err := platformBasicImageName(reg, platformName)
 		if err != nil {
 			return "", err

--- a/app/image/platform_test.go
+++ b/app/image/platform_test.go
@@ -5,9 +5,12 @@
 package image
 
 import (
+	"bytes"
 	"context"
+	"strings"
 
 	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/log"
 	imageTypes "github.com/tsuru/tsuru/types/app/image"
 	check "gopkg.in/check.v1"
 )
@@ -317,4 +320,22 @@ func (s *S) TestPlatformFindImage(c *check.C) {
 	image, err = service.FindImage(context.TODO(), "", platformName, imageName)
 	c.Assert(err, check.NotNil)
 	c.Assert(image, check.Equals, "")
+}
+
+func (s *S) TestPlatformCurrentImageNotFoundLogsDebugNotError(c *check.C) {
+	var buf bytes.Buffer
+	log.SetLogger(log.NewWriterLogger(&buf, true))
+	defer log.SetLogger(nil)
+	service := &platformImageService{
+		storage: &imageTypes.MockPlatformImageStorage{
+			OnFindByName: func(n string) (*imageTypes.PlatformImage, error) {
+				return nil, imageTypes.ErrPlatformImageNotFound
+			},
+		},
+	}
+	img, err := service.CurrentImage(context.TODO(), "", "myplatform")
+	c.Assert(err, check.IsNil)
+	c.Assert(img, check.Equals, "tsuru/myplatform:latest")
+	c.Assert(strings.Contains(buf.String(), "ERROR"), check.Equals, false)
+	c.Assert(strings.Contains(buf.String(), "DEBUG"), check.Equals, true)
 }

--- a/provision/kubernetes/monitor.go
+++ b/provision/kubernetes/monitor.go
@@ -138,7 +138,8 @@ func (c *clusterController) isLeader() bool {
 
 func (c *clusterController) startJobInformer() error {
 	if enable, _ := c.cluster.EnableJobEventCreation(); !enable {
-		return errors.New("job event creation is not enabled")
+		log.Debugf("job event creation is not enabled, skipping job informer")
+		return nil
 	}
 	eventsInformer, err := c.getEventInformerWait(false)
 	if err != nil {

--- a/provision/kubernetes/monitor_test.go
+++ b/provision/kubernetes/monitor_test.go
@@ -103,3 +103,12 @@ func (s *S) TestLeaderElectionRenewal(_ *check.C) {
 	require.NotNil(s.t, lease2.Spec.RenewTime)
 	require.True(s.t, lease2.Spec.RenewTime.Time.After(initialRenewTime), "lease should have been renewed")
 }
+
+func (s *S) TestStartJobInformerDisabledIsNotAnError(_ *check.C) {
+	clusterController, err := getClusterController(s.p, s.clusterClient)
+	require.NoError(s.t, err)
+	enabled, err := clusterController.cluster.EnableJobEventCreation()
+	require.NoError(s.t, err)
+	require.False(s.t, enabled, "job event creation should be disabled in the test cluster")
+	require.NoError(s.t, clusterController.startJobInformer())
+}

--- a/provision/servicecommon/actions.go
+++ b/provision/servicecommon/actions.go
@@ -80,7 +80,7 @@ func RunServicePipeline(ctx context.Context, manager ServiceManager, oldVersionN
 		if !appTypes.IsInvalidVersionError(err) {
 			return errors.WithStack(err)
 		}
-		log.Errorf("unable to find version %d for app %q: %v", oldVersionNumber, args.App.Name, err)
+		log.Debugf("unable to find version %d for app %q: %v", oldVersionNumber, args.App.Name, err)
 	}
 	newProcesses, err := args.Version.Processes()
 	if err != nil {

--- a/provision/servicecommon/actions_test.go
+++ b/provision/servicecommon/actions_test.go
@@ -5,9 +5,11 @@
 package servicecommon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -16,6 +18,7 @@ import (
 	"github.com/tsuru/tsuru/app"
 	"github.com/tsuru/tsuru/app/version"
 	"github.com/tsuru/tsuru/db/storagev2"
+	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/provisiontest"
 	"github.com/tsuru/tsuru/servicemanager"
@@ -782,4 +785,24 @@ func (s *S) TestRunServicePipelineUpdateStates(c *check.C) {
 		m.lastLabels = nil
 		m.lastReplicas = nil
 	}
+}
+
+func (s *S) TestRunServicePipelineOldVersionNotFoundLogsDebugNotError(c *check.C) {
+	var buf bytes.Buffer
+	log.SetLogger(log.NewWriterLogger(&buf, true))
+	defer log.SetLogger(nil)
+	m := &recordManager{}
+	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
+	newVersion := newVersion(c, fakeApp, map[string]interface{}{
+		"processes": map[string]interface{}{
+			"web": "python web1",
+		},
+	})
+	err := RunServicePipeline(context.TODO(), m, 0, provision.DeployArgs{
+		App:     fakeApp,
+		Version: newVersion,
+	}, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.Contains(buf.String(), "unable to find version"), check.Equals, true)
+	c.Assert(strings.Contains(buf.String(), "ERROR"), check.Equals, false)
 }


### PR DESCRIPTION
Fixes #2884.

Three conditions that occur on healthy happy paths were logged at ERROR level
(one with a full stack trace). Operators triage ERROR logs; entries that fire
on every healthy deploy or startup train people to ignore them.

- **`provision/kubernetes/monitor.go`** — `startJobInformer` returned an error
  when `job-event-creation` is deliberately disabled in the cluster config,
  and the caller logs it at ERROR with a stack on every cluster controller
  startup. A configured-off feature is not an error: return `nil` (a DEBUG
  line notes the informer is skipped). Real informer startup failures are
  still returned and logged as before.
- **`app/image/platform.go`** — `CurrentImage` logged ERROR before falling
  back to the default image name, which is the designed behavior for every
  container-image (platform `""`) deploy: downgraded to DEBUG.
- **`provision/servicecommon/actions.go`** — `RunServicePipeline` logged ERROR
  for version 0 on every first deploy of an app, where no previous version can
  exist; the code already distinguishes real lookup failures
  (non-`InvalidVersionError` still returns an error): downgraded to DEBUG.

Tests (GoCheck, matching the existing suites): `startJobInformer` returns no
error when the feature is disabled; the other two assert via a captured logger
that the messages are emitted at DEBUG and nothing is logged at ERROR.

All three observed on every app deploy / startup of a healthy 1.30.2
installation.
