### PR TITLE
bump: Go toolchain to 1.26.6 to fix 6 standard library vulnerabilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
         version: v3.14.3
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/cache@v4
       with:
         path: |
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - run: make yamllint
     - uses: golangci/golangci-lint-action@v8
@@ -96,7 +96,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
     - name: Run govulncheck
@@ -111,7 +111,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -125,7 +125,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -139,7 +139,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -153,7 +153,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - run: make validate-api-spec
   verify-codegen:
@@ -161,7 +161,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tsuru/tsuru
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/adhocore/gronx v1.6.6


### PR DESCRIPTION
The `govulncheck` CI job currently fails on `main`, reporting six Go standard library vulnerabilities. All six are fixed in go1.26.6, which this bumps the pinned toolchain to.

| ID | Package | Summary |
|---|---|---|
| GO-2026-6218 | `net/url` | Quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template` | Javascript regexp context tracking |
| GO-2026-6090 | `crypto/tls` | Unbounded post-handshake messages |
| GO-2026-6089 | `net/http` | `ReadHeaderTimeout` not applied on unencrypted HTTP/2 check |
| GO-2026-5972 | `encoding/asn1` | Unbounded recursion depth |
| GO-2026-5026 | `net/http` (`x/net/idna`) | ASCII-only Punycode labels not rejected |

Each is reachable from application code — for example `app.SetCertificate` → `x509.ParseCertificate` → `asn1.Unmarshal` for GO-2026-5972, and `api.start` → `http.Server.ListenAndServe` for GO-2026-6089.

## Change

`go.mod` and the nine `go-version` pins in `.github/workflows/ci.yaml` move from `1.26.5` to `1.26.6`. No source changes.

## Verification

On go1.26.6, same tree:

```
$ ./misc/govulncheck.sh
No vulnerabilities found.
```

| | before (go1.26.5) | after (go1.26.6) |
|---|---|---|
| `misc/govulncheck.sh` | exit 1, 6 vulnerabilities | exit 0, none |
| `go build ./...` | exit 0 | exit 0 |
| `go vet ./...` | exit 0 | exit 0 |
| `make test` | exit 0 | exit 0 |
