### PR TITLE
fix(tsurud): root-user-create under non-UserScheme auth

### DIFF
--- a/cmd/tsurud/testdata/tsuru-oidc.conf
+++ b/cmd/tsurud/testdata/tsuru-oidc.conf
@@ -1,0 +1,18 @@
+listen: "0.0.0.0:8080"
+host: http://tsuru.server:8080/
+use-tls: false
+tls:
+  cert-file: /path/to/cert.pem
+  key-file: /path/to/key.pem
+database:
+  url: 127.0.0.1:27017
+  name: tsuru_tsurud_tests
+auth:
+  scheme: oidc
+  salt: tsuru-salt
+  token-expire-days: 2
+  hash-cost: 4
+  user-registration: true
+quota:
+  units-per-app: 4
+  apps-per-user: 2

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -41,6 +41,7 @@ func (createRootUserCmd) Run(c *cmd.Context) error {
 			return err
 		}
 		fmt.Fprintln(c.Stdout, "Root user successfully updated.")
+		return nil
 	}
 	var confirm, password string
 	if scheme == nativeSchemeName {

--- a/cmd/tsurud/token.go
+++ b/cmd/tsurud/token.go
@@ -69,6 +69,7 @@ func (createRootUserCmd) Run(c *cmd.Context) error {
 			return err
 		}
 	} else {
+		user = &auth.User{Email: email}
 		err = user.Create(ctx)
 		if err != nil {
 			return err

--- a/cmd/tsurud/token_test.go
+++ b/cmd/tsurud/token_test.go
@@ -41,3 +41,25 @@ func (s *S) TestCreateRootUserCmdRun(c *check.C) {
 	c.Assert(perms[0].Scheme, check.Equals, permission.PermUser)
 	c.Assert(perms[1].Scheme, check.Equals, permission.PermAll)
 }
+
+func (s *S) TestCreateRootUserCmdRunNonUserSchemeNewUser(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"my@user.com"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  strings.NewReader(""),
+	}
+	command := &tsurudCommand{Command: createRootUserCmd{}}
+	command.Flags().Parse(true, []string{"--config", "testdata/tsuru-oidc.conf"})
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, "Root user successfully created.\n")
+	u, err := auth.GetUserByEmail(stdContext.TODO(), "my@user.com")
+	c.Assert(err, check.IsNil)
+	perms, err := u.Permissions(stdContext.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(perms, check.HasLen, 2)
+	c.Assert(perms[0].Scheme, check.Equals, permission.PermUser)
+	c.Assert(perms[1].Scheme, check.Equals, permission.PermAll)
+}

--- a/cmd/tsurud/token_test.go
+++ b/cmd/tsurud/token_test.go
@@ -42,6 +42,31 @@ func (s *S) TestCreateRootUserCmdRun(c *check.C) {
 	c.Assert(perms[1].Scheme, check.Equals, permission.PermAll)
 }
 
+func (s *S) TestCreateRootUserCmdRunExistingUser(c *check.C) {
+	existing := &auth.User{Email: "my@user.com"}
+	err := existing.Create(stdContext.TODO())
+	c.Assert(err, check.IsNil)
+	var stdout, stderr bytes.Buffer
+	context := cmd.Context{
+		Args:   []string{"my@user.com"},
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  strings.NewReader("foo123\nfoo123\n"),
+	}
+	command := &tsurudCommand{Command: createRootUserCmd{}}
+	command.Flags().Parse(true, []string{"--config", "testdata/tsuru.conf"})
+	err = command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(stdout.String(), check.Equals, "Root user successfully updated.\n")
+	u, err := auth.GetUserByEmail(stdContext.TODO(), "my@user.com")
+	c.Assert(err, check.IsNil)
+	perms, err := u.Permissions(stdContext.TODO())
+	c.Assert(err, check.IsNil)
+	c.Assert(perms, check.HasLen, 2)
+	c.Assert(perms[0].Scheme, check.Equals, permission.PermUser)
+	c.Assert(perms[1].Scheme, check.Equals, permission.PermAll)
+}
+
 func (s *S) TestCreateRootUserCmdRunNonUserSchemeNewUser(c *check.C) {
 	var stdout, stderr bytes.Buffer
 	context := cmd.Context{


### PR DESCRIPTION
Fixes #2888.

Two fixes to `createRootUserCmd.Run` (one commit each):

1. **Don't panic creating a root user under non-UserScheme auth.** For schemes
   that don't implement `auth.UserScheme` (e.g. `oidc`), the code called
   `user.Create(ctx)` on the nil `user` returned by `GetUserByEmail` for a
   nonexistent user — SIGSEGV. Now the user is constructed
   (`&auth.User{Email: email}`) before creating; `User.Create` already applies
   the default quota.
2. **Return after updating an existing root user.** The existing-user path
   printed "Root user successfully updated." and then fell through to the
   creation code, failing with a duplicate-key error (E11000) and exit code 1
   even though the update succeeded — now it returns after the update, making
   the command idempotent.

Tests (GoCheck, `cmd/tsurud`): creating a root user under the `oidc` scheme
(new `testdata/tsuru-oidc.conf`) — previously panicked the test binary — and
running the command for an already-existing user, asserting exit 0, the
"updated" message only, and the super-role permissions.

Both bugs observed bootstrapping a 1.30.x install with `auth: {scheme: oidc}`;
the function is unchanged on current master.
