### PR TITLE
auth/oidc: auto-create personal team on user registration

### DIFF
--- a/auth/oidc/oidc.go
+++ b/auth/oidc/oidc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tsuru/tsuru/auth"
 	internalConfig "github.com/tsuru/tsuru/config"
 	"github.com/tsuru/tsuru/log"
+	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/set"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 )
@@ -52,12 +53,41 @@ func init() {
 }
 
 type oidcScheme struct {
-	jwksURL             string
-	cache               *jwk.Cache
-	validClaims         map[string]interface{}
-	initialized         sync.Once
-	registrationEnabled bool
-	groupsInClaims      bool
+	jwksURL                string
+	cache                  *jwk.Cache
+	validClaims            map[string]interface{}
+	initialized            sync.Once
+	registrationEnabled    bool
+	groupsInClaims         bool
+	autoCreatePersonalTeam bool
+}
+
+func personalTeamName(email string) string {
+	name := email
+	if idx := strings.Index(email, "@"); idx >= 0 {
+		name = email[:idx]
+	}
+	return auth.NormalizeTeamName(name)
+}
+
+// createPersonalTeam gives a freshly registered user a team of their own so
+// they can create apps without any manual role setup. Best effort: failures
+// are logged and never block the login.
+func (s *oidcScheme) createPersonalTeam(ctx context.Context, user *auth.User) {
+	authUser, err := auth.ConvertOldUser(user, nil)
+	if err != nil {
+		log.Errorf("unable to create personal team for %q: %v", user.Email, err)
+		return
+	}
+	name := personalTeamName(user.Email)
+	err = servicemanager.Team.Create(ctx, name, []string{"personal"}, authUser)
+	if err == authTypes.ErrTeamAlreadyExists {
+		name = auth.NormalizeTeamName(user.Email)
+		err = servicemanager.Team.Create(ctx, name, []string{"personal"}, authUser)
+	}
+	if err != nil {
+		log.Errorf("unable to create personal team %q for %q: %v", name, user.Email, err)
+	}
 }
 
 func (s *oidcScheme) Auth(ctx context.Context, token string) (auth.Token, error) {
@@ -104,6 +134,9 @@ func (s *oidcScheme) Auth(ctx context.Context, token string) (auth.Token, error)
 			err = user.Create(ctx)
 			if err != nil {
 				return nil, err
+			}
+			if s.autoCreatePersonalTeam {
+				s.createPersonalTeam(ctx, user)
 			}
 		} else {
 			return nil, err
@@ -181,6 +214,7 @@ func (s *oidcScheme) lazyInitialize(ctx context.Context) error {
 
 		s.registrationEnabled, _ = config.GetBool("auth:user-registration")
 		s.groupsInClaims, _ = config.GetBool("auth:oidc:groups-in-claims")
+		s.autoCreatePersonalTeam, _ = config.GetBool("auth:oidc:auto-create-personal-team")
 
 		s.validClaims = map[string]interface{}{}
 		internalConfig.UnmarshalConfig("auth:oidc:valid-claims", &s.validClaims)

--- a/auth/oidc/oidc_test.go
+++ b/auth/oidc/oidc_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/tsuru/config"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/db/storagev2"
+	"github.com/tsuru/tsuru/servicemanager"
+	_ "github.com/tsuru/tsuru/storage/mongodb"
+	authTypes "github.com/tsuru/tsuru/types/auth"
 	check "gopkg.in/check.v1"
 )
 
@@ -49,7 +52,11 @@ func (s *AuthSuite) SetUpSuite(c *check.C) {
 	config.Set("auth:oidc:jwks-url", s.fakeJWKSServer.URL)
 	config.Set("auth:user-registration", true)
 
-	err := s.scheme.lazyInitialize(context.Background())
+	var err error
+	servicemanager.Team, err = auth.TeamService()
+	c.Assert(err, check.IsNil)
+
+	err = s.scheme.lazyInitialize(context.Background())
 	c.Check(err, check.IsNil)
 }
 
@@ -228,6 +235,133 @@ func (s *AuthSuite) TestLoginWithDisabledUser(c *check.C) {
 	tsuruToken, err := s.scheme.Auth(context.TODO(), tokenString)
 	c.Assert(err, check.Equals, auth.ErrUserDisabled)
 	c.Assert(tsuruToken, check.IsNil)
+}
+
+func (s *AuthSuite) loginNewUser(c *check.C, kid, userEmail string) {
+	privateRSAKey, err := s.generateNewPrivateRSAKey(kid)
+	c.Assert(err, check.IsNil)
+
+	user := &auth.User{Email: userEmail}
+	user.Delete(context.TODO()) // remove from previous crashed tests
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"email": userEmail,
+	})
+	token.Header["kid"] = kid
+	tokenString, err := token.SignedString(privateRSAKey)
+	c.Assert(err, check.IsNil)
+
+	tsuruToken, err := s.scheme.Auth(context.TODO(), tokenString)
+	c.Assert(err, check.IsNil)
+	c.Assert(tsuruToken.GetUserName(), check.Equals, userEmail)
+}
+
+func (s *AuthSuite) TestLoginRegistrationAutoCreatesPersonalTeam(c *check.C) {
+	s.scheme.autoCreatePersonalTeam = true
+	defer func() {
+		s.scheme.autoCreatePersonalTeam = false
+	}()
+
+	servicemanager.Team.Remove(context.TODO(), "joao-silva") // remove from previous crashed tests
+
+	s.loginNewUser(c, "rsa-personal-team", "joao.silva@company.com")
+
+	team, err := servicemanager.Team.FindByName(context.TODO(), "joao-silva")
+	c.Assert(err, check.IsNil)
+	c.Assert(team.CreatingUser, check.Equals, "joao.silva@company.com")
+	c.Assert(team.Tags, check.DeepEquals, []string{"personal"})
+}
+
+func (s *AuthSuite) TestLoginRegistrationPersonalTeamNameCollision(c *check.C) {
+	s.scheme.autoCreatePersonalTeam = true
+	defer func() {
+		s.scheme.autoCreatePersonalTeam = false
+	}()
+
+	servicemanager.Team.Remove(context.TODO(), "maria")
+	servicemanager.Team.Remove(context.TODO(), "maria-company-com")
+
+	err := servicemanager.Team.Create(context.TODO(), "maria", nil, &authTypes.User{Email: "someone.else@company.com"})
+	c.Assert(err, check.IsNil)
+
+	s.loginNewUser(c, "rsa-personal-team-collision", "maria@company.com")
+
+	team, err := servicemanager.Team.FindByName(context.TODO(), "maria-company-com")
+	c.Assert(err, check.IsNil)
+	c.Assert(team.CreatingUser, check.Equals, "maria@company.com")
+
+	original, err := servicemanager.Team.FindByName(context.TODO(), "maria")
+	c.Assert(err, check.IsNil)
+	c.Assert(original.CreatingUser, check.Equals, "someone.else@company.com")
+}
+
+func (s *AuthSuite) TestLoginRegistrationNoPersonalTeamByDefault(c *check.C) {
+	servicemanager.Team.Remove(context.TODO(), "pedro-souza")
+
+	s.loginNewUser(c, "rsa-no-personal-team", "pedro.souza@company.com")
+
+	_, err := servicemanager.Team.FindByName(context.TODO(), "pedro-souza")
+	c.Assert(err, check.Equals, authTypes.ErrTeamNotFound)
+}
+
+func (s *AuthSuite) TestLoginExistingUserDoesNotCreatePersonalTeam(c *check.C) {
+	s.scheme.autoCreatePersonalTeam = true
+	defer func() {
+		s.scheme.autoCreatePersonalTeam = false
+	}()
+
+	userEmail := "ana.lima@company.com"
+	servicemanager.Team.Remove(context.TODO(), "ana-lima")
+
+	user := &auth.User{Email: userEmail}
+	user.Delete(context.TODO())
+	err := user.Create(context.TODO())
+	c.Assert(err, check.IsNil)
+	defer user.Delete(context.TODO())
+
+	kid := "rsa-existing-user-no-team"
+	privateRSAKey, err := s.generateNewPrivateRSAKey(kid)
+	c.Assert(err, check.IsNil)
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"email": userEmail,
+	})
+	token.Header["kid"] = kid
+	tokenString, err := token.SignedString(privateRSAKey)
+	c.Assert(err, check.IsNil)
+
+	_, err = s.scheme.Auth(context.TODO(), tokenString)
+	c.Assert(err, check.IsNil)
+
+	_, err = servicemanager.Team.FindByName(context.TODO(), "ana-lima")
+	c.Assert(err, check.Equals, authTypes.ErrTeamNotFound)
+}
+
+func (s *AuthSuite) TestLoadConfigAutoCreatePersonalTeam(c *check.C) {
+	config.Set("auth:oidc:auto-create-personal-team", true)
+	defer config.Unset("auth:oidc:auto-create-personal-team")
+
+	scheme := &oidcScheme{}
+	err := scheme.lazyInitialize(context.Background())
+	c.Assert(err, check.IsNil)
+	c.Assert(scheme.autoCreatePersonalTeam, check.Equals, true)
+}
+
+func (s *AuthSuite) TestPersonalTeamName(c *check.C) {
+	tests := map[string]string{
+		"guilherme.brezende@quintoandar.com.br": "guilherme-brezende",
+		"bar@company.com":                       "bar",
+		"John_Doe@company.com":                  "john_doe",
+		"user+tag@company.com":                  "user-tag",
+		"123user@company.com":                   "u-123user",
+	}
+	for email, expected := range tests {
+		c.Check(personalTeamName(email), check.Equals, expected, check.Commentf("email: %s", email))
+	}
+
+	longEmail := "very.long.email.address.that.goes.on.and.on.and.on.and.on.forever.and.ever@company.com"
+	name := personalTeamName(longEmail)
+	c.Check(len(name) <= 63, check.Equals, true)
+	c.Check(name, check.Matches, `^[a-z][a-z0-9_\-]{1,62}$`)
 }
 
 func (s *AuthSuite) generateNewPrivateRSAKey(kid string) (*rsa.PrivateKey, error) {

--- a/auth/team.go
+++ b/auth/team.go
@@ -26,7 +26,25 @@ import (
 //
 //	Keys have a minimum length of 1 character and a maximum length of 63 characters, and cannot be empty. Values can be empty, and have a maximum length of 63 characters.
 //	Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes. All characters must use UTF-8 encoding, and international characters are allowed. Keys must start with a lowercase letter or international character.
-var teamNameRegexp = regexp.MustCompile(`^[a-z][a-z0-9_\-]{1,62}$`)
+var (
+	teamNameRegexp       = regexp.MustCompile(`^[a-z][a-z0-9_\-]{1,62}$`)
+	invalidTeamNameChars = regexp.MustCompile(`[^a-z0-9_-]`)
+)
+
+// NormalizeTeamName transforms an arbitrary string into one that satisfies
+// teamNameRegexp: lowercased, invalid characters replaced by dashes, prefixed
+// with "u-" when not starting with a letter, capped at 63 characters and
+// stripped of trailing separators.
+func NormalizeTeamName(s string) string {
+	s = invalidTeamNameChars.ReplaceAllString(strings.ToLower(s), "-")
+	if s == "" || s[0] < 'a' || s[0] > 'z' {
+		s = "u-" + s
+	}
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	return strings.TrimRight(s, "-_")
+}
 
 type teamService struct {
 	storage authTypes.TeamStorage

--- a/auth/team_test.go
+++ b/auth/team_test.go
@@ -13,6 +13,28 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+func (s *S) TestNormalizeTeamName(c *check.C) {
+	tests := map[string]string{
+		"john.doe":  "john-doe",
+		"John_Doe":  "john_doe",
+		"user+tag":  "user-tag",
+		"123user":   "u-123user",
+		"user.":     "user",
+		"plain":     "plain",
+		"UPPERCASE": "uppercase",
+	}
+	for input, expected := range tests {
+		normalized := NormalizeTeamName(input)
+		c.Check(normalized, check.Equals, expected, check.Commentf("input: %s", input))
+		c.Check(teamNameRegexp.MatchString(normalized), check.Equals, true, check.Commentf("input: %s", input))
+	}
+
+	long := "very.long.name.that.goes.on.and.on.and.on.and.on.forever.and.ever.and.ever"
+	normalized := NormalizeTeamName(long)
+	c.Check(len(normalized) <= 63, check.Equals, true)
+	c.Check(teamNameRegexp.MatchString(normalized), check.Equals, true)
+}
+
 func (s *S) TestTeamServiceCreate(c *check.C) {
 	teamName := "pos"
 	tags := []string{"tag1", "tag1 ", "tag2"}


### PR DESCRIPTION
Closes #2894

## What

Adds an opt-in config to the OIDC auth scheme:

```yaml
auth:
  oidc:
    auto-create-personal-team: true
```

When enabled, right after the scheme auto-registers a new user (`auth:user-registration: true`), it creates a team for them named after their email local part — `joao.silva@example.com` → `joao-silva` — falling back to a full-email slug (`joao-silva-example-com`) if the name is taken. Team creation is best-effort: failures are logged and never block the login. Off by default; no behavior change unless the config is set.

Because `teamService.Create` fires the `team-create` role event, any default role bound to that event (e.g. a `team-member` role with app permissions) is applied automatically — a brand-new user can create and deploy apps on first login with zero admin setup. See #2894 for the full motivation: default roles at `user-create` are applied with an empty context value, so they cannot grant team membership.

## Implementation notes

- Name normalization lives in the `auth` package as `NormalizeTeamName`, exported next to `teamNameRegexp` so the rule and its normalizer evolve together (lowercase, invalid chars → `-`, `u-` prefix when not starting with a letter, 63-char cap, trailing separators trimmed).
- `auth/oidc` keeps only the OIDC-specific part (email → local part) and the best-effort team creation.

## Testing

- `auth/oidc`: registration creates the team (name + creating user + `personal` tag), collision falls back to the full-email slug, disabled by default, no-op for already-existing users, config wiring.
- `auth`: `NormalizeTeamName` table tests, including conformance to `teamNameRegexp`.

Running in production on our internal platform (tsuru on Kubernetes + Keycloak).