### PR TITLE
fix(makefile): run golangci-lint from GOBIN instead of PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: metalint yamllint
 
 metalint:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	golangci-lint run --timeout=10m ./...
+	$(GOBIN)/golangci-lint run --timeout=10m ./...
 
 yamlfmt: ## Format your code with yamlfmt
 ifeq (, $(shell which yamlfmt))


### PR DESCRIPTION
Follow-up to #2898.

`metalint` installs the linter with `go install`, which writes it to `GOBIN` (or `$(go env GOPATH)/bin` when `GOBIN` is unset), and then invokes it by bare name. That only resolves when `GOPATH/bin` is on `PATH`, so on a machine that carries just the Go toolchain on `PATH` the target installs the pinned version and immediately fails:

```
go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
golangci-lint run --timeout=10m ./...
/bin/bash: golangci-lint: command not found
make: *** [metalint] Error 127
```

The Makefile already computes `GOBIN` for exactly this, honoring `go env GOBIN` and falling back to `$(go env GOPATH)/bin`, and the `swagger` target invokes its tool as `$(GOBIN)/swagger`. This applies the same pattern.

CI is unaffected: the lint job runs `golangci-lint-action`, not this target.

## Test plan

- [x] `make metalint` with `GOPATH/bin` absent from `PATH`: installs v2.11.4 and reports `0 issues` (previously `command not found`)
- [x] `GOBIN=/tmp/gobin-check make metalint`: installs into and runs from that directory, `0 issues`