### PR TITLE
fix(kubernetes): make KEDA optional, mirroring the VPA crdExists gate

### DIFF
--- a/provision/kubernetes/autoscale.go
+++ b/provision/kubernetes/autoscale.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	vpaCRDName = "verticalpodautoscalers.autoscaling.k8s.io"
+	vpaCRDName  = "verticalpodautoscalers.autoscaling.k8s.io"
+	kedaCRDName = "scaledobjects.keda.sh"
 )
 
 var errNoDeploy = errors.New("no routable version found for app, at least one deploy is required before configuring autoscale")
@@ -127,11 +128,6 @@ func (p *kubernetesProvisioner) GetAutoScale(ctx context.Context, a *appTypes.Ap
 		return nil, err
 	}
 
-	kedaClient, err := KEDAClientForConfig(client.restConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	ls, err := provision.ServiceLabels(ctx, provision.ServiceLabelsOpts{
 		App: a,
 		ServiceLabelExtendedOpts: provision.ServiceLabelExtendedOpts{
@@ -161,6 +157,20 @@ func (p *kubernetesProvisioner) GetAutoScale(ctx context.Context, a *appTypes.Ap
 		if scaledObjectName == "" {
 			specs = append(specs, hpaToSpec(hpa))
 		}
+	}
+
+	// KEDA is optional: without its CRDs there are no ScaledObjects to list.
+	hasKEDA, err := kedaCRDExists(ctx, client)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !hasKEDA {
+		return specs, nil
+	}
+
+	kedaClient, err := KEDAClientForConfig(client.restConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	scaledObjects, err := kedaClient.KedaV1alpha1().ScaledObjects(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set(ls.ToHPASelector())).String()})
@@ -367,6 +377,15 @@ func (p *kubernetesProvisioner) swapAutoScale(ctx context.Context, a *appTypes.A
 }
 
 func removeKEDAScaleObject(ctx context.Context, client *ClusterClient, ns string, scaledObjectName string) error {
+	// KEDA is optional: without its CRDs there is nothing to delete.
+	hasKEDA, err := kedaCRDExists(ctx, client)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !hasKEDA {
+		return nil
+	}
+
 	kedaClient, err := KEDAClientForConfig(client.restConfig)
 	if err != nil {
 		return err
@@ -428,6 +447,14 @@ func setAutoScale(ctx context.Context, client *ClusterClient, a *appTypes.App, s
 	hpaName := hpaNameForApp(a, depInfo.process)
 
 	if len(spec.Schedules) > 0 || len(spec.Prometheus) > 0 {
+		hasKEDA, err := kedaCRDExists(ctx, client)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !hasKEDA {
+			return errors.Errorf("cannot configure schedule/prometheus autoscale: KEDA is not installed in the cluster (missing CRD %s)", kedaCRDName)
+		}
+
 		err = setKEDAAutoscale(ctx, client, spec, a, depInfo, hpaName, labels, preserveVersions)
 		if err != nil {
 			return errors.WithStack(err)
@@ -780,6 +807,10 @@ func minimumAutoScaleVersion(ctx context.Context, client *ClusterClient, a *appT
 
 func vpaCRDExists(ctx context.Context, client *ClusterClient) (bool, error) {
 	return crdExists(ctx, client, vpaCRDName)
+}
+
+func kedaCRDExists(ctx context.Context, client *ClusterClient) (bool, error) {
+	return crdExists(ctx, client, kedaCRDName)
 }
 
 func ensureAutoScale(ctx context.Context, client *ClusterClient, a *appTypes.App, process string) error {

--- a/provision/kubernetes/autoscale_test.go
+++ b/provision/kubernetes/autoscale_test.go
@@ -29,8 +29,11 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func toInt32Ptr(i int32) *int32 {
@@ -342,6 +345,7 @@ func (s *S) TestProvisionerSetAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -480,6 +484,7 @@ func (s *S) TestProvisionerSetScheduleKEDAAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 
@@ -653,6 +658,7 @@ func (s *S) TestProvisionerSetPrometheusKEDAAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerSetPrometheusKEDAAutoScaleWithoutTemplateConfig(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 
@@ -836,6 +842,7 @@ func (s *S) TestProvisionerSetAutoScaleMultipleVersions(c *check.C) {
 }
 
 func (s *S) TestProvisionerSetKEDAAutoScaleMultipleVersions(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 
@@ -1036,6 +1043,7 @@ func (s *S) TestProvisionerRemoveAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerRemoveKEDAAutoScale(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -1147,6 +1155,7 @@ func (s *S) TestProvisionerGetAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -1262,6 +1271,7 @@ func (s *S) TestProvisionerGetScheduleKEDAAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 
@@ -1391,6 +1401,7 @@ func (s *S) TestProvisionerGetPrometheusKEDAAutoScale(c *check.C) {
 }
 
 func (s *S) TestProvisionerKEDAAutoScaleWhenAppStopAppStart(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -1446,6 +1457,7 @@ func (s *S) TestProvisionerKEDAAutoScaleWhenAppStopAppStart(c *check.C) {
 }
 
 func (s *S) TestProvisionerKEDAAutoScaleWhenBevaher(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -1771,6 +1783,7 @@ func (s *S) TestEnsureHPAWithCPUPlanInvalid(c *check.C) {
 }
 
 func (s *S) TestEnsureHPAKEDAPausedReplicasWhenAppStopped(c *check.C) {
+	s.createKEDACRD(c)
 	a, wait, rollback := s.mock.DefaultReactions(c)
 	defer rollback()
 	version := newSuccessfulVersion(c, a, map[string][]string{
@@ -1984,4 +1997,92 @@ func findHPAByProcess(hpas []autoscalingv2.HorizontalPodAutoscaler, processName 
 		}
 	}
 	return nil
+}
+
+func (s *S) createKEDACRD(c *check.C) {
+	kedaCRD := &extensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "scaledobjects.keda.sh"},
+	}
+	_, err := s.client.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), kedaCRD, metav1.CreateOptions{})
+	c.Assert(err, check.IsNil)
+}
+
+// simulateKEDANotInstalled makes every ScaledObject API call fail the way a
+// real cluster without KEDA fails: the CRD is absent from the apiextensions
+// clientset (default) and the API server answers requests for the resource
+// with a NotFound error.
+func (s *S) simulateKEDANotInstalled() {
+	s.client.KEDAClientForConfig.PrependReactor("*", "scaledobjects", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8sErrors.NewNotFound(schema.GroupResource{Group: "keda.sh", Resource: "scaledobjects"}, "")
+	})
+}
+
+func (s *S) TestProvisionerGetAutoScaleWithoutKEDAInstalled(c *check.C) {
+	s.simulateKEDANotInstalled()
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	version := newSuccessfulVersion(c, a, map[string][]string{
+		"web": {"python", "myapp.py"},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	require.NoError(s.t, err)
+	wait()
+
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
+		MinUnits:   1,
+		MaxUnits:   2,
+		AverageCPU: "500m",
+	})
+	require.NoError(s.t, err)
+
+	specs, err := s.p.GetAutoScale(context.TODO(), a)
+	require.NoError(s.t, err)
+	require.Len(s.t, specs, 1)
+	require.Equal(s.t, "web", specs[0].Process)
+}
+
+func (s *S) TestProvisionerDeleteAllAutoScaleWithoutKEDAInstalled(c *check.C) {
+	s.simulateKEDANotInstalled()
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	version := newSuccessfulVersion(c, a, map[string][]string{
+		"web": {"python", "myapp.py"},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	require.NoError(s.t, err)
+	wait()
+
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
+		MinUnits:   1,
+		MaxUnits:   2,
+		AverageCPU: "500m",
+	})
+	require.NoError(s.t, err)
+
+	err = s.p.deleteAllAutoScale(context.TODO(), a)
+	require.NoError(s.t, err)
+}
+
+func (s *S) TestProvisionerSetScheduleAutoScaleWithoutKEDAInstalled(c *check.C) {
+	s.simulateKEDANotInstalled()
+	a, wait, rollback := s.mock.DefaultReactions(c)
+	defer rollback()
+	version := newSuccessfulVersion(c, a, map[string][]string{
+		"web": {"python", "myapp.py"},
+	})
+	err := s.p.AddUnits(context.TODO(), a, 1, "web", version, nil)
+	require.NoError(s.t, err)
+	wait()
+
+	err = s.p.SetAutoScale(context.TODO(), a, provTypes.AutoScaleSpec{
+		MinUnits:   1,
+		MaxUnits:   2,
+		AverageCPU: "500m",
+		Schedules: []provTypes.AutoScaleSchedule{
+			{MinReplicas: 2, Start: "0 6 * * *", End: "0 18 * * *", Timezone: "UTC"},
+		},
+	})
+	require.Error(s.t, err)
+	require.ErrorContains(s.t, err, "KEDA is not installed")
+	require.ErrorContains(s.t, err, "scaledobjects.keda.sh")
 }


### PR DESCRIPTION
Fixes #2890.

On clusters without KEDA installed, every deploy fails at `ensureAutoScale`
and `app remove` half-completes (orphaned App CR), because the provisioner
queries `scaledobjects.keda.sh` unconditionally. This applies the same gate
the file already uses for VPA (`crdExists`):

- **`GetAutoScale`** skips the ScaledObjects listing when the KEDA CRD is
  absent — an install without KEDA has no ScaledObjects by definition. This
  unblocks both failure paths: deploy (`ensureHPA`) and destroy
  (`deleteAllAutoScale`).
- **`removeKEDAScaleObject`** becomes a no-op without the CRD.
- **`setAutoScale`** returns an explicit, actionable error when the spec
  actually requires KEDA (`Schedules`/`Prometheus` non-empty) and the CRD is
  absent: `cannot configure schedule/prometheus autoscale: KEDA is not
  installed in the cluster (missing CRD scaledobjects.keda.sh)`. No silent
  fallback to a plain HPA, no inert ScaledObject — basic usage works without
  KEDA, KEDA-only features fail loudly with the reason.

Design notes:

- **Why CRD state instead of a config flag:** the cluster state is the source
  of truth; a flag can lie in both directions. This also matches the VPA
  precedent, which is state-based.
- **Cost:** one apiextensions GET per call — identical to the existing VPA
  behavior. Caching could be a follow-up if desired.
- **No behavior change for KEDA users:** with the CRD present, all paths are
  exactly as before (existing KEDA tests now create the CRD fixture,
  mirroring how the VPA tests simulate the VPA CRD).

Tests: new cases simulate a KEDA-less cluster the way a real API server
behaves (CRD absent + NotFound reactor on ScaledObject calls) — deploy path
and CPU-only autoscale work, `deleteAllAutoScale` (destroy path) completes,
and a schedules spec fails with the explicit KEDA error. Notably, before the
fix even the test setup (`AddUnits`) failed with the exact production error.

Both failure modes observed on a production 1.30.x install without KEDA.
