### PR TITLE
fix(ci): integration test race and bump Go to 1.26.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
         version: v3.14.3
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/cache@v4
       with:
         path: |
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - run: make yamllint
     - uses: golangci/golangci-lint-action@v8
@@ -96,7 +96,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
     - name: Run govulncheck
@@ -111,7 +111,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -125,7 +125,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -139,7 +139,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:
@@ -153,7 +153,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - run: make validate-api-spec
   verify-codegen:
@@ -161,7 +161,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.26.5"
+        go-version: "1.26.6"
     - uses: actions/checkout@v4
     - uses: actions/cache@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG alpine_version=3.23
-ARG golang_version=1.26.5
+ARG golang_version=1.26.6
 
 FROM golang:${golang_version}-alpine${alpine_version} AS builder
 RUN apk add --update --no-cache bash make git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tsuru/tsuru
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/adhocore/gronx v1.6.6

--- a/scripts/localkube-integration.sh
+++ b/scripts/localkube-integration.sh
@@ -130,7 +130,11 @@ main() {
   install_tsuru_stack
   install_kedacore
 
-  sleep 30
+  # Both releases are installed with --wait, so everything should already be
+  # ready here. This is a cheap backstop for objects the charts do not gate on,
+  # and it fails with the name of the offending pod instead of surfacing later
+  # as a connection refused from inside a test.
+  ${KUBECTL} -n ${NAMESPACE} wait --for=condition=Ready pod --all --timeout=10m
 
   local_tsuru_api_port=8080
   DEBUG="" ${KUBECTL} -n ${NAMESPACE} port-forward svc/tsuru-api ${local_tsuru_api_port}:80 --address=127.0.0.1 &

--- a/scripts/localkube-integration.sh
+++ b/scripts/localkube-integration.sh
@@ -71,7 +71,7 @@ install_tsuru_stack() {
     --set tsuru-api.image.pullPolicy=Never \
     --set tsuru-api.service.type=ClusterIP \
     --set tsuru-api.tsuruConfig.debug=true \
-    --timeout 5m \
+    --wait --timeout 10m \
     tsuru tsuru/tsuru-stack
 }
 
@@ -80,7 +80,8 @@ install_kedacore() {
 
   ${HELM} repo add --force-update kedacore https://kedacore.github.io/charts
 
-  ${HELM} install keda kedacore/keda --namespace tsuru-system --version 2.11.1
+  ${HELM} install keda kedacore/keda --namespace tsuru-system --version 2.11.1 \
+    --wait --timeout 5m
 }
 
 build_tsuru_api_container_image() {


### PR DESCRIPTION
CI is currently red on `main` for two independent reasons. This fixes both, because neither can be verified green on its own — a PR fixing only one still shows the other as failing.

## 1. Integration tests race the stack coming up

The `integration` jobs fail on every PR, on both k8s 1.33 and 1.34, with:

```
[tsuru platform add go-iplat -i tsuru/go]: Error: rpc error: code = Unavailable
desc = connection error: desc = "transport: Error while dialing:
dial tcp 10.109.155.230:80: connect: connection refused"
FAIL: install_test.go:733: S.TestBase
```

`10.109.155.230` is the `tsuru-deploy-agent` ClusterIP. The pod dump in the same log shows `tsuru-deploy-agent-0` at `0/2 Running` — the suite starts before the stack is ready.

### Cause

`install_tsuru_stack` passes `--timeout 5m` but not `--wait`. Per `helm install --help`:

> `--wait` — if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. **It will wait for as long as `--timeout`**
>
> `--timeout duration` — time to wait for any individual Kubernetes operation (like Jobs for hooks) **(default 5m0s)**

So `--timeout 5m` is a no-op twice over: it only gates readiness alongside `--wait`, and `5m` is already the default. `install_kedacore` passes neither flag. That leaves `sleep 30` as the only gate, giving the whole stack roughly 44s (the sleep plus port-forward, login and client download) before `make test-ci-integration` runs.

### Measurements

Reproduced on minikube with k8s 1.34, 4 CPUs / 8 GiB, cold image cache:

| | helm returned | pods not ready at that moment |
|---|---|---|
| `--timeout 5m` (current) | exit 0 after **16s** | **7 of 7**, all `ContainerCreating` |
| actual readiness of `tsuru-deploy-agent-0` | — | Ready at **71s** |
| `--wait --timeout 10m` (this PR) | exit 0 after 24s | **0 of 7** |

The current invocation reports success 16 seconds in, with nothing running. Readiness actually takes ~71s on a 16-core workstation, against a ~44s budget in CI — the margin is negative even under favourable conditions, and a hosted runner is slower. The last green run on `main` (`f95e3171c`, Aug 12) was luck, not headroom.

The third row's 24s is not comparable to the other timings — images were cached by then. The meaningful result is the readiness column.

### Change

- `--wait --timeout 10m` on the tsuru-stack release, `--wait --timeout 5m` on keda.
- `sleep 30` replaced by `kubectl wait --for=condition=Ready pod --all`.

One consequence worth flagging: with `--wait`, helm blocks on LoadBalancer services acquiring an ingress address. The script already starts `minikube tunnel` before `install_tsuru_stack`, so this is satisfied — but if the tunnel ever fails to come up, the install will now block until the timeout rather than racing ahead. That is a better failure mode, and the 10m timeout is sized for it.

## 2. govulncheck reports six standard library vulnerabilities

All six are fixed in go1.26.6, which this bumps the pinned toolchain to.

| ID | Package | Summary |
|---|---|---|
| GO-2026-6218 | `net/url` | Quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template` | Javascript regexp context tracking |
| GO-2026-6090 | `crypto/tls` | Unbounded post-handshake messages |
| GO-2026-6089 | `net/http` | `ReadHeaderTimeout` not applied on unencrypted HTTP/2 check |
| GO-2026-5972 | `encoding/asn1` | Unbounded recursion depth |
| GO-2026-5026 | `net/http` (`x/net/idna`) | ASCII-only Punycode labels not rejected |

Each is reachable from application code — for example `app.SetCertificate` → `x509.ParseCertificate` → `asn1.Unmarshal` for GO-2026-5972, and `api.start` → `http.Server.ListenAndServe` for GO-2026-6089.

`go.mod` and the nine `go-version` pins in `.github/workflows/ci.yaml` move from `1.26.5` to `1.26.6`. No source changes.

```
$ ./misc/govulncheck.sh
No vulnerabilities found.
```

## Verification

The integration fix was already confirmed green on this branch before the toolchain commit was added — `integration (1.33)` and `integration (1.34)` both passed a full ~37 minute run, having previously failed at ~4m30s on every PR.

Locally, on go1.26.6: `go build ./...`, `go vet ./...`, `make test` and `./misc/govulncheck.sh` all pass.
