### PR TITLE
fix: make lint and locale-dependent check scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ PLATFORMS_DIR = /tmp/platforms
 TSR_SRC       = ./cmd/tsurud
 GIT_TAG_VER   := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "$${TSURU_BUILD_VERSION:-dev}")
 
+# Keep in sync with the golangci-lint-action version in .github/workflows/ci.yaml.
+GOLANGCI_LINT_VERSION ?= v2.11.4
+
 ifeq (, $(shell go env GOBIN))
 GOBIN := $(shell go env GOPATH)/bin
 else
@@ -36,9 +39,8 @@ lint: metalint yamllint
 	misc/check-contributors.sh
 
 metalint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.45.2
-	echo "$$(go list ./... | grep -v /vendor/)" | sed 's|github.com/tsuru/tsuru/|./|' | xargs -t -n 4 \
-		time golangci-lint run -c ./.golangci.yml
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	golangci-lint run --timeout=10m ./...
 
 yamlfmt: ## Format your code with yamlfmt
 ifeq (, $(shell which yamlfmt))

--- a/misc/check-events.sh
+++ b/misc/check-events.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# sort(1) output below is consumed by comm(1), which requires both inputs to
+# share a collation order. Locales such as en_US.UTF-8 make comm reject the
+# input with "file 1 is not in sorted order".
+export LC_ALL=C
+
 ignored=$(
   cat <<EOF
 github.com/tsuru/tsuru/api.registerUnit

--- a/misc/check-handlers.sh
+++ b/misc/check-handlers.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# sort(1) output below is consumed by comm(1), which requires both inputs to
+# share a collation order. Locales such as en_US.UTF-8 make comm reject the
+# input with "file 1 is not in sorted order".
+export LC_ALL=C
+
 function check_go {
     set +e
     version=$(go version | grep -o 'go1.5')


### PR DESCRIPTION
Two independent repairs to existing tooling. No change to application code or behavior.

## `make lint` cannot run

`metalint` installs golangci-lint **v1.45.2** (released 2022) and points it at `.golangci.yml`, which is in the v2 format (`version: "2"`, plus a `formatters:` section). That release predates the format and cannot parse it, so `make lint` fails before linting anything.

The target now installs the same version CI uses via `golangci-lint-action` (v2.11.4), pinned in one place and commented to stay in sync. `go install` also matches how this Makefile already installs `yamlfmt`, `swagger` and `tsuru-api-docs`, and removes a `curl | sh` fetched from the installer's `master` branch.

```
$ make metalint
golangci-lint run --timeout=10m ./...
0 issues.
```

## Check scripts fail outside the C locale

`check-handlers.sh` and `check-events.sh` pipe `sort` output into `comm`, which requires both inputs to share a collation order. GitHub runners default to the C locale, so CI is green; on a developer machine with `LANG=en_US.UTF-8` both scripts abort:

```
comm: file 1 is not in sorted order
comm: input is not in sorted order
```

Same machine, same locale, before and after:

| | `LANG=en_US.UTF-8` |
|---|---|
| `check-handlers.sh` before | exit 1, `comm: file 1 is not in sorted order` |
| `check-handlers.sh` after | exit 0 |
| `check-events.sh` after | exit 0 |

Both scripts now `export LC_ALL=C`. The fix is in the scripts rather than the Makefile because CI invokes them directly (`.github/workflows/ci.yaml`), so a Makefile-level fix would not reach the failing path.
