### PR TITLE
storage: decouple Job persistence from MongoDB and add a PostgreSQL adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,15 @@ jobs:
       redis:
         image: redis
         ports: ["6379:6379"]
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: tsuru
+          POSTGRES_PASSWORD: tsuru
+          POSTGRES_DB: tsuru
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
     - uses: actions/setup-go@v5
       with:

--- a/db/storagepg/storage.go
+++ b/db/storagepg/storage.go
@@ -1,0 +1,84 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagepg
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tsuru/config"
+)
+
+const DefaultDatabaseURL = "postgres://tsuru:tsuru@127.0.0.1:5432/tsuru?sslmode=disable"
+
+var (
+	pool *pgxpool.Pool
+	mu   sync.Mutex
+)
+
+// schema is applied idempotently on first connect. The JSONB document-mirror
+// stores the full entity in `doc`; promoted columns back hot predicates.
+const schema = `
+CREATE TABLE IF NOT EXISTS jobs (
+	name       text PRIMARY KEY,
+	team_owner text,
+	owner      text,
+	pool       text,
+	tags       text[],
+	doc        jsonb NOT NULL
+);
+CREATE INDEX IF NOT EXISTS jobs_pool_idx ON jobs (pool);
+CREATE INDEX IF NOT EXISTS jobs_team_owner_idx ON jobs (team_owner);
+`
+
+func dbURL() string {
+	url, _ := config.GetString("database:postgres:url")
+	if url == "" {
+		url = DefaultDatabaseURL
+	}
+	return url
+}
+
+func connect() (*pgxpool.Pool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	p, err := pgxpool.New(ctx, dbURL())
+	if err != nil {
+		return nil, err
+	}
+	if _, err = p.Exec(ctx, schema); err != nil {
+		p.Close()
+		return nil, err
+	}
+	return p, nil
+}
+
+// Pool returns the shared connection pool, connecting on first use.
+func Pool() (*pgxpool.Pool, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if pool != nil {
+		return pool, nil
+	}
+	p, err := connect()
+	if err != nil {
+		return nil, err
+	}
+	pool = p
+	return pool, nil
+}
+
+// Reset drops the cached pool (used between test suites).
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	if pool != nil {
+		pool.Close()
+		pool = nil
+	}
+}

--- a/db/storagepg/tests.go
+++ b/db/storagepg/tests.go
@@ -1,0 +1,24 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagepg
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// ClearAllTables truncates every adapter table. Tests only.
+func ClearAllTables() error {
+	if !testing.Testing() {
+		return errors.New("ClearAllTables should only be used in tests")
+	}
+	p, err := Pool()
+	if err != nil {
+		return err
+	}
+	_, err = p.Exec(context.Background(), "TRUNCATE TABLE jobs")
+	return err
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,19 @@ services:
     - datadb:/data/db
     restart: unless-stopped
 
+  postgres:
+    container_name: postgres
+    image: postgres:16
+    environment:
+    - POSTGRES_USER=tsuru
+    - POSTGRES_PASSWORD=tsuru
+    - POSTGRES_DB=tsuru
+    ports:
+    - ${TSURU_POSTGRES_PORT:-5432}:5432
+    volumes:
+    - datapg:/var/lib/postgresql/data
+    restart: unless-stopped
+
   registry:
     container_name: registry
     image: registry:2
@@ -65,3 +78,4 @@ services:
 
 volumes:
   datadb:
+  datapg:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/imdario/mergo v0.3.16
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/kedacore/keda/v2 v2.20.0
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.21
@@ -87,6 +88,9 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/moby/moby/api v1.54.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,14 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/job/actions.go
+++ b/job/actions.go
@@ -11,12 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tsuru/tsuru/action"
 	"github.com/tsuru/tsuru/auth"
-	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/log"
 	"github.com/tsuru/tsuru/servicemanager"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	jobTypes "github.com/tsuru/tsuru/types/job"
-	mongoBSON "go.mongodb.org/mongo-driver/bson"
 )
 
 var provisionJob = action.Action{
@@ -153,22 +151,15 @@ var insertJob = action.Action{
 }
 
 func insertJobDB(ctx context.Context, job *jobTypes.Job) error {
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return err
 	}
-	_, err = servicemanager.Job.GetByName(ctx, job.Name)
-	if err == jobTypes.ErrJobNotFound {
-		_, err = collection.InsertOne(ctx, job)
-		return err
-	} else if err == nil {
-		return jobTypes.ErrJobAlreadyExists
-	}
-	return err
+	return st.Insert(ctx, *job)
 }
 
 func updateJobDB(ctx context.Context, job *jobTypes.Job) error {
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return err
 	}
@@ -181,9 +172,7 @@ func updateJobDB(ctx context.Context, job *jobTypes.Job) error {
 		return nil
 	}
 
-	_, err = collection.ReplaceOne(ctx, mongoBSON.M{"name": job.Name}, job)
-
-	return err
+	return st.Update(ctx, *job)
 }
 
 var reserveTeamCronjob = action.Action{

--- a/job/job.go
+++ b/job/job.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -18,21 +17,19 @@ import (
 	"github.com/tsuru/tsuru/app/image"
 	"github.com/tsuru/tsuru/auth"
 	"github.com/tsuru/tsuru/builder"
-	"github.com/tsuru/tsuru/db/storagev2"
 	tsuruEnvs "github.com/tsuru/tsuru/envs"
 	tsuruErrors "github.com/tsuru/tsuru/errors"
 	"github.com/tsuru/tsuru/provision"
 	"github.com/tsuru/tsuru/provision/pool"
 	"github.com/tsuru/tsuru/servicemanager"
 	"github.com/tsuru/tsuru/set"
+	"github.com/tsuru/tsuru/storage"
 	"github.com/tsuru/tsuru/streamfmt"
 	imgTypes "github.com/tsuru/tsuru/types/app/image"
 	authTypes "github.com/tsuru/tsuru/types/auth"
 	bindTypes "github.com/tsuru/tsuru/types/bind"
 	jobTypes "github.com/tsuru/tsuru/types/job"
 	provTypes "github.com/tsuru/tsuru/types/provision"
-	mongoBSON "go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type jobService struct{}
@@ -65,6 +62,17 @@ func JobService() (jobTypes.JobService, error) {
 	return &jobService{}, nil
 }
 
+func jobStorage() (jobTypes.JobStorage, error) {
+	dbDriver, err := storage.GetCurrentDbDriver()
+	if err != nil {
+		dbDriver, err = storage.GetDefaultDbDriver()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dbDriver.JobStorage, nil
+}
+
 func (*jobService) KillUnit(ctx context.Context, job *jobTypes.Job, unit string, force bool) error {
 	prov, err := getProvisioner(ctx, job)
 	if err != nil {
@@ -76,33 +84,20 @@ func (*jobService) KillUnit(ctx context.Context, job *jobTypes.Job, unit string,
 // GetByName queries the database to find a job identified by the given
 // name.
 func (*jobService) GetByName(ctx context.Context, name string) (*jobTypes.Job, error) {
-	var job jobTypes.Job
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return nil, err
 	}
-	err = collection.FindOne(ctx, mongoBSON.M{"name": name}).Decode(&job)
-	if err == mongo.ErrNoDocuments {
-		return nil, jobTypes.ErrJobNotFound
-	}
-	return &job, err
+	return st.FindByName(ctx, name)
 }
 
 func (*jobService) RemoveJob(ctx context.Context, job *jobTypes.Job) error {
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return err
 	}
-	result, err := collection.DeleteOne(ctx, mongoBSON.M{"name": job.Name})
-	if err == mongo.ErrNoDocuments {
-		return jobTypes.ErrJobNotFound
-	}
-	if err != nil {
+	if err = st.Delete(ctx, job.Name); err != nil {
 		return err
-	}
-
-	if result.DeletedCount == 0 {
-		return jobTypes.ErrJobNotFound
 	}
 
 	servicemanager.TeamQuota.Inc(ctx, &authTypes.Team{Name: job.TeamOwner}, -1)
@@ -361,17 +356,11 @@ func (*jobService) AddServiceEnv(ctx context.Context, job *jobTypes.Job, addArgs
 	}
 	job.Spec.ServiceEnvs = append(job.Spec.ServiceEnvs, addArgs.Envs...)
 
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return err
 	}
-
-	_, err = collection.UpdateOne(ctx, mongoBSON.M{"name": job.Name}, mongoBSON.M{"$set": mongoBSON.M{"spec.serviceenvs": job.Spec.ServiceEnvs}})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return st.UpdateServiceEnvs(ctx, job.Name, job.Spec.ServiceEnvs)
 }
 
 func (*jobService) RemoveServiceEnv(ctx context.Context, job *jobTypes.Job, removeArgs jobTypes.RemoveInstanceArgs) error {
@@ -393,16 +382,11 @@ func (*jobService) RemoveServiceEnv(ctx context.Context, job *jobTypes.Job, remo
 		streamfmt.FprintlnSectionf(removeArgs.Writer, "Unsetting %d environment variables", toUnset)
 	}
 
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return err
 	}
-	_, err = collection.UpdateOne(ctx, mongoBSON.M{"name": job.Name}, mongoBSON.M{"$set": mongoBSON.M{"spec.serviceenvs": job.Spec.ServiceEnvs}})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return st.UpdateServiceEnvs(ctx, job.Name, job.Spec.ServiceEnvs)
 }
 
 func (*jobService) UpdateJobProv(ctx context.Context, job *jobTypes.Job) error {
@@ -419,74 +403,12 @@ func (*jobService) Trigger(ctx context.Context, job *jobTypes.Job) error {
 	return action.NewPipeline([]*action.Action{&triggerCron}...).Execute(ctx, job)
 }
 
-func processTags(tags []string) []string {
-	if tags == nil {
-		return nil
-	}
-	processedTags := []string{}
-	usedTags := make(map[string]bool)
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if len(tag) > 0 && !usedTags[tag] {
-			processedTags = append(processedTags, tag)
-			usedTags[tag] = true
-		}
-	}
-	return processedTags
-}
-
-func filterQuery(f *jobTypes.Filter) mongoBSON.M {
-	if f == nil {
-		return mongoBSON.M{}
-	}
-	query := mongoBSON.M{}
-	if f.Extra != nil {
-		var orBlock []mongoBSON.M
-		for field, values := range f.Extra {
-			orBlock = append(orBlock, mongoBSON.M{
-				field: mongoBSON.M{"$in": values},
-			})
-		}
-		query["$or"] = orBlock
-	}
-	if f.Name != "" {
-		query["name"] = mongoBSON.M{"$regex": f.Name}
-	}
-	if f.TeamOwner != "" {
-		query["teamowner"] = f.TeamOwner
-	}
-	if f.UserOwner != "" {
-		query["owner"] = f.UserOwner
-	}
-	if f.Pool != "" {
-		query["pool"] = f.Pool
-	}
-	if len(f.Pools) > 0 {
-		query["pool"] = mongoBSON.M{"$in": f.Pools}
-	}
-	tags := processTags(f.Tags)
-	if len(tags) > 0 {
-		query["tags"] = mongoBSON.M{"$all": tags}
-	}
-	return query
-}
-
 func (*jobService) List(ctx context.Context, filter *jobTypes.Filter) ([]jobTypes.Job, error) {
-	jobs := []jobTypes.Job{}
-	query := filterQuery(filter)
-	collection, err := storagev2.JobsCollection()
+	st, err := jobStorage()
 	if err != nil {
 		return nil, err
 	}
-	cursor, err := collection.Find(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	err = cursor.All(ctx, &jobs)
-	if err != nil {
-		return nil, err
-	}
-	return jobs, nil
+	return st.ListByFilter(ctx, filter)
 }
 
 func (*jobService) GetEnvs(ctx context.Context, job *jobTypes.Job) map[string]bindTypes.EnvVar {

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tsuru/tsuru/types/auth"
 	"github.com/tsuru/tsuru/types/cache"
 	"github.com/tsuru/tsuru/types/event"
+	"github.com/tsuru/tsuru/types/job"
 	"github.com/tsuru/tsuru/types/provision"
 	"github.com/tsuru/tsuru/types/quota"
 	"github.com/tsuru/tsuru/types/router"
@@ -39,6 +40,7 @@ type DbDriver struct {
 	AuthGroupStorage       auth.GroupStorage
 	PoolStorage            provision.PoolStorage
 	VolumeStorage          volume.VolumeStorage
+	JobStorage             job.JobStorage
 }
 
 var (

--- a/storage/mongodb/job.go
+++ b/storage/mongodb/job.go
@@ -1,0 +1,139 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"context"
+
+	storagev2 "github.com/tsuru/tsuru/db/storagev2"
+	bindTypes "github.com/tsuru/tsuru/types/bind"
+	jobTypes "github.com/tsuru/tsuru/types/job"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type JobStorage struct{}
+
+var _ jobTypes.JobStorage = &JobStorage{}
+
+func (s *JobStorage) Insert(ctx context.Context, job jobTypes.Job) error {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return err
+	}
+	span := newMongoDBSpan(ctx, mongoSpanInsert, collection.Name())
+	defer span.Finish()
+
+	_, err = collection.InsertOne(ctx, job)
+	if mongo.IsDuplicateKeyError(err) {
+		err = jobTypes.ErrJobAlreadyExists
+	}
+	span.SetError(err)
+	return err
+}
+
+func (s *JobStorage) Update(ctx context.Context, job jobTypes.Job) error {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return err
+	}
+	span := newMongoDBSpan(ctx, mongoSpanUpdate, collection.Name())
+	defer span.Finish()
+
+	result, err := collection.ReplaceOne(ctx, mongoBSON.M{"name": job.Name}, job)
+	if err != nil {
+		span.SetError(err)
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return jobTypes.ErrJobNotFound
+	}
+	return nil
+}
+
+func (s *JobStorage) FindByName(ctx context.Context, name string) (*jobTypes.Job, error) {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return nil, err
+	}
+	span := newMongoDBSpan(ctx, mongoSpanFind, collection.Name())
+	defer span.Finish()
+
+	var job jobTypes.Job
+	err = collection.FindOne(ctx, mongoBSON.M{"name": name}).Decode(&job)
+	if err == mongo.ErrNoDocuments {
+		return nil, jobTypes.ErrJobNotFound
+	}
+	if err != nil {
+		span.SetError(err)
+		return nil, err
+	}
+	return &job, nil
+}
+
+func (s *JobStorage) ListByFilter(ctx context.Context, filter *jobTypes.Filter) ([]jobTypes.Job, error) {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return nil, err
+	}
+	query := translateQuery(filter.ToQuery())
+
+	span := newMongoDBSpan(ctx, mongoSpanFind, collection.Name())
+	span.SetQueryStatement(query)
+	defer span.Finish()
+
+	jobs := []jobTypes.Job{}
+	cursor, err := collection.Find(ctx, query)
+	if err != nil {
+		span.SetError(err)
+		return nil, err
+	}
+	if err = cursor.All(ctx, &jobs); err != nil {
+		span.SetError(err)
+		return nil, err
+	}
+	return jobs, nil
+}
+
+func (s *JobStorage) Delete(ctx context.Context, name string) error {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return err
+	}
+	span := newMongoDBSpan(ctx, mongoSpanDelete, collection.Name())
+	defer span.Finish()
+
+	result, err := collection.DeleteOne(ctx, mongoBSON.M{"name": name})
+	if err != nil {
+		span.SetError(err)
+		return err
+	}
+	if result.DeletedCount == 0 {
+		return jobTypes.ErrJobNotFound
+	}
+	return nil
+}
+
+func (s *JobStorage) UpdateServiceEnvs(ctx context.Context, name string, serviceEnvs []bindTypes.ServiceEnvVar) error {
+	collection, err := storagev2.JobsCollection()
+	if err != nil {
+		return err
+	}
+	span := newMongoDBSpan(ctx, mongoSpanUpdate, collection.Name())
+	defer span.Finish()
+
+	result, err := collection.UpdateOne(ctx,
+		mongoBSON.M{"name": name},
+		mongoBSON.M{"$set": mongoBSON.M{"spec.serviceenvs": serviceEnvs}},
+	)
+	if err != nil {
+		span.SetError(err)
+		return err
+	}
+	if result.MatchedCount == 0 {
+		return jobTypes.ErrJobNotFound
+	}
+	return nil
+}

--- a/storage/mongodb/job_test.go
+++ b/storage/mongodb/job_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.JobSuite{
+	JobStorage: &JobStorage{},
+	SuiteHooks: &mongodbBaseTest{name: "job"},
+})

--- a/storage/mongodb/mongodb.go
+++ b/storage/mongodb/mongodb.go
@@ -27,6 +27,7 @@ func init() {
 		AuthGroupStorage:       &authGroupStorage{},
 		PoolStorage:            &PoolStorage{},
 		VolumeStorage:          &volumeStorage{},
+		JobStorage:             &JobStorage{},
 	}
 	storage.RegisterDbDriver("mongodb", mongodbDriver)
 }

--- a/storage/mongodb/query.go
+++ b/storage/mongodb/query.go
@@ -1,0 +1,35 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mongodb
+
+import (
+	"github.com/tsuru/tsuru/types/query"
+	mongoBSON "go.mongodb.org/mongo-driver/bson"
+)
+
+// translateQuery converts a backend-neutral query.Query into a MongoDB filter.
+func translateQuery(q query.Query) mongoBSON.M {
+	m := mongoBSON.M{}
+	for field, val := range q.Eq {
+		m[field] = val
+	}
+	for field, vals := range q.In {
+		m[field] = mongoBSON.M{"$in": vals}
+	}
+	for field, pattern := range q.Regex {
+		m[field] = mongoBSON.M{"$regex": pattern}
+	}
+	for field, vals := range q.All {
+		m[field] = mongoBSON.M{"$all": vals}
+	}
+	if len(q.Or) > 0 {
+		or := make([]mongoBSON.M, len(q.Or))
+		for i, sub := range q.Or {
+			or[i] = translateQuery(sub)
+		}
+		m["$or"] = or
+	}
+	return m
+}

--- a/storage/postgres/job.go
+++ b/storage/postgres/job.go
@@ -1,0 +1,194 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/tsuru/tsuru/db/storagepg"
+	bindTypes "github.com/tsuru/tsuru/types/bind"
+	jobTypes "github.com/tsuru/tsuru/types/job"
+)
+
+type JobStorage struct{}
+
+var _ jobTypes.JobStorage = &JobStorage{}
+
+const uniqueViolation = "23505"
+
+// jobDoc is the on-disk representation. It carries fields the public API hides
+// from JSON (Spec.ServiceEnvs is tagged `json:"-"`) but that storage must
+// persist, keeping the public API contract untouched.
+type jobDoc struct {
+	jobTypes.Job
+	ServiceEnvs []serviceEnvVar `json:"_serviceEnvs"`
+}
+
+// serviceEnvVar mirrors bindTypes.ServiceEnvVar with storage JSON tags:
+// ServiceName and InstanceName are `json:"-"` on the public type.
+type serviceEnvVar struct {
+	bindTypes.EnvVar
+	ServiceName  string `json:"serviceName"`
+	InstanceName string `json:"instanceName"`
+}
+
+func toServiceEnvs(envs []bindTypes.ServiceEnvVar) []serviceEnvVar {
+	if envs == nil {
+		return nil
+	}
+	out := make([]serviceEnvVar, len(envs))
+	for i, e := range envs {
+		out[i] = serviceEnvVar{EnvVar: e.EnvVar, ServiceName: e.ServiceName, InstanceName: e.InstanceName}
+	}
+	return out
+}
+
+func fromServiceEnvs(envs []serviceEnvVar) []bindTypes.ServiceEnvVar {
+	if envs == nil {
+		return nil
+	}
+	out := make([]bindTypes.ServiceEnvVar, len(envs))
+	for i, e := range envs {
+		out[i] = bindTypes.ServiceEnvVar{EnvVar: e.EnvVar, ServiceName: e.ServiceName, InstanceName: e.InstanceName}
+	}
+	return out
+}
+
+func marshalJob(j jobTypes.Job) ([]byte, error) {
+	return json.Marshal(jobDoc{Job: j, ServiceEnvs: toServiceEnvs(j.Spec.ServiceEnvs)})
+}
+
+func unmarshalJob(data []byte) (jobTypes.Job, error) {
+	var d jobDoc
+	if err := json.Unmarshal(data, &d); err != nil {
+		return jobTypes.Job{}, err
+	}
+	job := d.Job
+	job.Spec.ServiceEnvs = fromServiceEnvs(d.ServiceEnvs)
+	return job, nil
+}
+
+func (s *JobStorage) Insert(ctx context.Context, job jobTypes.Job) error {
+	p, err := storagepg.Pool()
+	if err != nil {
+		return err
+	}
+	doc, err := marshalJob(job)
+	if err != nil {
+		return err
+	}
+	_, err = p.Exec(ctx,
+		`INSERT INTO jobs (name, team_owner, owner, pool, tags, doc)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		job.Name, job.TeamOwner, job.Owner, job.Pool, job.Tags, doc)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation {
+		return jobTypes.ErrJobAlreadyExists
+	}
+	return err
+}
+
+func (s *JobStorage) Update(ctx context.Context, job jobTypes.Job) error {
+	p, err := storagepg.Pool()
+	if err != nil {
+		return err
+	}
+	doc, err := marshalJob(job)
+	if err != nil {
+		return err
+	}
+	tag, err := p.Exec(ctx,
+		`UPDATE jobs SET team_owner=$2, owner=$3, pool=$4, tags=$5, doc=$6
+		 WHERE name=$1`,
+		job.Name, job.TeamOwner, job.Owner, job.Pool, job.Tags, doc)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return jobTypes.ErrJobNotFound
+	}
+	return nil
+}
+
+func (s *JobStorage) FindByName(ctx context.Context, name string) (*jobTypes.Job, error) {
+	p, err := storagepg.Pool()
+	if err != nil {
+		return nil, err
+	}
+	var doc []byte
+	err = p.QueryRow(ctx, `SELECT doc FROM jobs WHERE name=$1`, name).Scan(&doc)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, jobTypes.ErrJobNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	job, err := unmarshalJob(doc)
+	if err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+func (s *JobStorage) ListByFilter(ctx context.Context, filter *jobTypes.Filter) ([]jobTypes.Job, error) {
+	p, err := storagepg.Pool()
+	if err != nil {
+		return nil, err
+	}
+	where, args := translateJobQuery(filter.ToQuery())
+	sql := `SELECT doc FROM jobs`
+	if where != "" {
+		sql += " WHERE " + where
+	}
+	rows, err := p.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	jobs := []jobTypes.Job{}
+	for rows.Next() {
+		var doc []byte
+		if err = rows.Scan(&doc); err != nil {
+			return nil, err
+		}
+		job, err := unmarshalJob(doc)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func (s *JobStorage) Delete(ctx context.Context, name string) error {
+	p, err := storagepg.Pool()
+	if err != nil {
+		return err
+	}
+	tag, err := p.Exec(ctx, `DELETE FROM jobs WHERE name=$1`, name)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return jobTypes.ErrJobNotFound
+	}
+	return nil
+}
+
+// UpdateServiceEnvs is a read-modify-write here (vs Mongo's `$set`). If Job ever
+// needs concurrency-safe partial updates, switch to a jsonb_set UPDATE.
+func (s *JobStorage) UpdateServiceEnvs(ctx context.Context, name string, serviceEnvs []bindTypes.ServiceEnvVar) error {
+	job, err := s.FindByName(ctx, name)
+	if err != nil {
+		return err
+	}
+	job.Spec.ServiceEnvs = serviceEnvs
+	return s.Update(ctx, *job)
+}

--- a/storage/postgres/job_test.go
+++ b/storage/postgres/job_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postgres
+
+import (
+	"github.com/tsuru/tsuru/storage/storagetest"
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&storagetest.JobSuite{
+	JobStorage: &JobStorage{},
+	SuiteHooks: &postgresBaseTest{},
+})

--- a/storage/postgres/query.go
+++ b/storage/postgres/query.go
@@ -1,0 +1,68 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postgres
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tsuru/tsuru/types/query"
+)
+
+// jobColumns maps neutral field names to promoted SQL columns for the jobs table.
+var jobColumns = map[string]string{
+	"name":      "name",
+	"teamowner": "team_owner",
+	"owner":     "owner",
+	"pool":      "pool",
+	"tags":      "tags",
+}
+
+// translateJobQuery builds a SQL WHERE fragment (without the WHERE keyword) and
+// the positional args. Returns ("", nil) for an empty query.
+func translateJobQuery(q query.Query) (string, []any) {
+	conds, args := buildConds(q, 0)
+	if len(conds) == 0 {
+		return "", nil
+	}
+	return strings.Join(conds, " AND "), args
+}
+
+func col(field string) string {
+	if c, ok := jobColumns[field]; ok {
+		return c
+	}
+	return fmt.Sprintf("doc->>'%s'", field)
+}
+
+func buildConds(q query.Query, start int) ([]string, []any) {
+	var conds []string
+	var args []any
+	n := start
+	next := func(v any) string { n++; args = append(args, v); return fmt.Sprintf("$%d", n) }
+
+	for field, val := range q.Eq {
+		conds = append(conds, fmt.Sprintf("%s = %s", col(field), next(val)))
+	}
+	for field, vals := range q.In {
+		conds = append(conds, fmt.Sprintf("%s = ANY(%s)", col(field), next(vals)))
+	}
+	for field, pattern := range q.Regex {
+		conds = append(conds, fmt.Sprintf("%s ~ %s", col(field), next(pattern)))
+	}
+	for field, vals := range q.All {
+		// tags is a text[] column: contains-all via the @> operator.
+		conds = append(conds, fmt.Sprintf("%s @> %s", col(field), next(vals)))
+	}
+	for _, sub := range q.Or {
+		subConds, subArgs := buildConds(sub, n)
+		if len(subConds) > 0 {
+			conds = append(conds, "("+strings.Join(subConds, " OR ")+")")
+			args = append(args, subArgs...)
+			n += len(subArgs)
+		}
+	}
+	return conds, args
+}

--- a/storage/postgres/suite_test.go
+++ b/storage/postgres/suite_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package postgres
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/db/storagepg"
+	check "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type postgresBaseTest struct{}
+
+// testDatabaseURL points at the docker-compose `postgres` service. Override it
+// with TSURU_POSTGRES_TEST_URL when the default port is taken locally.
+func testDatabaseURL() string {
+	if url := os.Getenv("TSURU_POSTGRES_TEST_URL"); url != "" {
+		return url
+	}
+	return storagepg.DefaultDatabaseURL
+}
+
+func (t *postgresBaseTest) SetUpSuite(c *check.C) {
+	config.Set("database:postgres:url", testDatabaseURL())
+	storagepg.Reset()
+	// Force a connect so the schema is created before the first test.
+	_, err := storagepg.Pool()
+	c.Assert(err, check.IsNil)
+}
+
+func (t *postgresBaseTest) SetUpTest(c *check.C) {
+	err := storagepg.ClearAllTables()
+	c.Assert(err, check.IsNil)
+}
+
+func (t *postgresBaseTest) TearDownSuite(c *check.C) {
+	err := storagepg.ClearAllTables()
+	c.Assert(err, check.IsNil)
+}
+
+func (t *postgresBaseTest) TearDownTest(c *check.C) {}

--- a/storage/storagetest/job_suite.go
+++ b/storage/storagetest/job_suite.go
@@ -1,0 +1,142 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagetest
+
+import (
+	"context"
+	"sort"
+
+	bindTypes "github.com/tsuru/tsuru/types/bind"
+	jobTypes "github.com/tsuru/tsuru/types/job"
+	check "gopkg.in/check.v1"
+)
+
+type JobSuite struct {
+	SuiteHooks
+	JobStorage jobTypes.JobStorage
+}
+
+func (s *JobSuite) newJob(name string) jobTypes.Job {
+	return jobTypes.Job{
+		Name:      name,
+		TeamOwner: "team1",
+		Owner:     "me@example.com",
+		Pool:      "pool1",
+		Tags:      []string{"tag1", "tag2"},
+		Spec: jobTypes.JobSpec{
+			Schedule: "* * * * *",
+		},
+	}
+}
+
+func (s *JobSuite) TestInsertJob(c *check.C) {
+	j := s.newJob("myjob")
+	err := s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	got, err := s.JobStorage.FindByName(context.TODO(), "myjob")
+	c.Assert(err, check.IsNil)
+	c.Assert(got.Name, check.Equals, "myjob")
+	c.Assert(got.TeamOwner, check.Equals, "team1")
+	c.Assert(got.Pool, check.Equals, "pool1")
+	c.Assert(got.Tags, check.DeepEquals, []string{"tag1", "tag2"})
+}
+
+func (s *JobSuite) TestInsertDuplicateJob(c *check.C) {
+	j := s.newJob("myjob")
+	err := s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	err = s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.Equals, jobTypes.ErrJobAlreadyExists)
+}
+
+func (s *JobSuite) TestFindByNameNotFound(c *check.C) {
+	got, err := s.JobStorage.FindByName(context.TODO(), "missing")
+	c.Assert(err, check.Equals, jobTypes.ErrJobNotFound)
+	c.Assert(got, check.IsNil)
+}
+
+func (s *JobSuite) TestUpdateJob(c *check.C) {
+	j := s.newJob("myjob")
+	err := s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	j.Description = "updated"
+	j.Pool = "pool2"
+	err = s.JobStorage.Update(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	got, err := s.JobStorage.FindByName(context.TODO(), "myjob")
+	c.Assert(err, check.IsNil)
+	c.Assert(got.Description, check.Equals, "updated")
+	c.Assert(got.Pool, check.Equals, "pool2")
+}
+
+func (s *JobSuite) TestUpdateJobNotFound(c *check.C) {
+	err := s.JobStorage.Update(context.TODO(), s.newJob("missing"))
+	c.Assert(err, check.Equals, jobTypes.ErrJobNotFound)
+}
+
+func (s *JobSuite) TestDeleteJob(c *check.C) {
+	j := s.newJob("myjob")
+	err := s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	err = s.JobStorage.Delete(context.TODO(), "myjob")
+	c.Assert(err, check.IsNil)
+	_, err = s.JobStorage.FindByName(context.TODO(), "myjob")
+	c.Assert(err, check.Equals, jobTypes.ErrJobNotFound)
+}
+
+func (s *JobSuite) TestDeleteJobNotFound(c *check.C) {
+	err := s.JobStorage.Delete(context.TODO(), "missing")
+	c.Assert(err, check.Equals, jobTypes.ErrJobNotFound)
+}
+
+func (s *JobSuite) TestUpdateServiceEnvs(c *check.C) {
+	j := s.newJob("myjob")
+	err := s.JobStorage.Insert(context.TODO(), j)
+	c.Assert(err, check.IsNil)
+	envs := []bindTypes.ServiceEnvVar{{
+		ServiceName:  "mysql",
+		InstanceName: "db1",
+		EnvVar:       bindTypes.EnvVar{Name: "DB_HOST", Value: "localhost"},
+	}}
+	err = s.JobStorage.UpdateServiceEnvs(context.TODO(), "myjob", envs)
+	c.Assert(err, check.IsNil)
+	got, err := s.JobStorage.FindByName(context.TODO(), "myjob")
+	c.Assert(err, check.IsNil)
+	c.Assert(got.Spec.ServiceEnvs, check.DeepEquals, envs)
+}
+
+func (s *JobSuite) TestListAll(c *check.C) {
+	err := s.JobStorage.Insert(context.TODO(), s.newJob("job-a"))
+	c.Assert(err, check.IsNil)
+	err = s.JobStorage.Insert(context.TODO(), s.newJob("job-b"))
+	c.Assert(err, check.IsNil)
+	jobs, err := s.JobStorage.ListByFilter(context.TODO(), nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(jobs, check.HasLen, 2)
+	names := []string{jobs[0].Name, jobs[1].Name}
+	sort.Strings(names)
+	c.Assert(names, check.DeepEquals, []string{"job-a", "job-b"})
+}
+
+func (s *JobSuite) TestListFilterByPoolAndName(c *check.C) {
+	ja := s.newJob("alpha")
+	ja.Pool = "poolX"
+	err := s.JobStorage.Insert(context.TODO(), ja)
+	c.Assert(err, check.IsNil)
+	jb := s.newJob("beta")
+	jb.Pool = "poolY"
+	err = s.JobStorage.Insert(context.TODO(), jb)
+	c.Assert(err, check.IsNil)
+
+	byPool, err := s.JobStorage.ListByFilter(context.TODO(), &jobTypes.Filter{Pool: "poolX"})
+	c.Assert(err, check.IsNil)
+	c.Assert(byPool, check.HasLen, 1)
+	c.Assert(byPool[0].Name, check.Equals, "alpha")
+
+	byName, err := s.JobStorage.ListByFilter(context.TODO(), &jobTypes.Filter{Name: "bet"})
+	c.Assert(err, check.IsNil)
+	c.Assert(byName, check.HasLen, 1)
+	c.Assert(byName[0].Name, check.Equals, "beta")
+}

--- a/types/job/job.go
+++ b/types/job/job.go
@@ -71,6 +71,23 @@ type Filter struct {
 	Extra     map[string][]string
 }
 
+// JobStorage is the persistence boundary for jobs.
+type JobStorage interface {
+	// Insert persists a new job. Returns ErrJobAlreadyExists if a job with the
+	// same name already exists.
+	Insert(ctx context.Context, job Job) error
+	// Update replaces an existing job by name. Returns ErrJobNotFound if absent.
+	Update(ctx context.Context, job Job) error
+	// FindByName returns the job, or ErrJobNotFound.
+	FindByName(ctx context.Context, name string) (*Job, error)
+	// ListByFilter returns jobs matching filter (nil filter returns all).
+	ListByFilter(ctx context.Context, filter *Filter) ([]Job, error)
+	// Delete removes a job by name. Returns ErrJobNotFound if absent.
+	Delete(ctx context.Context, name string) error
+	// UpdateServiceEnvs sets the spec.serviceenvs field for the named job.
+	UpdateServiceEnvs(ctx context.Context, name string, serviceEnvs []bindTypes.ServiceEnvVar) error
+}
+
 type AddInstanceArgs struct {
 	Envs   []bindTypes.ServiceEnvVar
 	Writer io.Writer

--- a/types/job/job_query.go
+++ b/types/job/job_query.go
@@ -1,0 +1,81 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package job
+
+import (
+	"strings"
+
+	"github.com/tsuru/tsuru/types/query"
+)
+
+func processTags(tags []string) []string {
+	if tags == nil {
+		return nil
+	}
+	processed := []string{}
+	seen := map[string]bool{}
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if len(tag) > 0 && !seen[tag] {
+			processed = append(processed, tag)
+			seen[tag] = true
+		}
+	}
+	return processed
+}
+
+// ToQuery converts the domain filter into a backend-neutral query.Query.
+func (f *Filter) ToQuery() query.Query {
+	q := query.Query{}
+	if f == nil {
+		return q
+	}
+	if f.Extra != nil {
+		for field, values := range f.Extra {
+			anyVals := make([]any, len(values))
+			for i, v := range values {
+				anyVals[i] = v
+			}
+			q.Or = append(q.Or, query.Query{In: map[string][]any{field: anyVals}})
+		}
+	}
+	if f.Name != "" {
+		q.Regex = map[string]string{"name": f.Name}
+	}
+	if f.TeamOwner != "" {
+		q.Eq = ensureMap(q.Eq)
+		q.Eq["teamowner"] = f.TeamOwner
+	}
+	if f.UserOwner != "" {
+		q.Eq = ensureMap(q.Eq)
+		q.Eq["owner"] = f.UserOwner
+	}
+	if f.Pool != "" {
+		q.Eq = ensureMap(q.Eq)
+		q.Eq["pool"] = f.Pool
+	}
+	if len(f.Pools) > 0 {
+		anyVals := make([]any, len(f.Pools))
+		for i, v := range f.Pools {
+			anyVals[i] = v
+		}
+		q.In = map[string][]any{"pool": anyVals}
+	}
+	if tags := processTags(f.Tags); len(tags) > 0 {
+		allVals := make([]any, len(tags))
+		for i, v := range tags {
+			allVals[i] = v
+		}
+		q.All = map[string][]any{"tags": allVals}
+	}
+	return q
+}
+
+func ensureMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	return m
+}

--- a/types/job/job_query_test.go
+++ b/types/job/job_query_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package job
+
+import (
+	"testing"
+)
+
+func TestFilterToQueryNil(t *testing.T) {
+	var f *Filter
+	if !f.ToQuery().IsEmpty() {
+		t.Fatal("nil filter should produce empty query")
+	}
+}
+
+func TestFilterToQueryFields(t *testing.T) {
+	f := &Filter{Name: "web", TeamOwner: "t1", Pool: "p1", Tags: []string{"a", "a", "b"}}
+	q := f.ToQuery()
+	if q.Regex["name"] != "web" {
+		t.Fatalf("name regex: got %q", q.Regex["name"])
+	}
+	if q.Eq["teamowner"] != "t1" {
+		t.Fatalf("teamowner: got %v", q.Eq["teamowner"])
+	}
+	if q.Eq["pool"] != "p1" {
+		t.Fatalf("pool: got %v", q.Eq["pool"])
+	}
+	if len(q.All["tags"]) != 2 {
+		t.Fatalf("tags should be deduped to 2, got %v", q.All["tags"])
+	}
+}
+
+func TestFilterToQueryPools(t *testing.T) {
+	f := &Filter{Pools: []string{"p1", "p2"}}
+	q := f.ToQuery()
+	if len(q.In["pool"]) != 2 {
+		t.Fatalf("pools In: got %v", q.In["pool"])
+	}
+}

--- a/types/query/query.go
+++ b/types/query/query.go
@@ -1,0 +1,29 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query defines a backend-neutral query specification that storage
+// adapters (mongodb, postgres) translate into their native query language.
+package query
+
+// Query is a conjunction (AND) of the populated clauses. Empty Query matches
+// everything. Field names are the document field names as stored by the
+// adapter.
+type Query struct {
+	// Eq matches field == value.
+	Eq map[string]any
+	// In matches field ∈ values.
+	In map[string][]any
+	// Regex matches field against an (unanchored) regular expression.
+	Regex map[string]string
+	// All matches array fields that contain every listed value.
+	All map[string][]any
+	// Or, when non-empty, is OR-combined with the rest of this Query.
+	Or []Query
+}
+
+// IsEmpty reports whether the query has no clauses (matches everything).
+func (q Query) IsEmpty() bool {
+	return len(q.Eq) == 0 && len(q.In) == 0 && len(q.Regex) == 0 &&
+		len(q.All) == 0 && len(q.Or) == 0
+}


### PR DESCRIPTION
## What

Decouples job persistence from MongoDB and proves a PostgreSQL adapter end-to-end on a single pilot entity (**Job**), establishing a repeatable template for the remaining entities.

Today tsuru has two persistence layers: a clean `DbDriver` interface registry (`storage/driver.go`, 17 domains) and a raw `*mongo.Collection` layer (`db/storagev2`) that the core entities (App, Service, Job, User, Event) bypass with inline `bson` queries in business logic. This PR takes Job — the smallest of those core entities — and:

1. **Hides it behind a `JobStorage` interface** (`types/job/job.go`), registered in `DbDriver`.
2. **Replaces its inline `bson` search with a backend-neutral query spec** (`types/query`), which each adapter translates into its own dialect.
3. **Adds a PostgreSQL adapter** validated by the *same* behavioral suite the Mongo adapter passes.

No behavior change for existing deployments: MongoDB remains the only registered driver.

## How

**Backend-neutral queries.** `jobTypes.Filter.ToQuery()` produces a `query.Query` (a conjunction of `Eq` / `In` / `Regex` / `All` clauses, plus `Or`). `storage/mongodb/query.go` translates it to `bson.M`; `storage/postgres/query.go` translates it to a SQL `WHERE` fragment with positional args. The old `filterQuery` in `job/job.go` is gone.

**Postgres schema — JSONB document mirror.** The full entity is stored in a `doc jsonb` column, with a few promoted, indexed columns (`name`, `team_owner`, `owner`, `pool`, `tags`) backing hot predicates. This keeps DDL tiny while porting, and the query translator targets the promoted columns, falling back to `doc->>'field'` for anything else.

**Behavioral parity is enforced by construction.** `storage/storagetest/job_suite.go` is a backend-agnostic suite (10 tests: insert, duplicate, find, update, delete, not-found paths, service envs, list + filtered list). Both `storage/mongodb/job_test.go` and `storage/postgres/job_test.go` run it against their adapter.

**The `job` package no longer imports mongo.** `job/job.go` and `job/actions.go` go through `JobStorage`; `bson`, `mongo`, and `storagev2` imports are dropped from the package entirely.

## Notes for reviewers

- **`ServiceEnvs` round-trip.** `JobSpec.ServiceEnvs` is tagged `json:"-"`, and `bind.ServiceEnvVar.ServiceName`/`InstanceName` are too — so a naive JSON encode silently drops them. Rather than change the public API's JSON contract, `storage/postgres/job.go` marshals through a storage-side `jobDoc`/`serviceEnvVar` pair that carries those fields under storage-only keys. Mongo is unaffected (bson ignores json tags).
- **`insertJobDB` is now race-free.** It previously did check-then-insert; it now relies on the existing unique index on `name` and maps the duplicate-key error to `ErrJobAlreadyExists`.
- **`UpdateServiceEnvs` on Postgres is read-modify-write**, versus Mongo's `$set`. Acceptable for the pilot; the code notes the `jsonb_set` path if Job ever needs concurrency-safe partial updates.
- **The Postgres driver is deliberately NOT registered** as a `DbDriver`. Every other domain is still Mongo-only, and a partially-populated driver would panic with a nil field at first use. The adapter is exercised directly by its test suite, exactly as Mongo's is. Registration comes once all domains have an implementation.
- **Schema bootstrap is a `CREATE TABLE IF NOT EXISTS`** on first connect, not a migration tool. Deliberate for the pilot; a real migration tool is a tracked follow-up.

## Testing

```bash
docker compose up -d mongo postgres
go test ./...
```

Full suite green (67 packages). The shared `JobSuite` passes 10/10 on **both** backends — same tests, same expectations, two storage engines.

Postgres tests default to the compose service on `localhost:5432`; set `TSURU_POSTGRES_TEST_URL` to point elsewhere, and `TSURU_POSTGRES_PORT` to remap the compose port if 5432 is taken locally.

## Follow-ups (not in this PR)

- Repeat the slice for the remaining core entities (User/auth → Service → Event → App), each as its own PR.
- The already-interface-backed domains (team, plan, pool, volume, …) need only a Postgres implementation plus their existing `storagetest` suite.
- Register the full Postgres driver once every `DbDriver` field has an implementation; then `database:driver: postgres` selects it.
- Replace the DDL bootstrap with a migration tool; add a Postgres healthcheck and pool instrumentation mirroring the Mongo command monitor.
