### PR TITLE
modernize: replace interface{} with any across the tree

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -19,7 +19,7 @@ import (
 
 // Result is the value returned by Forward. It is used in the call of the next
 // action, and also when rolling back the actions.
-type Result interface{}
+type Result any
 
 // Forward is the function called by the pipeline executor in the forward
 // phase.  It receives a FWContext instance, that contains the list of
@@ -43,7 +43,7 @@ type FWContext struct {
 	Previous Result
 
 	// List of parameters given to the executor.
-	Params []interface{}
+	Params []any
 }
 
 // BWContext is the context used in calls to Backward functions (backward
@@ -54,7 +54,7 @@ type BWContext struct {
 	FWResult Result
 
 	// List of parameters given to the executor.
-	Params []interface{}
+	Params []any
 }
 
 // Action defines actions that should be . It is composed of two functions:
@@ -139,7 +139,7 @@ func (p *Pipeline) Result() Result {
 //
 // After rolling back all completed actions, it returns the original error
 // returned by the action that failed.
-func (p *Pipeline) Execute(ctx context.Context, params ...interface{}) (err error) {
+func (p *Pipeline) Execute(ctx context.Context, params ...any) (err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -196,7 +196,7 @@ func (p *Pipeline) Execute(ctx context.Context, params ...interface{}) (err erro
 	return nil
 }
 
-func (p *Pipeline) rollback(ctx context.Context, index int, params []interface{}) {
+func (p *Pipeline) rollback(ctx context.Context, index int, params []any) {
 	tracer := otel.Tracer("tsuru/action")
 	bwCtx := BWContext{Params: params}
 	for i := index; i >= 0; i-- {

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -31,7 +31,7 @@ func (s *S) TestSuccessAndParameters(c *check.C) {
 	actions := []*Action{
 		{
 			Forward: func(ctx FWContext) (Result, error) {
-				c.Assert(ctx.Params, check.DeepEquals, []interface{}{"hello"})
+				c.Assert(ctx.Params, check.DeepEquals, []any{"hello"})
 
 				currentSpan := trace.SpanFromContext(ctx.Context)
 				c.Assert(currentSpan, check.Not(check.IsNil))
@@ -53,7 +53,7 @@ func (s *S) TestRollback(c *check.C) {
 				return "ok", nil
 			},
 			Backward: func(ctx BWContext) {
-				c.Assert(ctx.Params, check.DeepEquals, []interface{}{"hello", "world"})
+				c.Assert(ctx.Params, check.DeepEquals, []any{"hello", "world"})
 				c.Assert(ctx.FWResult, check.DeepEquals, "ok")
 
 				currentSpan := trace.SpanFromContext(ctx.Context)
@@ -82,7 +82,7 @@ func (s *S) TestRollbackOnPanic(c *check.C) {
 				return "ok", nil
 			},
 			Backward: func(ctx BWContext) {
-				c.Assert(ctx.Params, check.DeepEquals, []interface{}{"hello", "world"})
+				c.Assert(ctx.Params, check.DeepEquals, []any{"hello", "world"})
 				c.Assert(ctx.FWResult, check.DeepEquals, "ok")
 				backwardCalled = true
 			},

--- a/api/apitest/setup.go
+++ b/api/apitest/setup.go
@@ -34,7 +34,7 @@ type MultiTestHandler struct {
 	Method             []string
 	URL                []string
 	Content            string
-	ConditionalContent map[string]interface{}
+	ConditionalContent map[string]any
 	Header             []http.Header
 	RspCode            int
 	RspHeader          http.Header

--- a/api/app.go
+++ b/api/app.go
@@ -488,7 +488,7 @@ func createApp(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 		}
 		return err
 	}
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"status": "success",
 	}
 	addrs, err := app.GetAddresses(ctx, a)
@@ -820,7 +820,7 @@ func killUnit(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) 
 		Kind:       permission.PermAppUpdateUnitKill,
 		Owner:      t,
 		RemoteAddr: r.RemoteAddr,
-		CustomData: []map[string]interface{}{
+		CustomData: []map[string]any{
 			{
 				"unit":  unitName,
 				"force": force,
@@ -1432,7 +1432,7 @@ func appLog(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 }
 
 type msgEncoder interface {
-	Encode(interface{}) error
+	Encode(any) error
 }
 
 func followLogs(ctx stdContext.Context, appName string, watcher appTypes.LogWatcher, encoder msgEncoder) error {

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -744,7 +744,7 @@ func (s *S) TestDelete(c *check.C) {
 		Target: appTarget(myApp.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": myApp.Name},
 		},
 	}, eventtest.HasEvent)
@@ -780,7 +780,7 @@ func (s *S) TestDeleteVersion(c *check.C) {
 		Target: appTarget(myApp.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": myApp.Name},
 			{"name": ":version", "value": "2"},
 			{"name": ":mux-path-template", "value": "/apps/{app}/versions/{version}"},
@@ -841,7 +841,7 @@ func (s *S) TestAppInfo(c *check.C) {
 	expectedApp := appTypes.App{Name: "new-app", Platform: "zend", TeamOwner: s.team.Name}
 	err := app.CreateApp(ctx, &expectedApp, s.user)
 	c.Assert(err, check.IsNil)
-	var myApp map[string]interface{}
+	var myApp map[string]any
 	request, err := http.NewRequest("GET", "/apps/"+expectedApp.Name+"?:app="+expectedApp.Name, nil)
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", "b "+s.token.GetValue())
@@ -944,7 +944,7 @@ func (s *S) TestCreateAppRemoveRole(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 		},
@@ -993,7 +993,7 @@ func (s *S) TestCreateApp(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 		},
@@ -1037,7 +1037,7 @@ func (s *S) TestCreateAppWithoutPlatform(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 		},
 	}, eventtest.HasEvent)
@@ -1098,7 +1098,7 @@ func (s *S) TestCreateAppTeamOwner(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 			{"name": "teamOwner", "value": t1.Name},
@@ -1143,7 +1143,7 @@ func (s *S) TestCreateAppAdminSingleTeam(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 		},
@@ -1192,7 +1192,7 @@ func (s *S) TestCreateAppCustomPlan(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 			{"name": "plan", "value": "myplan"},
@@ -1237,7 +1237,7 @@ func (s *S) TestCreateAppWithDescription(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": a.Name},
 			{"name": "platform", "value": "zend"},
 			{"name": "description", "value": "my app description"},
@@ -1281,7 +1281,7 @@ func (s *S) TestCreateAppWithTags(c *check.C) {
 		Target: appTarget("someapp"),
 		Kind:   "app.create",
 		Owner:  token.GetUserName(),
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "someapp"},
 			{"name": "platform", "value": "zend"},
 			{"name": "tag", "value": []string{"tag1", "tag2"}},
@@ -1365,7 +1365,7 @@ func (s *S) TestCreateAppWithMetadata(c *check.C) {
 		Target: appTarget("someapp"),
 		Kind:   "app.create",
 		Owner:  token.GetUserName(),
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "someapp"},
 			{"name": "platform", "value": "zend"},
 		},
@@ -1414,7 +1414,7 @@ func (s *S) TestCreateAppWithPool(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": appName},
 			{"name": "platform", "value": platName},
 			{"name": "pool", "value": "mypool1"},
@@ -1554,7 +1554,7 @@ func (s *S) TestCreateAppUserQuotaExceeded(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "someapp"},
 			{"name": "platform", "value": "zend"},
 		},
@@ -1584,7 +1584,7 @@ func (s *S) TestCreateAppInvalidName(c *check.C) {
 		Target: appTarget("123myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "123myapp"},
 			{"name": "platform", "value": "zend"},
 		},
@@ -1671,7 +1671,7 @@ func (s *S) TestCreateAppWithDisabledPlatformAndPlatformUpdater(c *check.C) {
 		Target: appTarget("someapp"),
 		Owner:  u.Email,
 		Kind:   "app.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "someapp"},
 			{"name": "platform", "value": p.Name},
 		},
@@ -1730,7 +1730,7 @@ func (s *S) TestUpdateAppWithDescriptionOnly(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "description", "value": "my app description"},
 		},
@@ -1769,7 +1769,7 @@ func (s *S) TestUpdateAppPlatformOnly(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "platform", "value": "heimerdinger"},
 		},
@@ -1813,7 +1813,7 @@ func (s *S) TestUpdateAppPlatformWithVersion(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "platform", "value": "myplatform:v1"},
 		},
@@ -1852,7 +1852,7 @@ func (s *S) TestUpdateAppWithTagsOnly(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "tag", "value": []string{"tag1", "tag2", "tag3"}},
 			{"name": "tags.0", "value": "tag0"},
@@ -1950,7 +1950,7 @@ func (s *S) TestUpdateAppWithAnnotations(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 		},
 	}, eventtest.HasEvent)
@@ -1995,7 +1995,7 @@ func (s *S) TestUpdateAppWithLabels(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 		},
 	}, eventtest.HasEvent)
@@ -2076,7 +2076,7 @@ func (s *S) TestUpdateAppWithCustomPlanByProcess(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "processes.0.name", "value": "web"},
 			{"name": "processes.0.plan", "value": "c1m1"},
@@ -2137,7 +2137,7 @@ func (s *S) TestUpdateAppWithResetPlanByProcess(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "processes.0.name", "value": "web"},
 			{"name": "processes.0.plan", "value": "$default"},
@@ -2493,7 +2493,7 @@ func (s *S) TestAddUnits(c *check.C) {
 		Target:          appTarget("armorandsword"),
 		Owner:           s.token.GetUserName(),
 		Kind:            "app.update.unit.add",
-		StartCustomData: []map[string]interface{}{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
+		StartCustomData: []map[string]any{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
 	}, eventtest.HasEvent)
 	c.Assert(recorder.Body.String(), check.Matches, `{"Message":".*added 3 units","Timestamp":".*"}`+"\n")
 }
@@ -2526,7 +2526,7 @@ func (s *S) TestAddUnitsUnlimited(c *check.C) {
 		Target:          appTarget("armorandsword"),
 		Owner:           s.token.GetUserName(),
 		Kind:            "app.update.unit.add",
-		StartCustomData: []map[string]interface{}{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
+		StartCustomData: []map[string]any{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
 	}, eventtest.HasEvent)
 	c.Assert(recorder.Body.String(), check.Matches, `{"Message":".*added 3 units","Timestamp":".*"}`+"\n")
 }
@@ -2611,7 +2611,7 @@ func (s *S) TestAddUnitsWorksIfProcessIsOmitted(c *check.C) {
 		Target:          appTarget("armorandsword"),
 		Owner:           s.token.GetUserName(),
 		Kind:            "app.update.unit.add",
-		StartCustomData: []map[string]interface{}{{"name": "units", "value": "3"}, {"name": "process", "value": ""}, {"name": ":app", "value": "armorandsword"}},
+		StartCustomData: []map[string]any{{"name": "units", "value": "3"}, {"name": "process", "value": ""}, {"name": ":app", "value": "armorandsword"}},
 	}, eventtest.HasEvent)
 }
 
@@ -2654,7 +2654,7 @@ func (s *S) TestAddUnitsQuotaExceeded(c *check.C) {
 		Target:          appTarget("armorandsword"),
 		Owner:           s.token.GetUserName(),
 		Kind:            "app.update.unit.add",
-		StartCustomData: []map[string]interface{}{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
+		StartCustomData: []map[string]any{{"name": "units", "value": "3"}, {"name": "process", "value": "web"}, {"name": ":app", "value": "armorandsword"}},
 		ErrorMatches:    `Quota exceeded. Available: 2, Requested: 3.`,
 	}, eventtest.HasEvent)
 }
@@ -2688,7 +2688,7 @@ func (s *S) TestRemoveUnits(c *check.C) {
 		Target: appTarget("velha"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.unit.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "units", "value": "2"},
 			{"name": "process", "value": "web"},
 			{"name": ":app", "value": "velha"},
@@ -2771,7 +2771,7 @@ func (s *S) TestRemoveUnitsWorksIfProcessIsOmitted(c *check.C) {
 		Target: appTarget("velha"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.unit.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "units", "value": "2"},
 			{"name": "process", "value": ""},
 			{"name": ":app", "value": "velha"},
@@ -2825,7 +2825,7 @@ func (s *S) TestAddTeamToTheApp(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.grant",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": s.team.Name},
 			{"name": ":app", "value": a.Name},
 		},
@@ -2897,7 +2897,7 @@ func (s *S) TestGrantAccessToTeamReturn409IfTheTeamHasAlreadyAccessToTheApp(c *c
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.grant",
 		ErrorMatches: "team already have access to this app",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": s.team.Name},
 			{"name": ":app", "value": a.Name},
 		},
@@ -2926,7 +2926,7 @@ func (s *S) TestRevokeAccessFromTeam(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.revoke",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": s.team.Name},
 			{"name": ":app", "value": a.Name},
 		},
@@ -3021,7 +3021,7 @@ func (s *S) TestRevokeAccessFromTeamReturn403IfTheTeamIsTheLastWithAccessToTheAp
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.revoke",
 		ErrorMatches: "You can not revoke the access from this team, because it is the unique team with access to the app, and an app can not be orphaned",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": s.team.Name},
 			{"name": ":app", "value": a.Name},
 		},
@@ -3059,7 +3059,7 @@ func (s *S) TestRunOnce(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.run",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "command", "value": "ls"},
 			{"name": "once", "value": "true"},
 			{"name": ":app", "value": a.Name},
@@ -3097,7 +3097,7 @@ func (s *S) TestRun(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.run",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "command", "value": "ls"},
 			{"name": ":app", "value": a.Name},
 		},
@@ -3131,7 +3131,7 @@ func (s *S) TestRunIsolated(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.run",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "command", "value": "ls"},
 			{"name": "isolated", "value": "true"},
 			{"name": ":app", "value": a.Name},
@@ -3161,7 +3161,7 @@ func (s *S) TestRunReturnsTheOutputOfTheCommandEvenIfItFails(c *check.C) {
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.run",
 		ErrorMatches: "something went wrong",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "command", "value": "ls"},
 			{"name": ":app", "value": a.Name},
 		},
@@ -3330,13 +3330,13 @@ func (s *S) TestGetEnv(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	expected := []map[string]interface{}{{
+	expected := []map[string]any{{
 		"name":   "DATABASE_HOST",
 		"value":  "localhost",
 		"public": true,
 		"alias":  "",
 	}}
-	result := []map[string]interface{}{}
+	result := []map[string]any{}
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.DeepEquals, expected)
@@ -3364,11 +3364,11 @@ func (s *S) TestGetEnvMultipleVariables(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-type"), check.Equals, "application/json")
-	expected := []map[string]interface{}{
+	expected := []map[string]any{
 		{"name": "DATABASE_HOST", "value": "localhost", "public": true, "alias": ""},
 		{"name": "DATABASE_USER", "value": "root", "public": true, "alias": ""},
 	}
-	var got []map[string]interface{}
+	var got []map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &got)
 	c.Assert(err, check.IsNil)
 	c.Assert(got, check.DeepEquals, expected)
@@ -3464,7 +3464,7 @@ func (s *S) TestSetEnvPublicEnvironmentVariableInTheApp(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "localhost"},
@@ -3517,7 +3517,7 @@ func (s *S) TestSetEnvPublicAndPrivate(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -3588,7 +3588,7 @@ func (s *S) TestSetEnvCanPruneOldVariables(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -3650,7 +3650,7 @@ func (s *S) TestSetEnvCanPruneAllVariables(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "NoRestart", "value": ""},
 			{"name": "Private", "value": ""},
@@ -3740,7 +3740,7 @@ func (s *S) TestSetEnvPublicEnvironmentVariableAlias(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Alias", "value": "MY_DB_HOST"},
@@ -3786,7 +3786,7 @@ func (s *S) TestSetEnvHandlerShouldSetAPrivateEnvironmentVariableInTheApp(c *che
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -3823,7 +3823,7 @@ func (s *S) TestSetEnvHandlerShouldSetADoublePrivateEnvironmentVariableInTheApp(
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -3861,7 +3861,7 @@ func (s *S) TestSetEnvHandlerShouldSetADoublePrivateEnvironmentVariableInTheApp(
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -3907,7 +3907,7 @@ func (s *S) TestSetEnvHandlerShouldSetMultipleEnvironmentVariablesInTheApp(c *ch
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "localhost"},
@@ -4011,7 +4011,7 @@ func (s *S) TestSetEnvHandlerNoRestart(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "localhost"},
@@ -4198,7 +4198,7 @@ func (s *S) TestUnsetEnv(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.unset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "env", "value": "DATABASE_HOST"},
 			{"name": "noRestart", "value": "false"},
@@ -4242,7 +4242,7 @@ func (s *S) TestUnsetEnvNoRestart(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.unset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "env", "value": "DATABASE_HOST"},
 			{"name": "noRestart", "value": "true"},
@@ -4288,7 +4288,7 @@ func (s *S) TestUnsetEnvHandlerRemovesAllGivenEnvironmentVariables(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.env.unset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "env", "value": []string{"DATABASE_HOST", "DATABASE_USER"}},
 			{"name": "noRestart", "value": "false"},
@@ -4403,8 +4403,8 @@ func (s *S) TestAddCName(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.cname.add",
-		StartCustomData: []map[string]interface{}{
-			{"name": "cname", "value": []interface{}{"leper.secretcompany.com", "blog.tsuru.com"}},
+		StartCustomData: []map[string]any{
+			{"name": "cname", "value": []any{"leper.secretcompany.com", "blog.tsuru.com"}},
 			{"name": ":app", "value": "leper"},
 		},
 	}, eventtest.HasEvent)
@@ -4430,7 +4430,7 @@ func (s *S) TestAddCNameAcceptsWildCard(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.cname.add",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "cname", "value": "*.leper.secretcompany.com"},
 			{"name": ":app", "value": "leper"},
 		},
@@ -4456,7 +4456,7 @@ func (s *S) TestAddCNameErrsOnInvalidCName(c *check.C) {
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.cname.add",
 		ErrorMatches: "Invalid cname",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "cname", "value": "_leper.secretcompany.com"},
 			{"name": ":app", "value": "leper"},
 		},
@@ -4480,7 +4480,7 @@ func (s *S) TestAddCNameHandlerReturnsBadRequestWhenCNameIsEmpty(c *check.C) {
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.cname.add",
 		ErrorMatches: "Invalid cname",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "cname", "value": ""},
 			{"name": ":app", "value": "leper"},
 		},
@@ -4559,7 +4559,7 @@ func (s *S) TestRemoveCNameHandler(c *check.C) {
 		Target: appTarget(app.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.cname.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "cname", "value": "foo.bar.com"},
 			{"name": ":app", "value": "leper"},
 		},
@@ -4593,8 +4593,8 @@ func (s *S) TestRemoveCNameTwoCnames(c *check.C) {
 		Target: appTarget(app.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.cname.remove",
-		StartCustomData: []map[string]interface{}{
-			{"name": "cname", "value": []interface{}{"foo.bar.com", "bar.com"}},
+		StartCustomData: []map[string]any{
+			{"name": "cname", "value": []any{"foo.bar.com", "bar.com"}},
 			{"name": ":app", "value": "leper"},
 		},
 	}, eventtest.HasEvent)
@@ -5074,7 +5074,7 @@ func (s *S) TestBindHandlerEndpointIsDown(c *check.C) {
 		Owner:        s.token.GetUserName(),
 		Kind:         "app.update.bind",
 		ErrorMatches: errRegex,
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -5148,7 +5148,7 @@ func (s *S) TestBindHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.bind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -5213,7 +5213,7 @@ func (s *S) TestBindHandlerWithoutEnvsDontRestartTheApp(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.bind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -5470,7 +5470,7 @@ func (s *S) TestBindWithManyInstanceNameWithSameNameAndNoRestartFlag(c *check.C)
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.bind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance2.Name},
 			{"name": ":service", "value": instance2.ServiceName},
@@ -5570,7 +5570,7 @@ func (s *S) TestUnbindHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.unbind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -5667,7 +5667,7 @@ func (s *S) TestUnbindNoRestartFlag(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.unbind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -5766,7 +5766,7 @@ func (s *S) TestUnbindForceFlag(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update.unbind",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -6033,7 +6033,7 @@ func (s *S) TestRestartHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.restart",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 		},
 	}, eventtest.HasEvent)
@@ -6072,7 +6072,7 @@ func (s *S) TestRestartHandlerSingleProcess(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.restart",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "process", "value": "web"},
 		},
@@ -6241,7 +6241,7 @@ func (s *S) TestStartHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.start",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "process", "value": "web"},
 		},
@@ -6274,7 +6274,7 @@ func (s *S) TestStopHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.stop",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "process", "value": "web"},
 		},
@@ -6303,7 +6303,7 @@ func (s *S) TestRebuildRoutes(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.admin.routes",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "dry", "value": "true"},
 			{"name": ":app", "value": a.Name},
 		},
@@ -6330,7 +6330,7 @@ func (s *S) TestSetCertificate(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.certificate.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "cname", "value": "app.io"},
 			{"name": "certificate", "value": testCert},
@@ -6413,7 +6413,7 @@ func (s *S) TestUnsetCertificate(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.update.certificate.unset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "cname", "value": "app.io"},
 		},
@@ -6573,7 +6573,7 @@ func (s *S) TestSetCertIssuer(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "certissuer.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "cname", "value": "app.io"},
 			{"name": "issuer", "value": "letsencrypt"},
@@ -6614,7 +6614,7 @@ func (s *S) TestUnsetCertIssuer(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "certissuer.unset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "cname", "value": "app.io"},
 		},
@@ -6651,10 +6651,10 @@ func (s *S) TestUnsetCertIssuerInvalidCName(c *check.C) {
 
 type fakeEncoder struct {
 	done chan struct{}
-	msg  interface{}
+	msg  any
 }
 
-func (e *fakeEncoder) Encode(msg interface{}) error {
+func (e *fakeEncoder) Encode(msg any) error {
 	e.msg = msg
 	close(e.done)
 	return nil

--- a/api/auth.go
+++ b/api/auth.go
@@ -489,9 +489,9 @@ func teamList(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
-	var result []map[string]interface{}
+	var result []map[string]any
 	for name, permissions := range permsMap {
-		result = append(result, map[string]interface{}{
+		result = append(result, map[string]any{
 			"name":        name,
 			"tags":        teamsMap[name].Tags,
 			"permissions": permissions,
@@ -569,7 +569,7 @@ func teamInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 			}
 		}
 	}
-	result := map[string]interface{}{
+	result := map[string]any{
 		"name":  team.Name,
 		"tags":  team.Tags,
 		"users": includedUsers,

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -369,7 +369,7 @@ func (s *AuthSuite) TestCreateTeam(c *check.C) {
 		Target: teamTarget(teamName),
 		Owner:  s.token.GetUserName(),
 		Kind:   "team.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": teamName},
 			{"name": "tag", "value": []string{"tag1", "tag2"}},
 		},
@@ -423,7 +423,7 @@ func (s *AuthSuite) TestRemoveTeam(c *check.C) {
 		Target: teamTarget(teamName),
 		Owner:  s.token.GetUserName(),
 		Kind:   "team.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": teamName},
 		},
 	}, eventtest.HasEvent)
@@ -505,12 +505,12 @@ func (s *AuthSuite) TestListTeamsListsAllTeamsThatTheUserHasAccess(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var m []map[string]interface{}
+	var m []map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &m)
 	c.Assert(err, check.IsNil)
 	c.Assert(m, check.HasLen, 1)
 	c.Assert(m[0]["name"], check.Equals, s.team.Name)
-	c.Assert(m[0]["permissions"], check.DeepEquals, []interface{}{
+	c.Assert(m[0]["permissions"], check.DeepEquals, []any{
 		"app.create",
 	})
 }
@@ -532,12 +532,12 @@ func (s *AuthSuite) TestListTeamsListsShowOnlyParents(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var m []map[string]interface{}
+	var m []map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &m)
 	c.Assert(err, check.IsNil)
 	c.Assert(m, check.HasLen, 1)
 	c.Assert(m[0]["name"], check.Equals, s.team.Name)
-	c.Assert(m[0]["permissions"], check.DeepEquals, []interface{}{
+	c.Assert(m[0]["permissions"], check.DeepEquals, []any{
 		"app",
 	})
 }
@@ -552,7 +552,7 @@ func (s *AuthSuite) TestListTeamsWithAllPoweredUser(c *check.C) {
 	recorder := httptest.NewRecorder()
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
-	var m []map[string]interface{}
+	var m []map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &m)
 	c.Assert(err, check.IsNil)
 	c.Assert(m, check.HasLen, 2)
@@ -641,13 +641,13 @@ func (s *AuthSuite) TestTeamInfoReturnsAppInfoWithoutEnvironments(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 
 	var result struct {
-		Apps []map[string]interface{} `json:"apps"`
+		Apps []map[string]any `json:"apps"`
 	}
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result.Apps, check.HasLen, 1)
 	c.Assert(result.Apps[0]["name"], check.Equals, teamApp.Name)
-	c.Assert(result.Apps[0]["cname"], check.DeepEquals, []interface{}{teamApp.CName[0]})
+	c.Assert(result.Apps[0]["cname"], check.DeepEquals, []any{teamApp.CName[0]})
 	_, hasUnits := result.Apps[0]["units"]
 	c.Assert(hasUnits, check.Equals, true)
 	_, hasRouters := result.Apps[0]["routers"]
@@ -779,7 +779,7 @@ func (s *AuthSuite) TestRemoveUserProvidingOwnEmail(c *check.C) {
 		Target: userTarget(u.Email),
 		Owner:  token.GetUserName(),
 		Kind:   "user.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "user", "value": u.Email},
 		},
 	}, eventtest.HasEvent)
@@ -806,7 +806,7 @@ func (s *AuthSuite) TestRemoveAnotherUser(c *check.C) {
 		Target: userTarget(u.Email),
 		Owner:  s.token.GetUserName(),
 		Kind:   "user.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "user", "value": u.Email},
 		},
 	}, eventtest.HasEvent)
@@ -927,7 +927,7 @@ func (s *AuthSuite) TestResetPasswordStep1(c *check.C) {
 	recorder := httptest.NewRecorder()
 	err = resetPassword(recorder, request)
 	c.Assert(err, check.IsNil)
-	var m map[string]interface{}
+	var m map[string]any
 	err = passwordTokensCollection.FindOne(context.TODO(), mongoBSON.M{"useremail": s.user.Email}).Decode(&m)
 	c.Assert(err, check.IsNil)
 	err = tsurutest.WaitCondition(time.Second, func() bool {
@@ -943,7 +943,7 @@ func (s *AuthSuite) TestResetPasswordStep1(c *check.C) {
 		Target: userTarget(s.token.GetUserName()),
 		Owner:  s.token.GetUserName(),
 		Kind:   "user.update.reset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":email", "value": s.token.GetUserName()},
 		},
 	}, eventtest.HasEvent)
@@ -982,7 +982,7 @@ func (s *AuthSuite) TestResetPasswordStep2(c *check.C) {
 	oldPassword := user.Password
 	err = nativeScheme.StartPasswordReset(context.TODO(), &user)
 	c.Assert(err, check.IsNil)
-	var t map[string]interface{}
+	var t map[string]any
 	err = passwordTokensCollection.FindOne(context.TODO(), mongoBSON.M{"useremail": user.Email}).Decode(&t)
 	c.Assert(err, check.IsNil)
 	url := fmt.Sprintf("/users/%s/password?:email=%s&token=%s", user.Email, user.Email, t["_id"])
@@ -997,7 +997,7 @@ func (s *AuthSuite) TestResetPasswordStep2(c *check.C) {
 		Target: userTarget(user.Email),
 		Owner:  user.Email,
 		Kind:   "user.update.reset",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":email", "value": user.Email},
 			{"name": "token", "value": t["_id"]},
 		},
@@ -1045,11 +1045,11 @@ func (s *AuthSuite) TestAuthScheme(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	err = json.NewDecoder(recorder.Body).Decode(&parsed)
 	c.Assert(err, check.IsNil)
 	c.Assert(parsed["name"], check.Equals, "test")
-	c.Assert(parsed["data"], check.DeepEquals, map[string]interface{}{"authorizeUrl": "http://foo/bar"})
+	c.Assert(parsed["data"], check.DeepEquals, map[string]any{"authorizeUrl": "http://foo/bar"})
 }
 
 func (s *AuthSuite) TestRegenerateAPITokenHandler(c *check.C) {
@@ -1115,7 +1115,7 @@ func (s *AuthSuite) TestRegenerateAPITokenHandlerOtherUserAndIsAdminUser(c *chec
 		Target: userTarget("leto@arrakis.com"),
 		Owner:  token.GetUserName(),
 		Kind:   "apikey.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "user", "value": "leto@arrakis.com"},
 		},
 	}, eventtest.HasEvent)

--- a/api/build_test.go
+++ b/api/build_test.go
@@ -178,7 +178,7 @@ func (s *BuildSuite) TestBuildHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.build",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   12,
@@ -190,7 +190,7 @@ func (s *BuildSuite) TestBuildHandler(c *check.C) {
 			"build":      true,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuruteam/app-otherapp:mytag",
 		},
 	}, eventtest.HasEvent)
@@ -231,7 +231,7 @@ func (s *BuildSuite) TestBuildArchiveURL(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.build",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -243,7 +243,7 @@ func (s *BuildSuite) TestBuildArchiveURL(c *check.C) {
 			"build":      true,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuruteam/app-otherapp:mytag",
 		},
 	}, eventtest.HasEvent)

--- a/api/deploy_test.go
+++ b/api/deploy_test.go
@@ -190,7 +190,7 @@ func (s *DeploySuite) TestDeployHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -202,7 +202,7 @@ func (s *DeploySuite) TestDeployHandler(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -238,7 +238,7 @@ func (s *DeploySuite) TestDeployOriginDragAndDrop(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   12,
@@ -250,7 +250,7 @@ func (s *DeploySuite) TestDeployOriginDragAndDrop(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -294,7 +294,7 @@ func (s *DeploySuite) TestDeployOriginImage(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -306,7 +306,7 @@ func (s *DeploySuite) TestDeployOriginImage(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -340,7 +340,7 @@ func (s *DeploySuite) TestDeployArchiveURL(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -352,7 +352,7 @@ func (s *DeploySuite) TestDeployArchiveURL(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`Builder deploy called`},
@@ -394,7 +394,7 @@ func (s *DeploySuite) TestDeployUploadFile(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   12,
@@ -406,7 +406,7 @@ func (s *DeploySuite) TestDeployUploadFile(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -450,7 +450,7 @@ func (s *DeploySuite) TestDeployUploadLargeFile(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   33 << 20,
@@ -462,7 +462,7 @@ func (s *DeploySuite) TestDeployUploadLargeFile(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -497,7 +497,7 @@ func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -509,7 +509,7 @@ func (s *DeploySuite) TestDeployWithCommitUserToken(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -543,7 +543,7 @@ func (s *DeploySuite) TestDeployWithMessage(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -556,7 +556,7 @@ func (s *DeploySuite) TestDeployWithMessage(c *check.C) {
 			"rollback":   false,
 			"message":    "and when he falleth",
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -607,7 +607,7 @@ func (s *DeploySuite) TestDeployDockerImage(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -619,7 +619,7 @@ func (s *DeploySuite) TestDeployDockerImage(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 		LogMatches: []string{`.*Builder deploy called`},
@@ -1129,7 +1129,7 @@ func (s *DeploySuite) TestDeployRollbackHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -1141,7 +1141,7 @@ func (s *DeploySuite) TestDeployRollbackHandler(c *check.C) {
 			"build":      false,
 			"rollback":   true,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": testBaseImage,
 		},
 	}, eventtest.HasEvent)
@@ -1171,7 +1171,7 @@ func (s *DeploySuite) TestDeployRollbackHandlerWithOnlyVersionImage(c *check.C) 
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -1183,7 +1183,7 @@ func (s *DeploySuite) TestDeployRollbackHandlerWithOnlyVersionImage(c *check.C) 
 			"build":      false,
 			"rollback":   true,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-otherapp:v1",
 		},
 		LogMatches: []string{`Builder deploy called`},
@@ -1316,7 +1316,7 @@ func (s *DeploySuite) TestDeployRebuildHandler(c *check.C) {
 		Target: appTarget(a.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"app.name":   a.Name,
 			"commit":     "",
 			"filesize":   0,
@@ -1328,7 +1328,7 @@ func (s *DeploySuite) TestDeployRebuildHandler(c *check.C) {
 			"build":      false,
 			"rollback":   false,
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/app-" + a.Name + ":v1",
 		},
 	}, eventtest.HasEvent)
@@ -1532,7 +1532,7 @@ func (s *DeploySuite) TestJobDeployHandler(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeJob, Value: job.Name},
 		Owner:  user.Email,
 		Kind:   "job.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"dockerfile": "",
 			"jobname":    job.Name,
 			"filesize":   0,
@@ -1541,7 +1541,7 @@ func (s *DeploySuite) TestJobDeployHandler(c *check.C) {
 			"image":      "127.0.0.1:5000/tsuru/somejob",
 			"message":    "",
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/job-" + job.Name + ":latest",
 		},
 		LogMatches: []string{`.*Deploy finished with success`},
@@ -1601,7 +1601,7 @@ func (s *DeploySuite) TestJobDeployWithDockerfile(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeJob, Value: job.Name},
 		Owner:  user.Email,
 		Kind:   "job.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"dockerfile": "FROM busybox",
 			"jobname":    job.Name,
 			"filesize":   0,
@@ -1610,7 +1610,7 @@ func (s *DeploySuite) TestJobDeployWithDockerfile(c *check.C) {
 			"image":      "",
 			"message":    "",
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "tsuru/job-" + job.Name + ":latest",
 		},
 		LogMatches: []string{`.*Deploy finished with success`},
@@ -1771,7 +1771,7 @@ func (s *DeploySuite) TestJobDeployFailed(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeJob, Value: job.Name},
 		Owner:  user.Email,
 		Kind:   "job.deploy",
-		StartCustomData: map[string]interface{}{
+		StartCustomData: map[string]any{
 			"dockerfile": "",
 			"jobname":    job.Name,
 			"filesize":   0,
@@ -1780,7 +1780,7 @@ func (s *DeploySuite) TestJobDeployFailed(c *check.C) {
 			"image":      "127.0.0.1:5000/tsuru/somejob",
 			"message":    "",
 		},
-		EndCustomData: map[string]interface{}{
+		EndCustomData: map[string]any{
 			"image": "",
 		},
 		LogMatches:   []string{`.*Tsuru failed to deploy job myjob\n`},

--- a/api/event.go
+++ b/api/event.go
@@ -270,7 +270,7 @@ func eventBlockRemove(w http.ResponseWriter, r *http.Request, t auth.Token) (err
 		Kind:       permission.PermEventBlockRemove,
 		Owner:      t,
 		RemoteAddr: r.RemoteAddr,
-		CustomData: []map[string]interface{}{
+		CustomData: []map[string]any{
 			{"name": "ID", "value": objID.Hex()},
 		},
 		Allowed: event.Allowed(permission.PermEventBlockReadEvents),

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -735,7 +735,7 @@ func (s *EventSuite) TestEventBlockRemove(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeEventBlock, Value: blocks[0].ID.Hex()},
 		Owner:  token.GetUserName(),
 		Kind:   "event-block.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "ID", "value": blocks[0].ID.Hex()},
 		},
 	}, eventtest.HasEvent)

--- a/api/index.go
+++ b/api/index.go
@@ -22,7 +22,7 @@ func index(w http.ResponseWriter, r *http.Request) error {
 	host, _ := config.GetString("host")
 	userCreate, _ := config.GetBool("auth:user-registration")
 	scheme, _ := config.GetString("auth:scheme")
-	data := map[string]interface{}{
+	data := map[string]any{
 		"tsuruTarget": host,
 		"userCreate":  userCreate,
 		"nativeLogin": scheme == "" || scheme == "native",

--- a/api/index_templates.go
+++ b/api/index_templates.go
@@ -11,7 +11,7 @@ import (
 )
 
 var funcMap = template.FuncMap{
-	"getConfig": func(v string) interface{} {
+	"getConfig": func(v string) any {
 		result, _ := config.Get(v)
 		return result
 	},

--- a/api/index_test.go
+++ b/api/index_test.go
@@ -32,7 +32,7 @@ func (IndexSuite) TestIndex(c *check.C) {
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var expected bytes.Buffer
-	indexTemplate.Execute(&expected, map[string]interface{}{
+	indexTemplate.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  true,
 		"nativeLogin": true,
@@ -48,7 +48,7 @@ func (IndexSuite) TestIndexNoRepoManager(c *check.C) {
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var expected bytes.Buffer
-	indexTemplate.Execute(&expected, map[string]interface{}{
+	indexTemplate.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  true,
 		"nativeLogin": true,
@@ -65,7 +65,7 @@ func (IndexSuite) TestIndexNoUserCreation(c *check.C) {
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var expected bytes.Buffer
-	indexTemplate.Execute(&expected, map[string]interface{}{
+	indexTemplate.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  false,
 		"nativeLogin": true,
@@ -82,7 +82,7 @@ func (IndexSuite) TestIndexNoAuthScheme(c *check.C) {
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var expected bytes.Buffer
-	indexTemplate.Execute(&expected, map[string]interface{}{
+	indexTemplate.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  true,
 		"nativeLogin": true,
@@ -99,7 +99,7 @@ func (IndexSuite) TestIndexOAuth(c *check.C) {
 	handler.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	var expected bytes.Buffer
-	indexTemplate.Execute(&expected, map[string]interface{}{
+	indexTemplate.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  true,
 		"nativeLogin": false,
@@ -118,7 +118,7 @@ func (IndexSuite) TestIndexCustomTemplate(c *check.C) {
 	c.Check(recorder.Code, check.Equals, http.StatusOK)
 	index := template.Must(template.ParseFiles("testdata/index.html"))
 	var expected bytes.Buffer
-	index.Execute(&expected, map[string]interface{}{
+	index.Execute(&expected, map[string]any{
 		"tsuruTarget": "http://localhost/",
 		"userCreate":  true,
 		"nativeLogin": true,

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -21,10 +21,10 @@ func (s *S) TestInfo(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-Type"), check.Equals, "application/json")
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"version": Version,
 	}
-	var info map[string]interface{}
+	var info map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &info)
 	c.Assert(err, check.IsNil)
 	c.Assert(info, check.DeepEquals, expected)

--- a/api/job.go
+++ b/api/job.go
@@ -177,7 +177,7 @@ func jobTrigger(w http.ResponseWriter, r *http.Request, t auth.Token) (err error
 	if err != nil {
 		return err
 	}
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"status": "success",
 	}
 	jsonMsg, err := json.Marshal(msg)
@@ -314,7 +314,7 @@ func killJob(w http.ResponseWriter, r *http.Request, t auth.Token) (err error) {
 		Kind:       permission.PermJobUnitKill,
 		Owner:      t,
 		RemoteAddr: r.RemoteAddr,
-		CustomData: []map[string]interface{}{
+		CustomData: []map[string]any{
 			{
 				"unit":  unitName,
 				"force": force,
@@ -538,7 +538,7 @@ func createJob(w http.ResponseWriter, r *http.Request, t auth.Token) (err error)
 	if err != nil {
 		return err
 	}
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"status":  "success",
 		"jobName": j.Name,
 	}

--- a/api/job_test.go
+++ b/api/job_test.go
@@ -1792,7 +1792,7 @@ func (s *S) TestSuccessfulJobServiceInstanceUnbind(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":job", "value": job.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -1887,7 +1887,7 @@ func (s *S) TestSuccessfulForceJobServiceInstanceUnbind(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":job", "value": job.Name},
 			{"name": ":instance", "value": instance.Name},
 			{"name": ":service", "value": instance.ServiceName},
@@ -2427,13 +2427,13 @@ func (s *S) TestGetOneJobEnv(c *check.C) {
 	s.testServer.ServeHTTP(recorder, request)
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 
-	expected := []map[string]interface{}{{
+	expected := []map[string]any{{
 		"name":   "MY_ENV",
 		"value":  "my-value",
 		"public": true,
 		"alias":  "",
 	}}
-	result := []map[string]interface{}{}
+	result := []map[string]any{}
 	err = json.Unmarshal(recorder.Body.Bytes(), &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.DeepEquals, expected)
@@ -2484,11 +2484,11 @@ func (s *S) TestGetMultipleJobEnvs(c *check.C) {
 	c.Assert(recorder.Code, check.Equals, http.StatusOK)
 	c.Assert(recorder.Header().Get("Content-type"), check.Equals, "application/json")
 
-	expected := []map[string]interface{}{
+	expected := []map[string]any{
 		{"name": "MY_ENV", "value": "my-value", "public": true, "alias": ""},
 		{"name": "THEIR_ENV", "value": "their-value", "public": true, "alias": ""},
 	}
-	var got []map[string]interface{}
+	var got []map[string]any
 	err = json.Unmarshal(recorder.Body.Bytes(), &got)
 	c.Assert(err, check.IsNil)
 	c.Assert(got, check.DeepEquals, expected)
@@ -2602,7 +2602,7 @@ func (s *S) TestJobEnvPublicEnvironmentVariableInTheJob(c *check.C) {
 		Target: jobTarget(j.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": j.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "localhost"},
@@ -2675,7 +2675,7 @@ func (s *S) TestSetJobEnvPrivateEnvironmentVariableInTheJob(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_PASSWORD"},
 			{"name": "Envs.0.Value", "value": "*****"},
@@ -2745,7 +2745,7 @@ func (s *S) TestSetJobEnvSetMultipleEnvironmentVariablesInTheJob(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "localhost"},
@@ -2825,7 +2825,7 @@ func (s *S) TestSetJobEnvNotToChangeValueOfServiceVariables(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "Envs.0.Name", "value": "DATABASE_HOST"},
 			{"name": "Envs.0.Value", "value": "newhost"},
@@ -3083,7 +3083,7 @@ func (s *S) TestUnsetJobEnv(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "env", "value": "DATABASE_HOST"},
 		},
@@ -3147,7 +3147,7 @@ func (s *S) TestUnsetJobEnvRemovesMultipleEnvironmentVariables(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "env", "value": []string{"DATABASE_HOST", "DATABASE_USER"}},
 		},
@@ -3207,7 +3207,7 @@ func (s *S) TestUnsetJobEnvRemovesPrivateVariables(c *check.C) {
 		Target: jobTarget(job.Name),
 		Owner:  s.token.GetUserName(),
 		Kind:   "job.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": job.Name},
 			{"name": "env", "value": "DATABASE_PASSWORD"},
 		},

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -254,7 +254,7 @@ func InputValues(r *http.Request, field string) ([]string, bool) {
 		if len(data) == 0 {
 			break
 		}
-		var dst map[string]interface{}
+		var dst map[string]any
 		err = json.Unmarshal(data, &dst)
 		if err != nil {
 			break
@@ -266,7 +266,7 @@ func InputValues(r *http.Request, field string) ([]string, bool) {
 		if _, isSet := r.Form[field]; !isSet {
 			r.Form[field] = nil
 		}
-		if asSlice, ok := val.([]interface{}); ok {
+		if asSlice, ok := val.([]any); ok {
 			for _, v := range asSlice {
 				r.Form[field] = append(r.Form[field], fmt.Sprint(v))
 			}
@@ -298,7 +298,7 @@ func InputFields(r *http.Request, exclude ...string) url.Values {
 		if len(data) == 0 {
 			return nil
 		}
-		var dst map[string]interface{}
+		var dst map[string]any
 		err = json.Unmarshal(data, &dst)
 		if err != nil {
 			return nil
@@ -324,7 +324,7 @@ func InputFields(r *http.Request, exclude ...string) url.Values {
 	return ret
 }
 
-func ParseJSON(r *http.Request, dst interface{}) error {
+func ParseJSON(r *http.Request, dst any) error {
 	data, err := context.GetBody(r)
 	if err != nil {
 		return err
@@ -343,7 +343,7 @@ func ParseJSON(r *http.Request, dst interface{}) error {
 	return nil
 }
 
-func ParseInput(r *http.Request, dst interface{}) error {
+func ParseInput(r *http.Request, dst any) error {
 	contentType := getContentType(r)
 	switch contentType {
 	case "application/json":

--- a/api/observability/middleware_test.go
+++ b/api/observability/middleware_test.go
@@ -93,15 +93,15 @@ func (s *S) TestMiddlewareJSON(c *check.C) {
 	middle.ServeHTTP(negroni.NewResponseWriter(recorder), request, h)
 	c.Assert(handlerLog.called, check.Equals, true)
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	err = json.NewDecoder(&out).Decode(&m)
 	c.Assert(err, check.IsNil)
 
 	timePart := time.Now().Format(time.RFC3339Nano)[:16]
 	c.Assert(m["time"], check.Matches, timePart+".*")
-	c.Assert(m["request"], check.DeepEquals, map[string]interface{}{"method": "PUT", "path": "/my/path", "scheme": "http", "userAgent": "ardata 1.1", "sourceIP": "10.1.1.1"})
+	c.Assert(m["request"], check.DeepEquals, map[string]any{"method": "PUT", "path": "/my/path", "scheme": "http", "userAgent": "ardata 1.1", "sourceIP": "10.1.1.1"})
 
-	response := m["response"].(map[string]interface{})
+	response := m["response"].(map[string]any)
 	c.Assert(response["statusCode"], check.Equals, float64(200))
 	c.Assert(response["durationMS"], check.Matches, `1\d{2}\.\d+`)
 }

--- a/api/permission_test.go
+++ b/api/permission_test.go
@@ -63,7 +63,7 @@ func (s *S) TestAddRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "test"},
 			{"name": "context", "value": "global"},
 		},
@@ -151,7 +151,7 @@ func (s *S) TestRemoveRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "test"},
 		},
 	}, eventtest.HasEvent)
@@ -301,7 +301,7 @@ func (s *S) TestAddPermissionsToARole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.permission.add",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "permission", "value": []string{"app.update", "app.deploy"}},
 		},
 	}, eventtest.HasEvent)
@@ -474,7 +474,7 @@ func (s *S) TestRemovePermissionsFromRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.permission.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "test"},
 			{"name": ":permission", "value": "app.update"},
 		},
@@ -512,7 +512,7 @@ func (s *S) TestAssignRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.assign",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "email", "value": emptyToken.GetUserName()},
 			{"name": "context", "value": "myteam"},
 		},
@@ -905,7 +905,7 @@ func (s *S) TestRoleAssignValidateCtxRouterFound(c *check.C) {
 	dr := routerTypes.DynamicRouter{
 		Name:   routerName,
 		Type:   "fake",
-		Config: map[string]interface{}{"a": "b"},
+		Config: map[string]any{"a": "b"},
 	}
 	s.mockService.DynamicRouter.OnGet = func(name string) (*routerTypes.DynamicRouter, error) {
 		return &dr, nil
@@ -1008,7 +1008,7 @@ func (s *S) TestDissociateRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.dissociate",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":email", "value": otherToken.GetUserName()},
 			{"name": "context", "value": "myteam"},
 		},
@@ -1203,7 +1203,7 @@ func (s *S) TestAddDefaultRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r1"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.default.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team-create", "value": []string{"r1", "r2"}},
 			{"name": "user-create", "value": "r3"},
 		},
@@ -1212,7 +1212,7 @@ func (s *S) TestAddDefaultRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r2"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.default.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team-create", "value": []string{"r1", "r2"}},
 			{"name": "user-create", "value": "r3"},
 		},
@@ -1221,7 +1221,7 @@ func (s *S) TestAddDefaultRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r3"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.default.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team-create", "value": []string{"r1", "r2"}},
 			{"name": "user-create", "value": "r3"},
 		},
@@ -1287,7 +1287,7 @@ func (s *S) TestRemoveDefaultRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r1"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.default.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team-create", "value": "r1"},
 		},
 	}, eventtest.HasEvent)
@@ -1317,7 +1317,7 @@ func (s *S) TestRoleUpdateDestroysAndCreatesNewRole(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r1"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "r1"},
 			{"name": "newName", "value": "r2"},
 			{"name": "contextType", "value": "team"},
@@ -1409,7 +1409,7 @@ func (s *S) TestRoleUpdateSingleField(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "r1"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "r1"},
 			{"name": "newName", "value": ""},
 			{"name": "contextType", "value": "team"},
@@ -1460,7 +1460,7 @@ func (s *S) TestAssignRoleToTeamToken(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "newrole"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.assign",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "token_id", "value": teamToken.TokenID},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "newrole"},
@@ -1493,7 +1493,7 @@ func (s *S) TestAssignRoleToTeamTokenRoleNotFound(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "rolenotfound"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.assign",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "token_id", "value": teamToken.TokenID},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "rolenotfound"},
@@ -1583,7 +1583,7 @@ func (s *S) TestDissociateRoleFromTeamToken(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "newrole"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.dissociate",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":token_id", "value": teamToken.TokenID},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "newrole"},
@@ -1624,7 +1624,7 @@ func (s *S) TestDissociateRoleFromTeamTokenRoleNotFound(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "rolenotfound"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.dissociate",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":token_id", "value": teamToken.TokenID},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "rolenotfound"},
@@ -1701,7 +1701,7 @@ func (s *S) TestAssignRoleToAuthGroup(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "newrole"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.assign",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "group_name", "value": "g1"},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "newrole"},
@@ -1730,7 +1730,7 @@ func (s *S) TestAssignRoleToAuthGroupRoleNotFound(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "rolenotfound"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.assign",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "group_name", "value": "g1"},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "rolenotfound"},
@@ -1792,7 +1792,7 @@ func (s *S) TestDissociateRoleFromAuthGroup(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "newrole"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.dissociate",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":group_name", "value": "g1"},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "newrole"},
@@ -1839,7 +1839,7 @@ func (s *S) TestDissociateRoleFromAuthGroupRoleNotFound(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeRole, Value: "rolenotfound"},
 		Owner:  token.GetUserName(),
 		Kind:   "role.update.dissociate",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":group_name", "value": "g1"},
 			{"name": "context", "value": "myapp"},
 			{"name": ":name", "value": "rolenotfound"},

--- a/api/plan_test.go
+++ b/api/plan_test.go
@@ -39,14 +39,14 @@ func (s *S) TestPlanAdd(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlan, Value: "xyz"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "plan.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "xyz"},
 			{"name": "memory", "value": "9223372036854775807"},
 			{"name": "cpumilli", "value": "2000"},
 		},
 	}, eventtest.HasEvent)
 
-	fill := map[string]interface{}{}
+	fill := map[string]any{}
 	c.Assert(json.NewDecoder(recorder.Body).Decode(&fill), check.IsNil)
 }
 
@@ -71,7 +71,7 @@ func (s *S) TestPlanAddJSON(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlan, Value: "xyz"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "plan.create",
-		StartCustomData: []interface{}{
+		StartCustomData: []any{
 			mongoBSON.M{"name": ":mux-path-template", "value": "/plans"},
 			mongoBSON.M{"name": "memory", "value": "9.223372036854776e+18"},
 			mongoBSON.M{"name": "cpumilli", "value": "2000"},
@@ -79,7 +79,7 @@ func (s *S) TestPlanAddJSON(c *check.C) {
 		},
 	}, eventtest.HasEvent)
 
-	fill := map[string]interface{}{}
+	fill := map[string]any{}
 	c.Assert(json.NewDecoder(recorder.Body).Decode(&fill), check.IsNil)
 }
 
@@ -162,7 +162,7 @@ func (s *S) TestPlanAddDupp(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlan, Value: "xyz"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "plan.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "xyz"},
 			{"name": "memory", "value": "9223372036854775807"},
 			{"name": "cpumilli", "value": "300"},
@@ -219,7 +219,7 @@ func (s *S) TestPlanRemove(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlan, Value: "plan1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "plan.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":planname", "value": "plan1"},
 		},
 	}, eventtest.HasEvent)

--- a/api/platform.go
+++ b/api/platform.go
@@ -244,7 +244,7 @@ func platformInfo(w http.ResponseWriter, r *http.Request, t auth.Token) error {
 	if err != nil {
 		return err
 	}
-	msg := map[string]interface{}{
+	msg := map[string]any{
 		"platform": platform,
 		"images":   images,
 	}

--- a/api/platform_test.go
+++ b/api/platform_test.go
@@ -101,7 +101,7 @@ func (s *PlatformSuite) TestPlatformAdd(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: "test"},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "test"},
 			{"name": "dockerfile", "value": dockerfileURL},
 		},
@@ -199,7 +199,7 @@ func (s *PlatformSuite) TestPlatformUpdate(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: platformName},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": platformName},
 		},
 	}, eventtest.HasEvent)
@@ -233,7 +233,7 @@ func (s *PlatformSuite) TestPlatformUpdateOnlyDisableTrue(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: platformName},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": platformName},
 			{"name": "disabled", "value": "true"},
 		},
@@ -270,7 +270,7 @@ func (s *PlatformSuite) TestPlatformUpdateDisableTrueAndDockerfile(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: platformName},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": platformName},
 			{"name": "disabled", "value": "true"},
 		},
@@ -327,7 +327,7 @@ func (s *PlatformSuite) TestPlatformRemove(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: name},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": name},
 		},
 	}, eventtest.HasEvent)
@@ -479,7 +479,7 @@ func (s *PlatformSuite) TestPlatformRollback(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePlatform, Value: name},
 		Owner:  token.GetUserName(),
 		Kind:   "platform.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": name},
 		},
 	}, eventtest.HasEvent)

--- a/api/pool_test.go
+++ b/api/pool_test.go
@@ -54,7 +54,7 @@ func (s *S) TestAddPoolDefaultPoolAlreadyExists(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "pool1"},
 			{"name": "default", "value": "true"},
 		},
@@ -79,7 +79,7 @@ func (s *S) TestAddPoolAlreadyExists(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "pool1"},
 		},
 		ErrorMatches: `Pool already exists\.`,
@@ -118,7 +118,7 @@ func (s *S) TestAddPool(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "pool1"},
 		},
 	}, eventtest.HasEvent)
@@ -126,7 +126,7 @@ func (s *S) TestAddPool(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool2"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "pool2"},
 			{"name": "public", "value": "true"},
 		},
@@ -160,7 +160,7 @@ func (s *S) TestRemovePoolHandler(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "pool1"},
 		},
 	}, eventtest.HasEvent)
@@ -262,7 +262,7 @@ func (s *S) TestAddTeamsToPool(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.update.team.add",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "pool1"},
 			{"name": "team", "value": s.team.Name},
 		},
@@ -358,7 +358,7 @@ func (s *S) TestRemoveTeamsFromPoolHandler(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.update.team.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "pool1"},
 			{"name": "team", "value": "ateam"},
 		},
@@ -614,7 +614,7 @@ func (s *S) TestPoolUpdateToPublicHandler(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "pool1"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "pool1"},
 			{"name": "public", "value": "true"},
 		},
@@ -754,7 +754,7 @@ func (s *S) TestPoolConstraintSet(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "*"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.update.constraints.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "PoolExpr", "value": "*"},
 			{"name": "Field", "value": "router"},
 			{"name": "Values.0", "value": "routerA"},
@@ -792,7 +792,7 @@ func (s *S) TestPoolConstraintSetAppend(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypePool, Value: "*"},
 		Owner:  s.token.GetUserName(),
 		Kind:   "pool.update.constraints.set",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "PoolExpr", "value": "*"},
 			{"name": "Field", "value": "router"},
 			{"name": "Values.0", "value": "routerB"},

--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -163,7 +163,7 @@ func (s *QuotaSuite) TestChangeUserQuota(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeUser, Value: user.Email},
 		Owner:  s.token.GetUserName(),
 		Kind:   "user.update.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":email", "value": user.Email},
 			{"name": "limit", "value": "40"},
 		},
@@ -212,7 +212,7 @@ func (s *QuotaSuite) TestChangeUserQuotaInvalidLimitValue(c *check.C) {
 			Target: eventTypes.Target{Type: eventTypes.TargetTypeUser, Value: user.Email},
 			Owner:  s.token.GetUserName(),
 			Kind:   "user.update.quota",
-			StartCustomData: []map[string]interface{}{
+			StartCustomData: []map[string]any{
 				{"name": ":email", "value": user.Email},
 				{"name": "limit", "value": value},
 			},
@@ -253,7 +253,7 @@ func (s *QuotaSuite) TestChangeUserQuotaLimitLowerThanAllocated(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeUser, Value: user.Email},
 		Owner:  s.token.GetUserName(),
 		Kind:   "user.update.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":email", "value": user.Email},
 			{"name": "limit", "value": "3"},
 		},
@@ -347,7 +347,7 @@ func (s *QuotaSuite) TestChangeTeamQuota(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: team.Name},
 		Owner:  s.token.GetUserName(),
 		Kind:   "team.update.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": team.Name},
 			{"name": "limit", "value": "40"},
 		},
@@ -390,7 +390,7 @@ func (s *QuotaSuite) TestChangeTeamQuotaInvalidLimitValue(c *check.C) {
 			Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: team.Name},
 			Owner:  s.token.GetUserName(),
 			Kind:   "team.update.quota",
-			StartCustomData: []map[string]interface{}{
+			StartCustomData: []map[string]any{
 				{"name": ":name", "value": team.Name},
 				{"name": "limit", "value": value},
 			},
@@ -427,7 +427,7 @@ func (s *QuotaSuite) TestChangeTeamQuotaLimitLowerThanAllocated(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: team.Name},
 		Owner:  s.token.GetUserName(),
 		Kind:   "team.update.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": team.Name},
 			{"name": "limit", "value": "4"},
 		},
@@ -556,7 +556,7 @@ func (s *QuotaSuite) TestChangeAppQuota(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeApp, Value: a.Name},
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.admin.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "limit", "value": "40"},
 		},
@@ -616,7 +616,7 @@ func (s *QuotaSuite) TestChangeAppQuotaInvalidLimitValue(c *check.C) {
 			Target: eventTypes.Target{Type: eventTypes.TargetTypeApp, Value: app.Name},
 			Owner:  s.token.GetUserName(),
 			Kind:   "app.admin.quota",
-			StartCustomData: []map[string]interface{}{
+			StartCustomData: []map[string]any{
 				{"name": ":app", "value": app.Name},
 				{"name": "limit", "value": value},
 			},
@@ -666,7 +666,7 @@ func (s *QuotaSuite) TestChangeAppQuotaLimitLowerThanAllocated(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeApp, Value: a.Name},
 		Owner:  s.token.GetUserName(),
 		Kind:   "app.admin.quota",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "limit", "value": "3"},
 		},

--- a/api/router_test.go
+++ b/api/router_test.go
@@ -41,7 +41,7 @@ func (s *S) TestRoutersAdd(c *check.C) {
 	c.Assert(created, check.DeepEquals, routerTypes.DynamicRouter{
 		Name:   "r1",
 		Type:   "t1",
-		Config: map[string]interface{}{"a": "b"},
+		Config: map[string]any{"a": "b"},
 	})
 }
 
@@ -62,7 +62,7 @@ func (s *S) TestRoutersUpdate(c *check.C) {
 	c.Assert(updated, check.DeepEquals, routerTypes.DynamicRouter{
 		Name:   "r1",
 		Type:   "t1",
-		Config: map[string]interface{}{"a": "b"},
+		Config: map[string]any{"a": "b"},
 	})
 }
 
@@ -98,7 +98,7 @@ func (s *S) TestRoutersList(c *check.C) {
 	dr := routerTypes.DynamicRouter{
 		Name:   "dr1",
 		Type:   "foo",
-		Config: map[string]interface{}{"a": "b"},
+		Config: map[string]any{"a": "b"},
 	}
 	s.mockService.DynamicRouter.OnList = func() ([]routerTypes.DynamicRouter, error) {
 		return []routerTypes.DynamicRouter{dr}, nil
@@ -117,11 +117,11 @@ func (s *S) TestRoutersList(c *check.C) {
 	defer router.Unregister("bar")
 	recorder := httptest.NewRecorder()
 	expected := []routerTypes.PlanRouter{
-		{Name: "dr1", Type: "foo", Dynamic: true, Config: map[string]interface{}{"a": "b"}, Info: map[string]string{}},
+		{Name: "dr1", Type: "foo", Dynamic: true, Config: map[string]any{"a": "b"}, Info: map[string]string{}},
 		{Name: "fake", Type: "fake", Default: true, Info: map[string]string{}},
 		{Name: "fake-tls", Type: "fake-tls", Info: map[string]string{}},
 		{Name: "router1", Type: "foo", Info: map[string]string{}},
-		{Name: "router2", Type: "bar", Config: map[string]interface{}{"mycfg": "1"}, Info: map[string]string{}},
+		{Name: "router2", Type: "bar", Config: map[string]any{"mycfg": "1"}, Info: map[string]string{}},
 	}
 	request, err := http.NewRequest("GET", "/routers", nil)
 	c.Assert(err, check.IsNil)
@@ -203,7 +203,7 @@ func (s *S) TestRoutersListWhenPoolHasNoRouterShouldNotReturnError(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = pool.RemovePool(context.TODO(), s.Pool)
 	c.Assert(err, check.IsNil)
-	router1 := routerTypes.DynamicRouter{Name: "router-1", Type: "api", Config: map[string]interface{}{"key1": "value1", "key2": "value2"}}
+	router1 := routerTypes.DynamicRouter{Name: "router-1", Type: "api", Config: map[string]any{"key1": "value1", "key2": "value2"}}
 	router2 := routerTypes.DynamicRouter{Name: "router-2", Type: "api"}
 	router.Register("api", func(_ string, _ router.ConfigGetter) (router.Router, error) { return &routertest.FakeRouter, nil })
 	defer router.Unregister("api")

--- a/api/scale_test.go
+++ b/api/scale_test.go
@@ -105,7 +105,7 @@ func (s *S) TestAddAutoScaleUnits(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update.unit.autoscale.add",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "averageCPU", "value": "600m"},
 			{"name": "process", "value": "p1"},
@@ -149,7 +149,7 @@ func (s *S) TestRemoveAutoScaleUnits(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update.unit.autoscale.remove",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "process", "value": "p1"},
 		},
@@ -202,7 +202,7 @@ func (s *S) TestAddAutoScaleDown(c *check.C) {
 		Target: appTarget("myapp"),
 		Owner:  token.GetUserName(),
 		Kind:   "app.update.unit.autoscale.add",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":app", "value": a.Name},
 			{"name": "averageCPU", "value": "600m"},
 			{"name": "process", "value": "p1"},

--- a/api/service.go
+++ b/api/service.go
@@ -308,7 +308,7 @@ func serviceProxy(w http.ResponseWriter, r *http.Request, t auth.Token) (err err
 			Kind:       permission.PermServiceUpdateProxy,
 			Owner:      t,
 			RemoteAddr: r.RemoteAddr,
-			CustomData: append(event.FormToCustomData(InputFields(r)), map[string]interface{}{
+			CustomData: append(event.FormToCustomData(InputFields(r)), map[string]any{
 				"name":  "method",
 				"value": r.Method,
 			}),
@@ -345,7 +345,7 @@ func serviceAuthenticatedResourcesProxy(w http.ResponseWriter, r *http.Request, 
 			Kind:       permission.PermServiceUpdateProxy,
 			Owner:      t,
 			RemoteAddr: r.RemoteAddr,
-			CustomData: append(event.FormToCustomData(InputFields(r)), map[string]interface{}{
+			CustomData: append(event.FormToCustomData(InputFields(r)), map[string]any{
 				"name":  "method",
 				"value": r.Method,
 			}),

--- a/api/service_instance.go
+++ b/api/service_instance.go
@@ -240,7 +240,7 @@ func updateServiceInstance(w http.ResponseWriter, r *http.Request, t auth.Token)
 		Plan        string
 		TeamOwner   string
 		Tags        []string
-		Parameters  map[string]interface{}
+		Parameters  map[string]any
 	}{}
 	err = ParseInput(r, &updateData)
 	if err != nil {
@@ -553,7 +553,7 @@ type serviceInstanceInfo struct {
 	Cluster         string
 	CustomInfo      map[string]string
 	Tags            []string
-	Parameters      map[string]interface{}
+	Parameters      map[string]any
 }
 
 // title: service instance info

--- a/api/service_instance_test.go
+++ b/api/service_instance_test.go
@@ -186,7 +186,7 @@ func (s *ServiceInstanceSuite) TearDownSuite(c *check.C) {
 	storagev2.ClearAllCollections(nil)
 }
 
-func makeRequestToCreateServiceInstance(params map[string]interface{}, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
+func makeRequestToCreateServiceInstance(params map[string]any, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
 	values := url.Values{}
 	url := fmt.Sprintf("/services/%s/instances", params["service_name"])
 	delete(params, "service_name")
@@ -235,7 +235,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithPlan(c *check.C) {
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"plan":         "small",
@@ -257,7 +257,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithPlan(c *check.C) {
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -266,7 +266,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithPlanImplicitTeam(c *check.C
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"plan":         "small",
@@ -286,7 +286,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithPlanImplicitTeam(c *check.C
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -301,7 +301,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceTeamOwnerMissing(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = s.user.AddRole(stdContext.TODO(), role.Name, p.Context.Value)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"token":        "bearer " + s.token.GetValue(),
@@ -313,7 +313,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceTeamOwnerMissing(c *check.C) {
 }
 
 func (s *ServiceInstanceSuite) TestCreateInstanceInvalidName(c *check.C) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "1brainsql",
 		"service_name": "mysql",
 		"owner":        s.team.Name,
@@ -326,7 +326,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceInvalidName(c *check.C) {
 }
 
 func (s *ServiceInstanceSuite) TestCreateInstanceNameAlreadyExists(c *check.C) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"owner":        s.team.Name,
@@ -344,7 +344,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceNameAlreadyExists(c *check.C) {
 }
 
 func (s *ServiceInstanceSuite) TestCreateInstance(c *check.C) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"owner":        s.team.Name,
@@ -364,7 +364,7 @@ func (s *ServiceInstanceSuite) TestCreateInstance(c *check.C) {
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -393,7 +393,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithInvalidPoolConstraint(c *ch
 		s.mockService.Pool.OnServices = nil
 	}()
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql-multicluster",
 		"owner":        s.team.Name,
@@ -416,7 +416,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceReturnsErrorWhenUserCann
 	}
 	err := service.Create(stdContext.TODO(), se)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysqlrestricted",
 		"owner":        s.team.Name,
@@ -428,7 +428,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceReturnsErrorWhenUserCann
 }
 
 func (s *ServiceInstanceSuite) TestCreateServiceInstanceIgnoresTeamAuthIfServiceIsNotRestricted(c *check.C) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"owner":        s.team.Name,
@@ -447,13 +447,13 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceIgnoresTeamAuthIfService
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 	c.Assert(eventtest.EventDesc{
 		Target: serviceInstanceTarget("mysql", "brainsql"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "brainsql"},
 			{"name": ":service", "value": "mysql"},
 			{"name": "owner", "value": s.team.Name},
@@ -471,7 +471,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceNoPermission(c *check.C)
 	}
 	err := service.Create(stdContext.TODO(), srvc)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysqlnoperms",
 		"token":        token.GetValue(),
@@ -482,7 +482,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceNoPermission(c *check.C)
 }
 
 func (s *ServiceInstanceSuite) TestCreateServiceInstanceReturnsErrorWhenServiceDoesntExists(c *check.C) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "notfound",
 		"owner":        s.team.Name,
@@ -505,7 +505,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceReturnErrorIfTheServiceA
 	}
 	err := service.Create(stdContext.TODO(), srvc)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysqlerror",
 		"owner":        s.team.Name,
@@ -519,7 +519,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceReturnErrorIfTheServiceA
 		Owner:        s.token.GetUserName(),
 		Kind:         "service-instance.create",
 		ErrorMatches: `.*Failed to create the instance brainsql.*`,
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "name", "value": "brainsql"},
 			{"name": ":service", "value": "mysqlerror"},
 			{"name": "owner", "value": s.team.Name},
@@ -532,7 +532,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithDescription(c *check.C) {
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"plan":         "small",
@@ -555,7 +555,7 @@ func (s *ServiceInstanceSuite) TestCreateInstanceWithDescription(c *check.C) {
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -564,7 +564,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceWithTags(c *check.C) {
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"plan":         "small",
@@ -586,7 +586,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceWithTags(c *check.C) {
 		Apps:        []string{},
 		Jobs:        []string{},
 		Tags:        []string{"tag a", "tag b"},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -606,7 +606,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceWithTagsAndTagValidator(
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"name":         "brainsql",
 		"service_name": "mysql",
 		"plan":         "small",
@@ -620,7 +620,7 @@ func (s *ServiceInstanceSuite) TestCreateServiceInstanceWithTagsAndTagValidator(
 	c.Assert(recorder.Body.String(), check.Equals, "invalid tag\n")
 }
 
-func makeRequestToUpdateServiceInstance(params map[string]interface{}, serviceName, instanceName, token string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
+func makeRequestToUpdateServiceInstance(params map[string]any, serviceName, instanceName, token string, c *check.C) (*httptest.ResponseRecorder, *http.Request) {
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(params)
 	c.Assert(err, check.IsNil)
@@ -646,12 +646,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "changed",
 		"plan":        "",
 		"teamowner":   s.team.Name,
 		"tags":        []string{},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdateDescription,
@@ -671,13 +671,13 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithDescription(c *check
 		Apps:        si.Apps,
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 	c.Assert(eventtest.EventDesc{
 		Target: serviceInstanceTarget("mysql", "brainsql"),
 		Owner:  token.GetUserName(),
 		Kind:   "service-instance.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "description", "value": "changed"},
 		},
 	}, eventtest.HasEvent)
@@ -696,12 +696,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTeamOwner(c *check.C
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
 	t := authTypes.Team{Name: "changed"}
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"plan":        "",
 		"teamowner":   t.Name,
 		"tags":        []string{},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdateTeamowner,
@@ -720,13 +720,13 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTeamOwner(c *check.C
 		Apps:        si.Apps,
 		Jobs:        []string{},
 		Tags:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 	c.Assert(eventtest.EventDesc{
 		Target: serviceInstanceTarget("mysql", "brainsql"),
 		Owner:  token.GetUserName(),
 		Kind:   "service-instance.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "teamowner", "value": t.Name},
 		},
 	}, eventtest.HasEvent)
@@ -745,12 +745,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTags(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"plan":        "",
 		"teamowner":   s.team.Name,
 		"tag":         []string{"tag b", "tag c"},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdateTags,
@@ -769,13 +769,13 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTags(c *check.C) {
 		Apps:        si.Apps,
 		Jobs:        []string{},
 		Tags:        []string{"tag b", "tag c"},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 	c.Assert(eventtest.EventDesc{
 		Target: serviceInstanceTarget("mysql", "brainsql"),
 		Owner:  token.GetUserName(),
 		Kind:   "service-instance.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "tag", "value": []string{"tag b", "tag c"}},
 		},
 	}, eventtest.HasEvent)
@@ -805,12 +805,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithTagsAndTagValidator(
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"plan":        "",
 		"teamowner":   s.team.Name,
 		"tag":         []string{"tag b", "tag c"},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdateTags,
@@ -835,12 +835,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithEmptyTagRemovesTags(
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"teamowner":   s.team.Name,
 		"plan":        "",
 		"tag":         []string{},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdateTags,
@@ -859,7 +859,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithEmptyTagRemovesTags(
 		Apps:        si.Apps,
 		Tags:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	})
 }
 
@@ -868,7 +868,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceDoesNotExist(c *check.C)
 		w.Write([]byte(`{"DATABASE_HOST":"localhost"}`))
 	}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "changed",
 	}
 	recorder, request := makeRequestToUpdateServiceInstance(params, "mysql", "brainsql", s.token.GetValue(), c)
@@ -892,7 +892,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithoutPermissions(c *ch
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "changed",
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser")
@@ -915,12 +915,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlan(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"teamowner":   s.team.Name,
 		"plan":        "newplan",
 		"tags":        []string{},
-		"parameters":  map[string]interface{}{},
+		"parameters":  map[string]any{},
 	}
 	_, token := permissiontest.CustomUserWithPermission(c, nativeScheme, "myuser", permTypes.Permission{
 		Scheme:  permission.PermServiceInstanceUpdatePlan,
@@ -936,7 +936,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlan(c *check.C) {
 		Target: serviceInstanceTarget("mysql", "brainsql"),
 		Owner:  token.GetUserName(),
 		Kind:   "service-instance.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "plan", "value": "newplan"},
 		},
 	}, eventtest.HasEvent)
@@ -952,7 +952,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithoutChanges(c *check.
 		TeamOwner:   s.team.Name,
 		PlanName:    "large",
 		Tags:        []string{"A", "B"},
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -961,12 +961,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstanceWithoutChanges(c *check.
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "Awesome description about brainsql",
 		"teamowner":   s.team.Name,
 		"plan":        "large",
 		"tags":        []string{"A", "B"},
-		"parameters": map[string]interface{}{
+		"parameters": map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -984,7 +984,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParameters(c *check.
 		Teams:       []string{s.team.Name},
 		TeamOwner:   s.team.Name,
 		PlanName:    "large",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage":       "hdd",
 			"old-parameter": "old-value",
 		},
@@ -993,12 +993,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParameters(c *check.
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "",
 		"plan":        "large",
 		"teamowner":   s.team.Name,
 		"tags":        []string{},
-		"parameters": map[string]interface{}{
+		"parameters": map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -1017,7 +1017,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParameters(c *check.
 		Jobs:        []string{},
 		Tags:        []string{},
 		PlanName:    "large",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -1031,7 +1031,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParametersWithoutPer
 		Teams:       []string{s.team.Name},
 		TeamOwner:   s.team.Name,
 		PlanName:    "large",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -1040,12 +1040,12 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParametersWithoutPer
 	c.Assert(err, check.IsNil)
 	_, err = serviceInstancesCollection.InsertOne(stdContext.TODO(), si)
 	c.Assert(err, check.IsNil)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"description": "changed",
 		"plan":        "large",
 		"teamowner":   s.team.Name,
 		"tags":        []string{},
-		"parameters": map[string]interface{}{
+		"parameters": map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -1068,7 +1068,7 @@ func (s *ServiceInstanceSuite) TestUpdateServiceInstancePlanParametersWithoutPer
 		Jobs:        []string{},
 		Tags:        []string{},
 		PlanName:    "large",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage":  "ssd",
 			"replicas": "5",
 		},
@@ -1124,7 +1124,7 @@ func (s *ServiceInstanceSuite) TestRemoveServiceServiceInstance(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":service", "value": "foo"},
 			{"name": ":instance", "value": "foo-instance"},
 		},
@@ -1576,7 +1576,7 @@ func (s *ServiceInstanceSuite) TestListServiceInstancesAppFilter(c *check.C) {
 				Jobs:        []string{},
 				Teams:       []string{s.team.Name},
 				Tags:        []string{},
-				Parameters:  map[string]interface{}(nil),
+				Parameters:  map[string]any(nil),
 			},
 		}},
 		{Service: "redis", Instances: []string{}, Plans: []string(nil)},
@@ -1871,7 +1871,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfo(c *check.C) {
 		Pool:        "my-pool",
 		Description: "desc",
 		Tags:        []string{"tag 1"},
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage-type": "ssd",
 		},
 	}
@@ -1904,7 +1904,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfo(c *check.C) {
 		PlanDescription: "no space left for you",
 		Description:     si.Description,
 		Tags:            []string{"tag 1"},
-		Parameters:      map[string]interface{}{"storage-type": "ssd"},
+		Parameters:      map[string]any{"storage-type": "ssd"},
 	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
@@ -1941,7 +1941,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoWithRemovedPlan(c *check.C
 		Pool:        "my-pool",
 		Description: "desc",
 		Tags:        []string{"tag 1"},
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"storage-type": "ssd",
 		},
 	}
@@ -1973,7 +1973,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoWithRemovedPlan(c *check.C
 		PlanName:    "plan1",
 		Description: si.Description,
 		Tags:        []string{"tag 1"},
-		Parameters:  map[string]interface{}{"storage-type": "ssd"},
+		Parameters:  map[string]any{"storage-type": "ssd"},
 	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
@@ -2020,7 +2020,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoForJob(c *check.C) {
 		PlanDescription: "",
 		Description:     si.Description,
 		Tags:            []string{"tag 1", "tag 2"},
-		Parameters:      map[string]interface{}{},
+		Parameters:      map[string]any{},
 	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
@@ -2067,7 +2067,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceInfoNoPlanAndNoCustomInfo(c *c
 		PlanDescription: "",
 		Description:     si.Description,
 		Tags:            []string{"tag 1", "tag 2"},
-		Parameters:      map[string]interface{}{},
+		Parameters:      map[string]any{},
 	}
 	c.Assert(instances, check.DeepEquals, expected)
 }
@@ -2689,7 +2689,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyPost(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "callback", "value": "/resources/foo-instance/mypath"},
 			{"name": "method", "value": "POST"},
 			{"name": "my", "value": "awesome"},
@@ -2743,7 +2743,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyV2Post(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":instance", "value": "foo-instance"},
 			{"name": ":mux-path-template", "value": "/services/{service}/resources/{instance}/{path:.*}"},
 			{"name": ":path", "value": "mypath"},
@@ -2801,7 +2801,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyPostRawBody(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "callback", "value": "/resources/foo-instance/mypath"},
 			{"name": "method", "value": "POST"},
 		},
@@ -2853,7 +2853,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyPostJSON(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "callback", "value": "/resources/foo-instance/mypath"},
 			{"name": "method", "value": "POST"},
 			{"name": "my", "value": "awesome"},
@@ -2942,7 +2942,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyOnlyPath(c *check.C) {
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "callback", "value": "/mypath"},
 			{"name": "method", "value": "POST"},
 		},
@@ -2979,7 +2979,7 @@ func (s *ServiceInstanceSuite) TestServiceInstanceProxyForbiddenPath(c *check.C)
 		Target: serviceInstanceTarget("foo", "foo-instance"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "callback", "value": "/"},
 			{"name": "method", "value": "POST"},
 		},
@@ -3012,7 +3012,7 @@ func (s *ServiceInstanceSuite) TestGrantRevokeServiceToTeam(c *check.C) {
 		Target: serviceInstanceTarget("go", "si-test"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.grant",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": "test"},
 		},
 	}, eventtest.HasEvent)
@@ -3030,7 +3030,7 @@ func (s *ServiceInstanceSuite) TestGrantRevokeServiceToTeam(c *check.C) {
 		Target: serviceInstanceTarget("go", "si-test"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service-instance.update.revoke",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":team", "value": "test"},
 		},
 	}, eventtest.HasEvent)

--- a/api/service_test.go
+++ b/api/service_test.go
@@ -172,7 +172,7 @@ func (s *ProvisionSuite) TestServiceCreate(c *check.C) {
 		Target: serviceTarget("some-service"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team", "value": "tsuruteam"},
 			{"name": "username", "value": "test"},
 			{"name": "endpoint", "value": "someservice.com"},
@@ -213,7 +213,7 @@ func (s *ProvisionSuite) TestServiceCreateMultipleEndpoints(c *check.C) {
 		Target: serviceTarget("some-service"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "team", "value": "tsuruteam"},
 			{"name": "username", "value": "test"},
 			{"name": "endpoints.cluster1", "value": "cluster1.com"},
@@ -441,7 +441,7 @@ func (s *ProvisionSuite) TestServiceUpdate(c *check.C) {
 		Target: serviceTarget("mysqlapi"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "username", "value": "mysqltest"},
 			{"name": "endpoint", "value": "mysqlapi.com"},
 		},
@@ -571,7 +571,7 @@ func (s *ProvisionSuite) TestServiceUpdateWithoutTeamIgnoresOwnerTeams(c *check.
 		Target: serviceTarget("mysqlapi"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "username", "value": "mysqltest"},
 			{"name": "endpoint", "value": "mysqlapi.com"},
 		},
@@ -675,7 +675,7 @@ func (s *ProvisionSuite) TestDeleteHandler(c *check.C) {
 		Target: serviceTarget("mysql"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "mysql"},
 		},
 	}, eventtest.HasEvent)
@@ -864,7 +864,7 @@ func (s *ProvisionSuite) TestServiceProxyPost(c *check.C) {
 		Target: serviceTarget("foo"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":service", "value": "foo"},
 			{"name": "callback", "value": "/mypath"},
 			{"name": "method", "value": http.MethodPost},
@@ -925,7 +925,7 @@ func (s *ProvisionSuite) TestServiceProxyPostRawBody(c *check.C) {
 		Target: serviceTarget("foo"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update.proxy",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":service", "value": "foo"},
 			{"name": "callback", "value": "/mypath"},
 			{"name": "method", "value": http.MethodPost},
@@ -1044,7 +1044,7 @@ func (s *ProvisionSuite) TestGrantServiceAccessToTeam(c *check.C) {
 		Target: serviceTarget("my-service"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update.grant-access",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":service", "value": "my-service"},
 			{"name": ":team", "value": t.Name},
 		},
@@ -1126,7 +1126,7 @@ func (s *ProvisionSuite) TestRevokeServiceAccessFromTeamRemovesTeamFromService(c
 		Target: serviceTarget("my-service"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update.revoke-access",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":service", "value": "my-service"},
 			{"name": ":team", "value": s.team.Name},
 		},
@@ -1250,7 +1250,7 @@ func (s *ProvisionSuite) TestAddDoc(c *check.C) {
 		Target: serviceTarget("some-service"),
 		Owner:  s.token.GetUserName(),
 		Kind:   "service.update.doc",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":name", "value": "some-service"},
 			{"name": "doc", "value": "doc"},
 		},

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -64,7 +64,7 @@ func (c *hasAccessToChecker) Info() *check.CheckerInfo {
 	return &check.CheckerInfo{Name: "HasAccessTo", Params: []string{"team", "service"}}
 }
 
-func (c *hasAccessToChecker) Check(params []interface{}, names []string) (bool, string) {
+func (c *hasAccessToChecker) Check(params []any, names []string) (bool, string) {
 	if len(params) != 2 {
 		return false, "you must provide two parameters"
 	}

--- a/api/team_token_test.go
+++ b/api/team_token_test.go
@@ -98,7 +98,7 @@ func (s *S) TestTeamTokenCreate(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: s.team.Name},
 		Owner:  s.user.Email,
 		Kind:   "team.token.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "token_id", "value": "t1"},
 			{"name": "description", "value": "desc"},
 			{"name": "expires_in", "value": "60"},
@@ -135,7 +135,7 @@ func (s *S) TestTeamTokenCreateAutomaticTeam(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: s.team.Name},
 		Owner:  s.user.Email,
 		Kind:   "team.token.create",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": "token_id", "value": "t1"},
 			{"name": "description", "value": "desc"},
 			{"name": "expires_in", "value": "60"},
@@ -185,7 +185,7 @@ func (s *S) TestTeamTokenDelete(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: s.team.Name},
 		Owner:  s.user.Email,
 		Kind:   "team.token.delete",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":token_id", "value": "id1"},
 		},
 	}, eventtest.HasEvent)
@@ -233,7 +233,7 @@ func (s *S) TestTeamTokenUpdate(c *check.C) {
 		Target: eventTypes.Target{Type: eventTypes.TargetTypeTeam, Value: s.team.Name},
 		Owner:  s.user.Email,
 		Kind:   "team.token.update",
-		StartCustomData: []map[string]interface{}{
+		StartCustomData: []map[string]any{
 			{"name": ":token_id", "value": "id1"},
 			{"name": "regenerate", "value": "true"},
 		},

--- a/api/volume_test.go
+++ b/api/volume_test.go
@@ -39,7 +39,7 @@ func (s *S) TestVolumeList(c *check.C) {
 			TeamOwner: s.team.Name,
 			Plan: volumeTypes.VolumePlan{
 				Name: "nfs",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"plugin":       "nfs",
 					"capacity":     "20Gi",
 					"access-modes": "ReadWriteMany",
@@ -65,7 +65,7 @@ func (s *S) TestVolumeList(c *check.C) {
 		TeamOwner: s.team.Name,
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin":       "nfs",
 				"capacity":     "20Gi",
 				"access-modes": "ReadWriteMany",
@@ -176,7 +176,7 @@ func (s *S) TestVolumeListBinded(c *check.C) {
 			},
 			Plan: volumeTypes.VolumePlan{
 				Name: "nfs",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"plugin":       "nfs",
 					"capacity":     "20Gi",
 					"access-modes": "ReadWriteMany",
@@ -218,7 +218,7 @@ func (s *S) TestVolumeListBinded(c *check.C) {
 		},
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin":       "nfs",
 				"capacity":     "20Gi",
 				"access-modes": "ReadWriteMany",
@@ -255,7 +255,7 @@ func (s *S) TestVolumeInfo(c *check.C) {
 	s.mockService.VolumeService.OnGet = func(ctx context.Context, appName string) (*volumeTypes.Volume, error) {
 		v1.Plan = volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"access-modes": "ReadWriteMany",
 				"capacity":     "20Gi",
 				"plugin":       "nfs",
@@ -299,7 +299,7 @@ func (s *S) TestVolumeInfo(c *check.C) {
 		TeamOwner: s.team.Name,
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"access-modes": "ReadWriteMany",
 				"capacity":     "20Gi",
 				"plugin":       "nfs",
@@ -358,7 +358,7 @@ func (s *S) TestVolumeCreate(c *check.C) {
 				Opts:      map[string]string{"a": "b"},
 				Plan: volumeTypes.VolumePlan{
 					Name: "nfs",
-					Opts: map[string]interface{}{
+					Opts: map[string]any{
 						"plugin": "nfs",
 					},
 				},
@@ -385,7 +385,7 @@ func (s *S) TestVolumeCreate(c *check.C) {
 		Opts:      map[string]string{"a": "b"},
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin": "nfs",
 			},
 		},
@@ -462,7 +462,7 @@ func (s *S) TestVolumeUpdate(c *check.C) {
 				Opts:      map[string]string{"a": "c"},
 				Plan: volumeTypes.VolumePlan{
 					Name: "nfs",
-					Opts: map[string]interface{}{
+					Opts: map[string]any{
 						"plugin": "nfs",
 					},
 				},
@@ -478,7 +478,7 @@ func (s *S) TestVolumeUpdate(c *check.C) {
 		Opts:      map[string]string{"a": "c"},
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin": "nfs",
 			},
 		},
@@ -515,11 +515,11 @@ func (s *S) TestVolumePlanList(c *check.C) {
 	s.mockService.VolumeService.OnListPlans = func(ctx context.Context) (map[string][]volumeTypes.VolumePlan, error) {
 		return map[string][]volumeTypes.VolumePlan{
 			"fake": {
-				{Name: "nfs1", Opts: map[string]interface{}{"plugin": "nfs"}},
-				{Name: "other", Opts: map[string]interface{}{"storage-class": "ebs"}},
+				{Name: "nfs1", Opts: map[string]any{"plugin": "nfs"}},
+				{Name: "other", Opts: map[string]any{"storage-class": "ebs"}},
 			},
 			"otherprov": {
-				{Name: "nfs1", Opts: map[string]interface{}{"opts": "-t=nfs"}},
+				{Name: "nfs1", Opts: map[string]any{"opts": "-t=nfs"}},
 			},
 		}, nil
 	}
@@ -539,11 +539,11 @@ func (s *S) TestVolumePlanList(c *check.C) {
 	}
 	c.Assert(result, check.DeepEquals, map[string][]volumeTypes.VolumePlan{
 		"fake": {
-			{Name: "nfs1", Opts: map[string]interface{}{"plugin": "nfs"}},
-			{Name: "other", Opts: map[string]interface{}{"storage-class": "ebs"}},
+			{Name: "nfs1", Opts: map[string]any{"plugin": "nfs"}},
+			{Name: "other", Opts: map[string]any{"storage-class": "ebs"}},
 		},
 		"otherprov": {
-			{Name: "nfs1", Opts: map[string]interface{}{"opts": "-t=nfs"}},
+			{Name: "nfs1", Opts: map[string]any{"opts": "-t=nfs"}},
 		},
 	})
 }
@@ -600,7 +600,7 @@ func (s *S) TestVolumeBind(c *check.C) {
 			},
 			Plan: volumeTypes.VolumePlan{
 				Name: "nfs",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"plugin": "nfs",
 				},
 			},
@@ -660,7 +660,7 @@ func (s *S) TestVolumeBind(c *check.C) {
 		},
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin": "nfs",
 			},
 		},
@@ -758,7 +758,7 @@ func (s *S) TestVolumeUnbind(c *check.C) {
 			},
 			Plan: volumeTypes.VolumePlan{
 				Name: "nfs",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"plugin": "nfs",
 				},
 			},
@@ -814,7 +814,7 @@ func (s *S) TestVolumeUnbind(c *check.C) {
 		},
 		Plan: volumeTypes.VolumePlan{
 			Name: "nfs",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"plugin": "nfs",
 			},
 		},

--- a/app/actions_test.go
+++ b/app/actions_test.go
@@ -59,7 +59,7 @@ func (s *S) TestBootstrapDeployAppName(c *check.C) {
 func (s *S) TestInsertAppForward(c *check.C) {
 	app := &appTypes.App{Name: "conviction", Platform: "evergrey"}
 	ctx := action.FWContext{
-		Params: []interface{}{app},
+		Params: []any{app},
 	}
 	r, err := insertApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -77,7 +77,7 @@ func (s *S) TestInsertAppForwardWithQuota(c *check.C) {
 	defer config.Unset("quota:units-per-app")
 	app := &appTypes.App{Name: "come", Platform: "beatles"}
 	ctx := action.FWContext{
-		Params: []interface{}{app},
+		Params: []any{app},
 	}
 	r, err := insertApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -101,7 +101,7 @@ func (s *S) TestInsertAppForwardWithQuota(c *check.C) {
 func (s *S) TestInsertAppForwardAppPointer(c *check.C) {
 	app := appTypes.App{Name: "conviction", Platform: "evergrey"}
 	ctx := action.FWContext{
-		Params: []interface{}{&app},
+		Params: []any{&app},
 	}
 	r, err := insertApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -116,7 +116,7 @@ func (s *S) TestInsertAppForwardAppPointer(c *check.C) {
 func (s *S) TestInsertAppForwardInvalidValue(c *check.C) {
 	app := appTypes.App{Name: "conviction", Platform: "evergrey"}
 	ctx := action.FWContext{
-		Params: []interface{}{app},
+		Params: []any{app},
 	}
 	r, err := insertApp.Forward(ctx)
 	c.Assert(r, check.IsNil)
@@ -129,7 +129,7 @@ func (s *S) TestInsertAppDuplication(c *check.C) {
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
 	ctx := action.FWContext{
-		Params: []interface{}{&app},
+		Params: []any{&app},
 	}
 	r, err := insertApp.Forward(ctx)
 	c.Assert(r, check.IsNil)
@@ -142,7 +142,7 @@ func (s *S) TestInsertAppBackward(c *check.C) {
 
 	app := appTypes.App{Name: "conviction", Platform: "evergrey", TeamOwner: s.team.Name}
 	ctx := action.BWContext{
-		Params:   []interface{}{app},
+		Params:   []any{app},
 		FWResult: &app,
 	}
 	err = CreateApp(context.TODO(), &app, s.user)
@@ -163,7 +163,7 @@ func (s *S) TestExportEnvironmentsForward(c *check.C) {
 	app := appTypes.App{Name: "mist", Platform: "opeth", TeamOwner: s.team.Name}
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
-	ctx := action.FWContext{Params: []interface{}{&app}}
+	ctx := action.FWContext{Params: []any{&app}}
 	result, err := exportEnvironmentsAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.FitsTypeOf, &app)
@@ -193,7 +193,7 @@ func (s *S) TestExportEnvironmentsBackward(c *check.C) {
 	}
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
-	ctx := action.BWContext{Params: []interface{}{&app}}
+	ctx := action.BWContext{Params: []any{&app}}
 	exportEnvironmentsAction.Backward(ctx)
 	copy, err := GetByName(context.TODO(), app.Name)
 	c.Assert(err, check.IsNil)
@@ -219,7 +219,7 @@ func (s *S) TestProvisionAppForward(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	ctx := action.FWContext{Params: []interface{}{&app, 4}}
+	ctx := action.FWContext{Params: []any{&app, 4}}
 	result, err := provisionApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	a, ok := result.(*appTypes.App)
@@ -239,7 +239,7 @@ func (s *S) TestProvisionAppForwardAppPointer(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	ctx := action.FWContext{Params: []interface{}{&app, 4}}
+	ctx := action.FWContext{Params: []any{&app, 4}}
 	result, err := provisionApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	a, ok := result.(*appTypes.App)
@@ -249,7 +249,7 @@ func (s *S) TestProvisionAppForwardAppPointer(c *check.C) {
 }
 
 func (s *S) TestProvisionAppForwardInvalidApp(c *check.C) {
-	ctx := action.FWContext{Params: []interface{}{"something", 1}}
+	ctx := action.FWContext{Params: []any{"something", 1}}
 	_, err := provisionApp.Forward(ctx)
 	c.Assert(err, check.NotNil)
 }
@@ -265,10 +265,10 @@ func (s *S) TestProvisionAppBackward(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	fwctx := action.FWContext{Params: []interface{}{&app, 4}}
+	fwctx := action.FWContext{Params: []any{&app, 4}}
 	result, err := provisionApp.Forward(fwctx)
 	c.Assert(err, check.IsNil)
-	bwctx := action.BWContext{Params: []interface{}{&app, 4}, FWResult: result}
+	bwctx := action.BWContext{Params: []any{&app, 4}, FWResult: result}
 	provisionApp.Backward(bwctx)
 	c.Assert(s.provisioner.Provisioned(&app), check.Equals, false)
 }
@@ -288,7 +288,7 @@ func (s *S) TestBootstrapDeployAppForwardNoConfig(c *check.C) {
 	c.Assert(err, check.IsNil)
 	ctx := action.FWContext{
 		Context: context.TODO(),
-		Params:  []interface{}{app},
+		Params:  []any{app},
 	}
 	result, err := bootstrapDeployApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -316,7 +316,7 @@ func (s *S) TestBootstrapDeployAppForwardWithConfig(c *check.C) {
 	c.Assert(err, check.IsNil)
 	ctx := action.FWContext{
 		Context: context.TODO(),
-		Params:  []interface{}{app},
+		Params:  []any{app},
 	}
 	result, err := bootstrapDeployApp.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -339,7 +339,7 @@ func (s *S) TestBootstrapDeployAppForwardWithConfig(c *check.C) {
 func (s *S) TestBootstrapDeployAppForwardInvalidParam(c *check.C) {
 	ctx := action.FWContext{
 		Context: context.TODO(),
-		Params:  []interface{}{"invalid"},
+		Params:  []any{"invalid"},
 	}
 	result, err := bootstrapDeployApp.Forward(ctx)
 	c.Assert(result, check.IsNil)
@@ -367,7 +367,7 @@ func (s *S) TestReserveUserAppForward(c *check.C) {
 		Platform: "django",
 	}
 	expected := map[string]string{"user": user.Email, "app": app.Name}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{&app, &user}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{&app, &user}})
 	c.Assert(err, check.IsNil)
 	c.Assert(previous, check.DeepEquals, expected)
 }
@@ -388,7 +388,7 @@ func (s *S) TestReserveUserAppForwardNonPointer(c *check.C) {
 		Platform: "django",
 	}
 	expected := map[string]string{"user": user.Email, "app": app.Name}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{&app, user}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{&app, user}})
 	c.Assert(err, check.IsNil)
 	c.Assert(previous, check.DeepEquals, expected)
 }
@@ -409,14 +409,14 @@ func (s *S) TestReserveUserAppForwardAppNotPointer(c *check.C) {
 		Platform: "django",
 	}
 	expected := map[string]string{"user": user.Email, "app": app.Name}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{&app, user}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{&app, user}})
 	c.Assert(err, check.IsNil)
 	c.Assert(previous, check.DeepEquals, expected)
 }
 
 func (s *S) TestReserveUserAppForwardInvalidApp(c *check.C) {
 	user := auth.User{Email: "clap@yes.com"}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{"something", user}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{"something", user}})
 	c.Assert(previous, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be *App.")
@@ -427,7 +427,7 @@ func (s *S) TestReserveUserAppForwardInvalidUser(c *check.C) {
 		Name:     "clap",
 		Platform: "django",
 	}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{&app, "something"}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{&app, "something"}})
 	c.Assert(previous, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be auth.User or *auth.User.")
@@ -448,7 +448,7 @@ func (s *S) TestReserveUserAppForwardQuotaExceeded(c *check.C) {
 		Name:     "clap",
 		Platform: "django",
 	}
-	previous, err := reserveUserApp.Forward(action.FWContext{Params: []interface{}{&app, user}})
+	previous, err := reserveUserApp.Forward(action.FWContext{Params: []any{&app, user}})
 	c.Assert(previous, check.IsNil)
 	e, ok := err.(*quota.QuotaExceededError)
 	c.Assert(ok, check.Equals, true)
@@ -501,7 +501,7 @@ func (s *S) TestReserveUnitsToAddForward(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{&app, 3}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{&app, 3}})
 	c.Assert(err, check.IsNil)
 	c.Assert(result.(int), check.Equals, 3)
 }
@@ -523,7 +523,7 @@ func (s *S) TestReserveUnitsToAddForwardUint(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{&app, uint(3)}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{&app, uint(3)}})
 	c.Assert(err, check.IsNil)
 	c.Assert(result.(int), check.Equals, 3)
 }
@@ -545,7 +545,7 @@ func (s *S) TestReserveUnitsToAddForwardQuotaExceeded(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{&app, 1}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{&app, 1}})
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
 	e, ok := err.(*quota.QuotaExceededError)
@@ -555,7 +555,7 @@ func (s *S) TestReserveUnitsToAddForwardQuotaExceeded(c *check.C) {
 }
 
 func (s *S) TestReserveUnitsToAddForwardInvalidApp(c *check.C) {
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{"something", 3}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{"something", 3}})
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be *App.")
@@ -563,14 +563,14 @@ func (s *S) TestReserveUnitsToAddForwardInvalidApp(c *check.C) {
 
 func (s *S) TestReserveUnitsToAddAppNotFound(c *check.C) {
 	app := appTypes.App{Name: "something"}
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{&app, 3}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{&app, 3}})
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "App not found")
 }
 
 func (s *S) TestReserveUnitsToAddForwardInvalidNumber(c *check.C) {
-	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []interface{}{&appTypes.App{}, "what"}})
+	result, err := reserveUnitsToAdd.Forward(action.FWContext{Params: []any{&appTypes.App{}, "what"}})
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be int or uint.")
@@ -593,7 +593,7 @@ func (s *S) TestReserveUnitsToAddBackward(c *check.C) {
 	}
 	_, err = appsCollection.InsertOne(context.TODO(), app)
 	c.Assert(err, check.IsNil)
-	reserveUnitsToAdd.Backward(action.BWContext{Params: []interface{}{&app, 3}, FWResult: 3})
+	reserveUnitsToAdd.Backward(action.BWContext{Params: []any{&app, 3}, FWResult: 3})
 }
 
 func (s *S) TestReserveUnitsMinParams(c *check.C) {
@@ -609,7 +609,7 @@ func (s *S) TestProvisionAddUnits(c *check.C) {
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
 	version := newSuccessfulAppVersion(c, &app)
-	ctx := action.FWContext{Previous: 3, Params: []interface{}{&app, 3, nil, "web", version}}
+	ctx := action.FWContext{Previous: 3, Params: []any{&app, 3, nil, "web", version}}
 	_, err = provisionAddUnits.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	units := s.provisioner.GetUnits(&app)
@@ -626,7 +626,7 @@ func (s *S) TestProvisionAddUnitsProvisionFailure(c *check.C) {
 	err := CreateApp(context.TODO(), &app, s.user)
 	c.Assert(err, check.IsNil)
 	version := newSuccessfulAppVersion(c, &app)
-	ctx := action.FWContext{Previous: 3, Params: []interface{}{&app, 3, nil, "web", version}}
+	ctx := action.FWContext{Previous: 3, Params: []any{&app, 3, nil, "web", version}}
 	result, err := provisionAddUnits.Forward(ctx)
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
@@ -634,7 +634,7 @@ func (s *S) TestProvisionAddUnitsProvisionFailure(c *check.C) {
 }
 
 func (s *S) TestProvisionAddUnitsInvalidApp(c *check.C) {
-	result, err := provisionAddUnits.Forward(action.FWContext{Params: []interface{}{"something"}})
+	result, err := provisionAddUnits.Forward(action.FWContext{Params: []any{"something"}})
 	c.Assert(result, check.IsNil)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be *App.")
@@ -661,7 +661,7 @@ func (s *S) TestUpdateAppProvisionerBackward(c *check.C) {
 	newSuccessfulAppVersion(c, &app)
 	err = AddUnits(ctx, &app, 1, "web", "", nil)
 	c.Assert(err, check.IsNil)
-	fwctx := action.FWContext{Params: []interface{}{&newApp, &app, io.Discard}}
+	fwctx := action.FWContext{Params: []any{&newApp, &app, io.Discard}}
 	_, err = updateAppProvisioner.Forward(fwctx)
 	c.Assert(err, check.IsNil)
 	units, err := AppUnits(ctx, &app)
@@ -669,7 +669,7 @@ func (s *S) TestUpdateAppProvisionerBackward(c *check.C) {
 	provApp, err := p1.GetAppFromUnitID(units[0].ID)
 	c.Assert(err, check.IsNil)
 	c.Assert(provApp.Platform, check.Equals, "python")
-	bwctx := action.BWContext{Params: []interface{}{&newApp, &app, io.Discard}}
+	bwctx := action.BWContext{Params: []any{&newApp, &app, io.Discard}}
 	updateAppProvisioner.Backward(bwctx)
 	units, err = AppUnits(ctx, &app)
 	c.Assert(err, check.IsNil)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1805,12 +1805,12 @@ func (s *S) TestAddInstanceFirst(c *check.C) {
 	serviceEnv := allEnvs[tsuruEnvs.TsuruServicesEnvVar]
 	c.Assert(serviceEnv.Name, check.Equals, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(serviceEnv.Public, check.Equals, false)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(serviceEnv.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"srv1": []interface{}{
-			map[string]interface{}{"instance_name": "myinstance", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"srv1": []any{
+			map[string]any{"instance_name": "myinstance", "envs": map[string]any{
 				"DATABASE_HOST": "localhost",
 				"DATABASE_PORT": "3306",
 				"DATABASE_USER": "root",
@@ -1866,12 +1866,12 @@ func (s *S) TestAddInstanceDuplicated(c *check.C) {
 	serviceEnv := allEnvs[tsuruEnvs.TsuruServicesEnvVar]
 	c.Assert(serviceEnv.Name, check.Equals, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(serviceEnv.Public, check.Equals, false)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(serviceEnv.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"srv1": []interface{}{
-			map[string]interface{}{"instance_name": "myinstance", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"srv1": []any{
+			map[string]any{"instance_name": "myinstance", "envs": map[string]any{
 				"ZMQ_PEER": "8.8.8.8",
 			}},
 		},
@@ -1904,12 +1904,12 @@ func (s *S) TestAddInstanceWithUnits(c *check.C) {
 	serviceEnv := allEnvs[tsuruEnvs.TsuruServicesEnvVar]
 	c.Assert(serviceEnv.Name, check.Equals, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(serviceEnv.Public, check.Equals, false)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(serviceEnv.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"myservice": []interface{}{
-			map[string]interface{}{"instance_name": "myinstance", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"myservice": []any{
+			map[string]any{"instance_name": "myinstance", "envs": map[string]any{
 				"DATABASE_HOST": "localhost",
 			}},
 		},
@@ -1944,12 +1944,12 @@ func (s *S) TestAddInstanceWithUnitsNoRestart(c *check.C) {
 	serviceEnv := allEnvs[tsuruEnvs.TsuruServicesEnvVar]
 	c.Assert(serviceEnv.Name, check.Equals, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(serviceEnv.Public, check.Equals, false)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(serviceEnv.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"myservice": []interface{}{
-			map[string]interface{}{"instance_name": "myinstance", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"myservice": []any{
+			map[string]any{"instance_name": "myinstance", "envs": map[string]any{
 				"DATABASE_HOST": "localhost",
 			}},
 		},
@@ -1992,20 +1992,20 @@ func (s *S) TestAddInstanceMultipleServices(c *check.C) {
 	serviceEnv := allEnvs[tsuruEnvs.TsuruServicesEnvVar]
 	c.Assert(serviceEnv.Name, check.Equals, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(serviceEnv.Public, check.Equals, false)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(serviceEnv.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "instance1", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "instance1", "envs": map[string]any{
 				"DATABASE_HOST": "host1",
 			}},
-			map[string]interface{}{"instance_name": "instance2", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "instance2", "envs": map[string]any{
 				"DATABASE_HOST": "host2",
 			}},
 		},
-		"mongodb": []interface{}{
-			map[string]interface{}{"instance_name": "instance3", "envs": map[string]interface{}{
+		"mongodb": []any{
+			map[string]any{"instance_name": "instance3", "envs": map[string]any{
 				"DATABASE_HOST": "host3",
 			}},
 		},
@@ -2043,15 +2043,15 @@ func (s *S) TestAddInstanceAndRemoveInstanceMultipleServices(c *check.C) {
 		ManagedBy: "mysql/instance2",
 		Public:    false,
 	})
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "instance1", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "instance1", "envs": map[string]any{
 				"DATABASE_HOST": "host1",
 			}},
-			map[string]interface{}{"instance_name": "instance2", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "instance2", "envs": map[string]any{
 				"DATABASE_HOST": "host2",
 			}},
 		},
@@ -2071,9 +2071,9 @@ func (s *S) TestAddInstanceAndRemoveInstanceMultipleServices(c *check.C) {
 	})
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "instance1", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "instance1", "envs": map[string]any{
 				"DATABASE_HOST": "host1",
 			}},
 		},
@@ -2099,10 +2099,10 @@ func (s *S) TestRemoveInstance(c *check.C) {
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
 	c.Assert(allEnvs["DATABASE_HOST"], check.DeepEquals, bindTypes.EnvVar{})
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{})
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{})
 	c.Assert(s.provisioner.Restarts(a, ""), check.Equals, 0)
 }
 
@@ -2131,21 +2131,21 @@ func (s *S) TestRemoveInstanceShifts(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "mydb", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "mydb", "envs": map[string]any{
 				"DATABASE_NAME": "mydb",
 			}},
-			map[string]interface{}{"instance_name": "yourdb", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "yourdb", "envs": map[string]any{
 				"DATABASE_NAME": "yourdb",
 			}},
-			map[string]interface{}{"instance_name": "herdb", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "herdb", "envs": map[string]any{
 				"DATABASE_NAME": "herdb",
 			}},
-			map[string]interface{}{"instance_name": "ourdb", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "ourdb", "envs": map[string]any{
 				"DATABASE_NAME": "ourdb",
 			}},
 		},
@@ -2175,12 +2175,12 @@ func (s *S) TestRemoveInstanceNotFound(c *check.C) {
 	a, err = GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "mydb", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "mydb", "envs": map[string]any{
 				"DATABASE_NAME": "mydb",
 			}},
 		},
@@ -2210,12 +2210,12 @@ func (s *S) TestRemoveInstanceServiceNotFound(c *check.C) {
 	a, err = GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"mysql": []interface{}{
-			map[string]interface{}{"instance_name": "mydb", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"mysql": []any{
+			map[string]any{"instance_name": "mydb", "envs": map[string]any{
 				"DATABASE_NAME": "mydb",
 			}},
 		},
@@ -2248,10 +2248,10 @@ func (s *S) TestRemoveInstanceWithUnits(c *check.C) {
 	a, err = GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{})
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{})
 	c.Assert(allEnvs["DATABASE_NAME"], check.DeepEquals, bindTypes.EnvVar{})
 	c.Assert(s.provisioner.Restarts(a, ""), check.Equals, 1)
 	c.Assert(s.provisioner.RestartsByVersion(a, ""), check.Equals, 1)
@@ -2278,10 +2278,10 @@ func (s *S) TestRemoveInstanceWithUnitsNoRestart(c *check.C) {
 	a, err = GetByName(context.TODO(), a.Name)
 	c.Assert(err, check.IsNil)
 	allEnvs := provision.EnvsForApp(a)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err = json.Unmarshal([]byte(allEnvs[tsuruEnvs.TsuruServicesEnvVar].Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{})
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{})
 	c.Assert(allEnvs["DATABASE_NAME"], check.DeepEquals, bindTypes.EnvVar{})
 	c.Assert(s.provisioner.Restarts(a, ""), check.Equals, 0)
 }
@@ -2578,18 +2578,18 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(units, check.HasLen, 1)
 
-	unitAddress := map[string]interface{}{}
+	unitAddress := map[string]any{}
 	rawAddress, err := json.Marshal(units[0].Address)
 	c.Assert(err, check.IsNil)
 	err = json.Unmarshal(rawAddress, &unitAddress)
 	c.Assert(err, check.IsNil)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"name":     "name",
 		"platform": "Framework",
-		"teams":    []interface{}{"myteam"},
-		"units": []interface{}{
-			map[string]interface{}{
+		"teams":    []any{"myteam"},
+		"units": []any{
+			map[string]any{
 				"Address":      unitAddress,
 				"Addresses":    nil,
 				"AppName":      "name",
@@ -2608,16 +2608,16 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 				"StatusReason": "",
 				"Type":         "Framework", "Version": 0},
 		},
-		"unitsMetrics": []interface{}{
-			map[string]interface{}{
+		"unitsMetrics": []any{
+			map[string]any{
 				"ID":     "name-0",
 				"CPU":    "10m",
 				"Memory": "100Mi",
 			},
 		},
 		"ip": "name.fakerouter.com",
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "name-web.fake-cluster.local",
 				"Protocol":   "TCP",
 				"Port":       float64(80),
@@ -2625,7 +2625,7 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 				"Process":    "web",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs.fake-cluster.local",
 				"Protocol":   "UDP",
 				"Port":       float64(12201),
@@ -2633,7 +2633,7 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 				"Process":    "logs",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs-v2.fake-cluster.local",
 				"Protocol":   "UDP",
 				"Port":       float64(12201),
@@ -2641,7 +2641,7 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 				"Process":    "logs",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-web-v2.fake-cluster.local",
 				"Protocol":   "TCP",
 				"Port":       float64(80),
@@ -2651,37 +2651,37 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 			},
 		},
 		"provisioner": "fake",
-		"cname":       []interface{}{"name.mycompany.com"},
+		"cname":       []any{"name.mycompany.com"},
 		"owner":       s.user.Email,
 		"deploys":     float64(7),
 		"pool":        "test",
 		"description": "description",
 		"teamowner":   "myteam",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "myplan",
 			"memory":   float64(64),
 			"cpumilli": float64(0),
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{"opt1": "val1"},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{"opt1": "val1"},
+		"routers": []any{
+			map[string]any{
 				"name":      "fake",
 				"address":   "name.fakerouter.com",
-				"addresses": []interface{}{"name.fakerouter.com"},
+				"addresses": []any{"name.fakerouter.com"},
 				"type":      "fake",
-				"opts":      map[string]interface{}{"opt1": "val1"},
+				"opts":      map[string]any{"opt1": "val1"},
 				"status":    "ready",
 			},
 		},
-		"tags": []interface{}{"tag a", "tag b"},
-		"metadata": map[string]interface{}{
+		"tags": []any{"tag a", "tag b"},
+		"metadata": map[string]any{
 			"annotations": nil,
 			"labels":      nil,
 		},
-		"volumeBinds": []interface{}{
-			map[string]interface{}{
-				"ID": map[string]interface{}{
+		"volumeBinds": []any{
+			map[string]any{
+				"ID": map[string]any{
 					"App":        "name",
 					"MountPoint": "/mnt",
 					"Volume":     "test-volume",
@@ -2689,18 +2689,18 @@ func (s *S) TestAppMarshalJSON(c *check.C) {
 				"ReadOnly": true,
 			},
 		},
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(0),
 			"limit": float64(-1),
 		},
-		"serviceInstanceBinds": []interface{}{},
+		"serviceInstanceBinds": []any{},
 		"dashboardURL":         "http://mydashboard.com/pools/test/apps/name",
 	}
 	appInfo, err := AppInfo(context.TODO(), &app)
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, tsuruTest.JSONEquals, expected)
@@ -2736,14 +2736,14 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"name":     "name",
 		"platform": "Framework",
-		"teams":    []interface{}{"team1"},
-		"units":    []interface{}{},
+		"teams":    []any{"team1"},
+		"units":    []any{},
 		"ip":       "name.fakerouter.com",
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "name-web.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -2751,7 +2751,7 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 				"Protocol":   "TCP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -2759,7 +2759,7 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs-v2.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -2767,7 +2767,7 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-web-v2.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -2777,58 +2777,58 @@ func (s *S) TestAppMarshalJSONWithAutoscaleProv(c *check.C) {
 			},
 		},
 		"provisioner": "fake",
-		"cname":       []interface{}{"name.mycompany.com"},
+		"cname":       []any{"name.mycompany.com"},
 		"owner":       "appOwner",
 		"deploys":     float64(7),
 		"pool":        "test",
 		"description": "description",
 		"teamowner":   "myteam",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "myplan",
 			"memory":   float64(64),
 			"cpumilli": float64(0),
 		},
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"annotations": nil,
 			"labels":      nil,
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{"opt1": "val1"},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{"opt1": "val1"},
+		"routers": []any{
+			map[string]any{
 				"name":    "fake",
 				"address": "name.fakerouter.com",
-				"addresses": []interface{}{
+				"addresses": []any{
 					"name.fakerouter.com",
 				},
 				"type":   "fake",
-				"opts":   map[string]interface{}{"opt1": "val1"},
+				"opts":   map[string]any{"opt1": "val1"},
 				"status": "ready",
 			},
 		},
-		"tags": []interface{}{"tag a", "tag b"},
-		"autoscale": []interface{}{
-			map[string]interface{}{"process": "p1", "minUnits": float64(0), "maxUnits": float64(0), "version": float64(0), "behavior": map[string]interface{}{}},
+		"tags": []any{"tag a", "tag b"},
+		"autoscale": []any{
+			map[string]any{"process": "p1", "minUnits": float64(0), "maxUnits": float64(0), "version": float64(0), "behavior": map[string]any{}},
 		},
-		"autoscaleRecommendation": []interface{}{
-			map[string]interface{}{
+		"autoscaleRecommendation": []any{
+			map[string]any{
 				"process": "p1",
-				"recommendations": []interface{}{
-					map[string]interface{}{"type": "target", "cpu": "100m", "memory": "100MiB"},
+				"recommendations": []any{
+					map[string]any{"type": "target", "cpu": "100m", "memory": "100MiB"},
 				},
 			},
 		},
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(0),
 			"limit": float64(-1),
 		},
-		"serviceInstanceBinds": []interface{}{},
+		"serviceInstanceBinds": []any{},
 	}
 	appInfo, err := AppInfo(context.TODO(), &app)
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.DeepEquals, expected)
@@ -2842,11 +2842,11 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 	}
 	err := routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"name":        "name",
 		"platform":    "",
 		"teams":       nil,
-		"units":       []interface{}{},
+		"units":       []any{},
 		"ip":          "name.fakerouter.com",
 		"cname":       nil,
 		"owner":       "",
@@ -2854,37 +2854,37 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 		"pool":        "",
 		"description": "",
 		"teamowner":   "",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "",
 			"memory":   float64(0),
 			"cpumilli": float64(0),
 		},
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"annotations": nil,
 			"labels":      nil,
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{},
+		"routers": []any{
+			map[string]any{
 				"name":    "fake",
 				"address": "name.fakerouter.com",
-				"addresses": []interface{}{
+				"addresses": []any{
 					"name.fakerouter.com",
 				},
 				"type":   "fake",
-				"opts":   map[string]interface{}{},
+				"opts":   map[string]any{},
 				"status": "ready",
 			},
 		},
 		"tags":        nil,
 		"provisioner": "fake",
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(0),
 			"limit": float64(-1),
 		},
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "name-web.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -2892,7 +2892,7 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 				"Protocol":   "TCP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -2900,7 +2900,7 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs-v2.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -2908,7 +2908,7 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-web-v2.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -2917,13 +2917,13 @@ func (s *S) TestAppMarshalJSONUnitsError(c *check.C) {
 				"Version":    "2",
 			},
 		},
-		"serviceInstanceBinds": []interface{}{},
+		"serviceInstanceBinds": []any{},
 	}
 	appInfo, err := AppInfo(context.TODO(), &app)
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result["error"], check.Matches, `(?s)unable to list app units: my err.*`)
@@ -2953,50 +2953,50 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 	}
 	err = routertest.FakeRouter.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{})
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"name":        "name",
 		"platform":    "Framework:v1",
-		"teams":       []interface{}{"team1"},
-		"units":       []interface{}{},
+		"teams":       []any{"team1"},
+		"units":       []any{},
 		"ip":          "name.fakerouter.com",
-		"cname":       []interface{}{"name.mycompany.com"},
+		"cname":       []any{"name.mycompany.com"},
 		"owner":       "appOwner",
 		"deploys":     float64(7),
 		"pool":        "test",
 		"description": "description",
 		"teamowner":   "myteam",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "myplan",
 			"memory":   float64(64),
 			"cpumilli": float64(0),
 		},
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"annotations": nil,
-			"labels":      []interface{}{map[string]interface{}{"name": "label", "value": "value"}},
+			"labels":      []any{map[string]any{"name": "label", "value": "value"}},
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{"opt1": "val1"},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{"opt1": "val1"},
+		"routers": []any{
+			map[string]any{
 				"name":    "fake",
 				"address": "name.fakerouter.com",
-				"addresses": []interface{}{
+				"addresses": []any{
 					"name.fakerouter.com",
 				},
 				"type":   "fake",
-				"opts":   map[string]interface{}{"opt1": "val1"},
+				"opts":   map[string]any{"opt1": "val1"},
 				"status": "ready",
 			},
 		},
-		"tags":        []interface{}{"tag a", "tag b"},
+		"tags":        []any{"tag a", "tag b"},
 		"provisioner": "fake",
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(0),
 			"limit": float64(-1),
 		},
-		"serviceInstanceBinds": []interface{}{},
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"serviceInstanceBinds": []any{},
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "name-web.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3004,7 +3004,7 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 				"Protocol":   "TCP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3012,7 +3012,7 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-logs-v2.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3020,7 +3020,7 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "name-web-v2.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3034,7 +3034,7 @@ func (s *S) TestAppMarshalJSONPlatformLocked(c *check.C) {
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.DeepEquals, expected)
@@ -3066,53 +3066,53 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
-	c.Assert(result, check.DeepEquals, map[string]interface{}{
+	c.Assert(result, check.DeepEquals, map[string]any{
 		"name":        "my-awesome-app",
 		"platform":    "awesome-platform:v1",
-		"teams":       []interface{}{"team-one"},
-		"units":       []interface{}{},
+		"teams":       []any{"team-one"},
+		"units":       []any{},
 		"ip":          "my-awesome-app.fakerouter.com",
-		"cname":       []interface{}{"my-awesome-app.mycompany.com"},
+		"cname":       []any{"my-awesome-app.mycompany.com"},
 		"owner":       "admin@example.com",
 		"deploys":     float64(1),
 		"pool":        "my-pool",
 		"description": "Awesome description about my-awesome-app",
 		"teamowner":   "team-one",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "small",
 			"cpumilli": float64(1000),
 			"memory":   float64(128),
 		},
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"annotations": nil,
 			"labels":      nil,
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{"opt1": "val1"},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{"opt1": "val1"},
+		"routers": []any{
+			map[string]any{
 				"name":    "fake",
 				"address": "my-awesome-app.fakerouter.com",
-				"addresses": []interface{}{
+				"addresses": []any{
 					"my-awesome-app.fakerouter.com",
 				},
 				"type":   "fake",
-				"opts":   map[string]interface{}{"opt1": "val1"},
+				"opts":   map[string]any{"opt1": "val1"},
 				"status": "ready",
 			},
 		},
 		"tags":        nil,
 		"provisioner": "fake",
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(100),
 			"limit": float64(777),
 		},
-		"serviceInstanceBinds": []interface{}{},
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"serviceInstanceBinds": []any{},
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "my-awesome-app-web.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3120,7 +3120,7 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 				"Protocol":   "TCP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-logs.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3128,7 +3128,7 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-logs-v2.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3136,7 +3136,7 @@ func (s *S) TestAppMarshalJSONWithCustomQuota(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-web-v2.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3220,57 +3220,57 @@ func (s *S) TestAppMarshalJSONServiceInstanceBinds(c *check.C) {
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(appInfo)
 	c.Assert(err, check.IsNil)
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
-	c.Assert(result, check.DeepEquals, map[string]interface{}{
+	c.Assert(result, check.DeepEquals, map[string]any{
 		"name":        "my-awesome-app",
 		"platform":    "awesome-platform:v1",
-		"teams":       []interface{}{"team-one"},
-		"units":       []interface{}{},
+		"teams":       []any{"team-one"},
+		"units":       []any{},
 		"ip":          "my-awesome-app.fakerouter.com",
-		"cname":       []interface{}{"my-awesome-app.mycompany.com"},
+		"cname":       []any{"my-awesome-app.mycompany.com"},
 		"owner":       "admin@example.com",
 		"deploys":     float64(1),
 		"pool":        "my-pool",
 		"description": "Awesome description about my-awesome-app",
 		"teamowner":   "team-one",
-		"plan": map[string]interface{}{
+		"plan": map[string]any{
 			"name":     "small",
 			"cpumilli": float64(1000),
 			"memory":   float64(128),
 		},
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"annotations": nil,
 			"labels":      nil,
 		},
 		"router":     "fake",
-		"routeropts": map[string]interface{}{"opt1": "val1"},
-		"routers": []interface{}{
-			map[string]interface{}{
+		"routeropts": map[string]any{"opt1": "val1"},
+		"routers": []any{
+			map[string]any{
 				"name":    "fake",
 				"address": "my-awesome-app.fakerouter.com",
-				"addresses": []interface{}{
+				"addresses": []any{
 					"my-awesome-app.fakerouter.com",
 				},
 				"type":   "fake",
-				"opts":   map[string]interface{}{"opt1": "val1"},
+				"opts":   map[string]any{"opt1": "val1"},
 				"status": "ready",
 			},
 		},
 		"tags":        nil,
 		"provisioner": "fake",
-		"quota": map[string]interface{}{
+		"quota": map[string]any{
 			"inuse": float64(0),
 			"limit": float64(-1),
 		},
-		"serviceInstanceBinds": []interface{}{
-			map[string]interface{}{"service": "service-1", "instance": "service-1-1", "plan": ""},
-			map[string]interface{}{"service": "service-1", "instance": "service-1-2", "plan": "some-example"},
-			map[string]interface{}{"service": "service-2", "instance": "service-2-1", "plan": "another-plan"},
+		"serviceInstanceBinds": []any{
+			map[string]any{"service": "service-1", "instance": "service-1-1", "plan": ""},
+			map[string]any{"service": "service-1", "instance": "service-1-2", "plan": "some-example"},
+			map[string]any{"service": "service-2", "instance": "service-2-1", "plan": "another-plan"},
 		},
-		"internalAddresses": []interface{}{
-			map[string]interface{}{
+		"internalAddresses": []any{
+			map[string]any{
 				"Domain":     "my-awesome-app-web.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3278,7 +3278,7 @@ func (s *S) TestAppMarshalJSONServiceInstanceBinds(c *check.C) {
 				"Protocol":   "TCP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-logs.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3286,7 +3286,7 @@ func (s *S) TestAppMarshalJSONServiceInstanceBinds(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-logs-v2.fake-cluster.local",
 				"Port":       float64(12201),
 				"TargetPort": float64(12201),
@@ -3294,7 +3294,7 @@ func (s *S) TestAppMarshalJSONServiceInstanceBinds(c *check.C) {
 				"Protocol":   "UDP",
 				"Version":    "2",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"Domain":     "my-awesome-app-web-v2.fake-cluster.local",
 				"Port":       float64(80),
 				"TargetPort": float64(8080),
@@ -3572,15 +3572,15 @@ func (s *S) TestEnvsWithServiceEnvConflict(c *check.C) {
 	delete(env, "TSURU_APPNAME")
 	delete(env, "TSURU_APPDIR")
 	c.Assert(env, check.DeepEquals, expected)
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err := json.Unmarshal([]byte(serviceEnvsRaw.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"srv1": []interface{}{
-			map[string]interface{}{"instance_name": "inst1", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"srv1": []any{
+			map[string]any{"instance_name": "inst1", "envs": map[string]any{
 				"DB_HOST": "host1",
 			}},
-			map[string]interface{}{"instance_name": "inst2", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "inst2", "envs": map[string]any{
 				"DB_HOST": "host2",
 			}},
 		},

--- a/app/suite_test.go
+++ b/app/suite_test.go
@@ -55,7 +55,7 @@ func (c *greaterChecker) Info() *check.CheckerInfo {
 	return &check.CheckerInfo{Name: "Greater", Params: []string{"expected", "obtained"}}
 }
 
-func (c *greaterChecker) Check(params []interface{}, names []string) (bool, string) {
+func (c *greaterChecker) Check(params []any, names []string) (bool, string) {
 	if len(params) != 2 {
 		return false, "you should pass two values to compare"
 	}

--- a/app/version/customdata.go
+++ b/app/version/customdata.go
@@ -45,7 +45,7 @@ type tsuruYamlKubernetesProcessPortConfig struct {
 	TargetPort int    `json:"target_port,omitempty" bson:"target_port,omitempty"`
 }
 
-func unmarshalYamlData(data map[string]interface{}) (provTypes.TsuruYamlData, error) {
+func unmarshalYamlData(data map[string]any) (provTypes.TsuruYamlData, error) {
 	if data == nil {
 		return provTypes.TsuruYamlData{}, nil
 	}
@@ -91,7 +91,7 @@ func unmarshalYamlData(data map[string]interface{}) (provTypes.TsuruYamlData, er
 	return result, nil
 }
 
-func marshalCustomData(data map[string]interface{}) (map[string]interface{}, error) {
+func marshalCustomData(data map[string]any) (map[string]any, error) {
 	if len(data) == 0 {
 		return nil, nil
 	}
@@ -105,7 +105,7 @@ func marshalCustomData(data map[string]interface{}) (map[string]interface{}, err
 		return nil, err
 	}
 
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	for k, v := range data {
 		if v != nil {
 			result[k] = v
@@ -141,10 +141,10 @@ func marshalCustomData(data map[string]interface{}) (map[string]interface{}, err
 	return result, nil
 }
 
-func processesFromCustomData(customData map[string]interface{}) (map[string][]string, error) {
+func processesFromCustomData(customData map[string]any) (map[string][]string, error) {
 	var processes map[string][]string
 	if data, ok := customData["processes"]; ok {
-		procs := data.(map[string]interface{})
+		procs := data.(map[string]any)
 		processes = make(map[string][]string, len(procs))
 		for name, command := range procs {
 			switch cmdType := command.(type) {
@@ -152,7 +152,7 @@ func processesFromCustomData(customData map[string]interface{}) (map[string][]st
 				processes[name] = []string{cmdType}
 			case []string:
 				processes[name] = cmdType
-			case []interface{}:
+			case []any:
 				for _, v := range cmdType {
 					if vStr, ok := v.(string); ok {
 						processes[name] = append(processes[name], vStr)

--- a/app/version/service_test.go
+++ b/app/version/service_test.go
@@ -116,8 +116,8 @@ func (s *S) TestAppVersionService_AppVersions(c *check.C) {
 	c.Assert(versions.AppName, check.DeepEquals, "myapp")
 	c.Assert(versions.Count, check.DeepEquals, 2)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		1: {Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -169,13 +169,13 @@ func (s *S) TestAppVersionService_AllAppVersions(c *check.C) {
 	c.Assert(allVersions[0].AppName, check.Equals, "myapp1")
 	c.Assert(allVersions[0].Count, check.Equals, 1)
 	c.Assert(allVersions[0].Versions[1], check.DeepEquals, appTypes.AppVersionInfo{
-		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
+		Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
 	})
 
 	c.Assert(allVersions[1].AppName, check.Equals, "myapp2")
 	c.Assert(allVersions[1].Count, check.Equals, 1)
 	c.Assert(allVersions[1].Versions[1], check.DeepEquals, appTypes.AppVersionInfo{
-		Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
+		Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{},
 	})
 }
 
@@ -206,7 +206,7 @@ func (s *S) TestAppVersionService_DeleteVersionIDs(c *check.C) {
 	c.Assert(versions.Count, check.Equals, 2)
 	c.Assert(versions.LastSuccessfulVersion, check.Equals, 0)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 

--- a/app/version/version_test.go
+++ b/app/version/version_test.go
@@ -78,7 +78,7 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		expectedYamlData  provTypes.TsuruYamlData
 		expectedProcesses map[string][]string
 		expectedPorts     []string
-		expectedRaw       map[string]interface{}
+		expectedRaw       map[string]any
 	}{
 		{
 			name:              "empty is okay",
@@ -108,9 +108,9 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		{
 			name: "processes priority over procfile",
 			addData: appTypes.AddVersionDataArgs{
-				CustomData: map[string]interface{}{
+				CustomData: map[string]any{
 					"procfile": "worker9: ignored",
-					"processes": map[string]interface{}{
+					"processes": map[string]any{
 						"worker1": "python myapp.py",
 						"worker2": "someworker",
 					},
@@ -125,7 +125,7 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		{
 			name: "procfile used as fallback",
 			addData: appTypes.AddVersionDataArgs{
-				CustomData: map[string]interface{}{
+				CustomData: map[string]any{
 					"procfile": "worker1: python myapp.py\nworker2: someworker",
 				},
 			},
@@ -138,8 +138,8 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		{
 			name: "processes with mixed list and string",
 			addData: appTypes.AddVersionDataArgs{
-				CustomData: map[string]interface{}{
-					"processes": map[string]interface{}{
+				CustomData: map[string]any{
+					"processes": map[string]any{
 						"worker1": "python myapp.py",
 						"worker2": []string{"worker", "arg", "arg2"},
 					},
@@ -154,11 +154,11 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		{
 			name: "saves unknown fields for future use",
 			addData: appTypes.AddVersionDataArgs{
-				CustomData: map[string]interface{}{
+				CustomData: map[string]any{
 					"myfield": "myvalue",
 				},
 			},
-			expectedRaw: map[string]interface{}{
+			expectedRaw: map[string]any{
 				"myfield":      "myvalue",
 				"healthcheck":  nil,
 				"startupcheck": nil,
@@ -170,32 +170,32 @@ func (s *S) TestAppVersionImpl_AddData(c *check.C) {
 		{
 			name: "parse and recover hooks and complex kubernetes",
 			addData: appTypes.AddVersionDataArgs{
-				CustomData: map[string]interface{}{
-					"hooks": map[string]interface{}{
+				CustomData: map[string]any{
+					"hooks": map[string]any{
 						"build": []string{"script1", "script2"},
 					},
-					"healthcheck": map[string]interface{}{
+					"healthcheck": map[string]any{
 						"path": "/status",
 					},
-					"startupcheck": map[string]interface{}{
+					"startupcheck": map[string]any{
 						"path": "/startup",
 					},
-					"kubernetes": map[string]interface{}{
-						"groups": map[string]interface{}{
-							"pod1": map[string]interface{}{
-								"proc1": map[string]interface{}{
-									"ports": []map[string]interface{}{
+					"kubernetes": map[string]any{
+						"groups": map[string]any{
+							"pod1": map[string]any{
+								"proc1": map[string]any{
+									"ports": []map[string]any{
 										{"port": 8888},
 									},
 								},
-								"proc2": map[string]interface{}{
-									"ports": []map[string]interface{}{
+								"proc2": map[string]any{
+									"ports": []map[string]any{
 										{"port": 8889},
 										{"target_port": 5000},
 									},
 								},
-								"proc.proc3": map[string]interface{}{
-									"ports": []map[string]interface{}{
+								"proc.proc3": map[string]any{
+									"ports": []map[string]any{
 										{"port": 9000},
 										{"target_port": 5001},
 									},

--- a/auth/native/token.go
+++ b/auth/native/token.go
@@ -141,7 +141,7 @@ func removeOldTokens(ctx context.Context, userEmail string) error {
 	if diff < 1 {
 		return nil
 	}
-	var tokens []map[string]interface{}
+	var tokens []map[string]any
 
 	opts := options.Find().SetSort(mongoBSON.M{"creation": 1}).SetLimit(int64(diff)).SetProjection(mongoBSON.M{"_id": 1})
 	cursor, err := collection.Find(ctx, mongoBSON.M{"useremail": userEmail}, opts)
@@ -152,7 +152,7 @@ func removeOldTokens(ctx context.Context, userEmail string) error {
 	if err != nil {
 		return nil
 	}
-	ids := make([]interface{}, 0, len(tokens))
+	ids := make([]any, 0, len(tokens))
 	for _, token := range tokens {
 		ids = append(ids, token["_id"])
 	}

--- a/auth/oidc/oidc.go
+++ b/auth/oidc/oidc.go
@@ -55,7 +55,7 @@ func init() {
 type oidcScheme struct {
 	jwksURL                string
 	cache                  *jwk.Cache
-	validClaims            map[string]interface{}
+	validClaims            map[string]any
 	initialized            sync.Once
 	registrationEnabled    bool
 	groupsInClaims         bool
@@ -216,7 +216,7 @@ func (s *oidcScheme) lazyInitialize(ctx context.Context) error {
 		s.groupsInClaims, _ = config.GetBool("auth:oidc:groups-in-claims")
 		s.autoCreatePersonalTeam, _ = config.GetBool("auth:oidc:auto-create-personal-team")
 
-		s.validClaims = map[string]interface{}{}
+		s.validClaims = map[string]any{}
 		internalConfig.UnmarshalConfig("auth:oidc:valid-claims", &s.validClaims)
 
 		var refreshIntervalErr error
@@ -242,7 +242,7 @@ func (s *oidcScheme) lazyInitialize(ctx context.Context) error {
 }
 
 func (s *oidcScheme) jwtGetKey(ctx context.Context) jwt.Keyfunc {
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		var err error
 
 		jwkKeySet, err := s.cache.Get(ctx, s.jwksURL)

--- a/auth/oidc/oidc_test.go
+++ b/auth/oidc/oidc_test.go
@@ -176,7 +176,7 @@ func (s *AuthSuite) TestLoginWithMissingEmail(c *check.C) {
 }
 
 func (s *AuthSuite) TestLoginWithClaimValidation(c *check.C) {
-	s.scheme.validClaims = map[string]interface{}{
+	s.scheme.validClaims = map[string]any{
 		"azp": "my-azp",
 	}
 	defer func() {

--- a/auth/oidc/token.go
+++ b/auth/oidc/token.go
@@ -40,7 +40,7 @@ func (f *extendedClaims) UnmarshalJSON(b []byte) error {
 		f.Email = email
 	}
 
-	if groups, ok := claims["groups"].([]interface{}); ok {
+	if groups, ok := claims["groups"].([]any); ok {
 
 		f.Groups = make([]string, len(groups))
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,15 +13,15 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func ConvertEntries(initial interface{}) interface{} {
+func ConvertEntries(initial any) any {
 	switch initialType := initial.(type) {
-	case []interface{}:
+	case []any:
 		for i := range initialType {
 			initialType[i] = ConvertEntries(initialType[i])
 		}
 		return initialType
-	case map[interface{}]interface{}:
-		output := make(map[string]interface{}, len(initialType))
+	case map[any]any:
+		output := make(map[string]any, len(initialType))
 		for k, v := range initialType {
 			output[fmt.Sprintf("%v", k)] = ConvertEntries(v)
 		}
@@ -31,27 +31,27 @@ func ConvertEntries(initial interface{}) interface{} {
 	}
 }
 
-func UnconvertEntries(initial interface{}) interface{} {
+func UnconvertEntries(initial any) any {
 	switch initialType := initial.(type) {
-	case []interface{}:
+	case []any:
 		for i := range initialType {
 			initialType[i] = UnconvertEntries(initialType[i])
 		}
 		return initialType
 	case primitive.A:
-		output := make([]interface{}, len(initialType))
+		output := make([]any, len(initialType))
 		for k, v := range initialType {
 			output[k] = UnconvertEntries(v)
 		}
 		return output
 	case primitive.M:
-		output := make(map[interface{}]interface{}, len(initialType))
+		output := make(map[any]any, len(initialType))
 		for k, v := range initialType {
 			output[k] = UnconvertEntries(v)
 		}
 		return output
-	case map[string]interface{}:
-		output := make(map[interface{}]interface{}, len(initialType))
+	case map[string]any:
+		output := make(map[any]any, len(initialType))
 		for k, v := range initialType {
 			output[k] = UnconvertEntries(v)
 		}
@@ -61,7 +61,7 @@ func UnconvertEntries(initial interface{}) interface{} {
 	}
 }
 
-func UnmarshalConfig(key string, result interface{}) error {
+func UnmarshalConfig(key string, result any) error {
 	data, err := config.Get(key)
 	if err != nil {
 		return errors.WithStack(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,20 +22,20 @@ func Test(t *testing.T) {
 
 func (s *S) TestConvertEntries(c *check.C) {
 	tests := []struct {
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{
-			input:    map[interface{}]interface{}{"": ""},
-			expected: map[string]interface{}{"": ""},
+			input:    map[any]any{"": ""},
+			expected: map[string]any{"": ""},
 		},
 		{
-			input:    []interface{}{map[interface{}]interface{}{"": ""}},
-			expected: []interface{}{map[string]interface{}{"": ""}},
+			input:    []any{map[any]any{"": ""}},
+			expected: []any{map[string]any{"": ""}},
 		},
 		{
-			input:    []interface{}{map[interface{}]interface{}{"": []interface{}{map[interface{}]interface{}{"a": 1}}}},
-			expected: []interface{}{map[string]interface{}{"": []interface{}{map[string]interface{}{"a": 1}}}},
+			input:    []any{map[any]any{"": []any{map[any]any{"a": 1}}}},
+			expected: []any{map[string]any{"": []any{map[string]any{"a": 1}}}},
 		},
 	}
 	for _, tt := range tests {
@@ -45,32 +45,32 @@ func (s *S) TestConvertEntries(c *check.C) {
 
 func (s *S) TestUnconvertEntries(c *check.C) {
 	tests := []struct {
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"headers": primitive.A{
 					"test1=a",
 					"test2=b",
 				},
 			},
-			expected: map[interface{}]interface{}{
-				"headers": []interface{}{
+			expected: map[any]any{
+				"headers": []any{
 					"test1=a",
 					"test2=b",
 				},
 			},
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"headers": primitive.M{
 					"test1": "a",
 					"test2": "b",
 				},
 			},
-			expected: map[interface{}]interface{}{
-				"headers": map[interface{}]interface{}{
+			expected: map[any]any{
+				"headers": map[any]any{
 					"test1": "a",
 					"test2": "b",
 				},

--- a/event/block_test.go
+++ b/event/block_test.go
@@ -94,13 +94,13 @@ func (s *S) TestCheckIsBlocked(c *check.C) {
 	bsonDataBlockedPoolCluster, err := makeBSONRaw([]mongoBSON.M{{"name": "pool", "value": "pool1"}, {"name": "cluster", "value": "c1"}})
 	c.Assert(err, check.IsNil)
 
-	bsonDataBlockedPool, err := makeBSONRaw([]map[string]interface{}{{"name": "pool", "value": "pool2"}, {"name": "cluster", "value": "c2"}})
+	bsonDataBlockedPool, err := makeBSONRaw([]map[string]any{{"name": "pool", "value": "pool2"}, {"name": "cluster", "value": "c2"}})
 	c.Assert(err, check.IsNil)
 
-	bsonDataAllowedPool, err := makeBSONRaw([]map[string]interface{}{{"name": "pool", "value": "pool1"}})
+	bsonDataAllowedPool, err := makeBSONRaw([]map[string]any{{"name": "pool", "value": "pool1"}})
 	c.Assert(err, check.IsNil)
 
-	bsonDataUnhandledFields, err := makeBSONRaw([]map[string]interface{}{{"foo": "bar"}})
+	bsonDataUnhandledFields, err := makeBSONRaw([]map[string]any{{"foo": "bar"}})
 	c.Assert(err, check.IsNil)
 
 	tt := []struct {

--- a/event/event.go
+++ b/event/event.go
@@ -214,7 +214,7 @@ type Opts struct {
 	Owner         auth.Token
 	RawOwner      eventTypes.Owner
 	RemoteAddr    string
-	CustomData    interface{}
+	CustomData    any
 	DisableLock   bool
 	Cancelable    bool
 	Allowed       eventTypes.AllowedPermission
@@ -643,7 +643,7 @@ func NewInternal(ctx context.Context, opts *Opts) (*Event, error) {
 	return newEvt(ctx, opts)
 }
 
-func makeBSONRaw(in interface{}) (mongoBSON.RawValue, error) {
+func makeBSONRaw(in any) (mongoBSON.RawValue, error) {
 	if in == nil {
 		return mongoBSON.RawValue{}, nil
 	}
@@ -915,7 +915,7 @@ func checkLocked(ctx context.Context, evt *Event, disableLock bool) error {
 	return ErrEventLocked{Event: &existing}
 }
 
-func (e *Event) RawInsert(ctx context.Context, start, other, end interface{}) error {
+func (e *Event) RawInsert(ctx context.Context, start, other, end any) error {
 	var err error
 	e.StartCustomData, err = makeBSONRaw(start)
 	if err != nil {
@@ -948,7 +948,7 @@ func (e *Event) Done(ctx context.Context, evtErr error) error {
 	return e.done(ctx, evtErr, nil, false)
 }
 
-func (e *Event) DoneCustomData(ctx context.Context, evtErr error, customData interface{}) error {
+func (e *Event) DoneCustomData(ctx context.Context, evtErr error, customData any) error {
 	return e.done(ctx, evtErr, customData, false)
 }
 
@@ -960,7 +960,7 @@ func (e *Event) GetLogWriter() io.Writer {
 	return e.logWriter
 }
 
-func (e *Event) SetOtherCustomData(ctx context.Context, data interface{}) error {
+func (e *Event) SetOtherCustomData(ctx context.Context, data any) error {
 	collection, err := storagev2.EventsCollection()
 	if err != nil {
 		return err
@@ -986,7 +986,7 @@ func (e *Event) SetCancelable(ctx context.Context, cancelable bool) error {
 	return err
 }
 
-func (e *Event) Logf(format string, params ...interface{}) {
+func (e *Event) Logf(format string, params ...any) {
 	log.Debugf(fmt.Sprintf("%s(%s)[%s] %s", e.Target.Type, e.Target.Value, e.Kind, format), params...)
 	format += "\n"
 	fmt.Fprintf(e, format, params...)
@@ -1098,28 +1098,28 @@ func (e *Event) AckCancel(ctx context.Context) (bool, error) {
 	return err == nil, err
 }
 
-func (e *Event) StartData(value interface{}) error {
+func (e *Event) StartData(value any) error {
 	if e.StartCustomData.Type == 0 {
 		return nil
 	}
 	return e.StartCustomData.Unmarshal(value)
 }
 
-func (e *Event) EndData(value interface{}) error {
+func (e *Event) EndData(value any) error {
 	if e.EndCustomData.Type == 0 {
 		return nil
 	}
 	return e.EndCustomData.Unmarshal(value)
 }
 
-func (e *Event) OtherData(value interface{}) error {
+func (e *Event) OtherData(value any) error {
 	if e.OtherCustomData.Type == 0 {
 		return nil
 	}
 	return e.OtherCustomData.Unmarshal(value)
 }
 
-func (e *Event) done(ctx context.Context, evtErr error, customData interface{}, abort bool) (err error) {
+func (e *Event) done(ctx context.Context, evtErr error, customData any, abort bool) (err error) {
 	ctx = context.WithoutCancel(ctx)
 	// Done will be usually called in a defer block ignoring errors. This is
 	// why we log error messages here.
@@ -1239,7 +1239,7 @@ func (e *Event) OwnerEmail() string {
 
 }
 
-func checkIsExpired(ctx context.Context, collection *mongo.Collection, lock interface{}) bool {
+func checkIsExpired(ctx context.Context, collection *mongo.Collection, lock any) bool {
 	var existingEvt Event
 
 	err := collection.FindOne(ctx, mongoBSON.M{"lock": lock}).Decode(&existingEvt.EventData)
@@ -1255,14 +1255,14 @@ func checkIsExpired(ctx context.Context, collection *mongo.Collection, lock inte
 	return false
 }
 
-func FormToCustomData(form url.Values) []map[string]interface{} {
-	ret := make([]map[string]interface{}, 0, len(form))
+func FormToCustomData(form url.Values) []map[string]any {
+	ret := make([]map[string]any, 0, len(form))
 	for k, v := range form {
-		var val interface{} = v
+		var val any = v
 		if len(v) == 1 {
 			val = v[0]
 		}
-		ret = append(ret, map[string]interface{}{"name": k, "value": val})
+		ret = append(ret, map[string]any{"name": k, "value": val})
 	}
 	return ret
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -1656,10 +1656,10 @@ func (s *S) TestEventInfo(c *check.C) {
 	c.Assert(evtInfo.OtherCustomData, check.DeepEquals, eventTypes.LegacyBSONRaw{})
 
 	c.Assert(evtInfo.CustomData, check.DeepEquals, eventTypes.EventInfoCustomData{
-		Start: map[string]interface{}{
+		Start: map[string]any{
 			"a": "value",
 		},
-		End: map[string]interface{}{
+		End: map[string]any{
 			"a": "other",
 		},
 	})

--- a/event/eventlist_test.go
+++ b/event/eventlist_test.go
@@ -69,7 +69,7 @@ func (s *S) TestListFilterMany(c *check.C) {
 		c.Assert(err, check.IsNil)
 		allEvts = append(allEvts, evt)
 	}
-	var checkFilters = func(f *event.Filter, expected interface{}) {
+	var checkFilters = func(f *event.Filter, expected any) {
 		evts, err := event.List(context.TODO(), f)
 		c.Assert(err, check.IsNil)
 		c.Assert(evts, eventtest.EvtEquals, expected, check.Commentf("Diff:\n%s", strings.Join(pretty.Diff(evts, expected), "\n")))

--- a/event/eventtest/checker.go
+++ b/event/eventtest/checker.go
@@ -23,9 +23,9 @@ type EventDesc struct {
 	ExtraTargets    []eventTypes.ExtraTarget
 	Kind            string
 	Owner           string
-	StartCustomData interface{}
-	EndCustomData   interface{}
-	OtherCustomData interface{}
+	StartCustomData any
+	EndCustomData   any
+	OtherCustomData any
 	LogMatches      []string
 	ErrorMatches    string
 	IsEmpty         bool
@@ -37,16 +37,16 @@ func (hasEventChecker) Info() *check.CheckerInfo {
 	return &check.CheckerInfo{Name: "HasEvent", Params: []string{"event desc"}}
 }
 
-func queryPartCustom(query map[string]interface{}, name string, value interface{}) {
+func queryPartCustom(query map[string]any, name string, value any) {
 	if value == nil {
 		return
 	}
 	switch data := value.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for k, v := range data {
 			query[name+"."+k] = v
 		}
-	case []map[string]interface{}:
+	case []map[string]any:
 		queryPart := []mongoBSON.M{}
 		for _, el := range data {
 			queryPart = append(queryPart, mongoBSON.M{
@@ -57,7 +57,7 @@ func queryPartCustom(query map[string]interface{}, name string, value interface{
 	}
 }
 
-func (hasEventChecker) Check(params []interface{}, names []string) (bool, string) {
+func (hasEventChecker) Check(params []any, names []string) (bool, string) {
 	ctx := context.TODO()
 	var evt EventDesc
 	switch params[0].(type) {
@@ -136,7 +136,7 @@ func debugEvts(evts []*event.Event) string {
 	var msgs []string
 	for i := range evts {
 		evt := evts[i]
-		var sData, oData, eData interface{}
+		var sData, oData, eData any
 		evt.StartData(&sData)
 		evt.OtherData(&oData)
 		evt.EndData(&eData)
@@ -154,7 +154,7 @@ type evtEqualsChecker struct {
 	check.CheckerInfo
 }
 
-func (evtEqualsChecker) Check(params []interface{}, names []string) (bool, string) {
+func (evtEqualsChecker) Check(params []any, names []string) (bool, string) {
 	evts := make([][]*event.Event, len(params))
 	for i := range evts {
 		switch e := params[i].(type) {
@@ -178,7 +178,7 @@ func (evtEqualsChecker) Check(params []interface{}, names []string) (bool, strin
 			e.LockUpdateTime = time.Time{}
 		}
 	}
-	return check.DeepEquals.Check([]interface{}{evts[0], evts[1]}, names)
+	return check.DeepEquals.Check([]any{evts[0], evts[1]}, names)
 }
 
 var EvtEquals check.Checker = &evtEqualsChecker{

--- a/fs/fstest/info.go
+++ b/fs/fstest/info.go
@@ -15,7 +15,7 @@ type fileInfo struct {
 	mode    os.FileMode
 	isDir   bool
 	modTime time.Time
-	sys     interface{}
+	sys     any
 }
 
 func (fi *fileInfo) Name() string {
@@ -38,6 +38,6 @@ func (fi *fileInfo) IsDir() bool {
 	return fi.isDir
 }
 
-func (fi *fileInfo) Sys() interface{} {
+func (fi *fileInfo) Sys() any {
 	return fi.sys
 }

--- a/integration/matchers.go
+++ b/integration/matchers.go
@@ -13,7 +13,7 @@ import (
 type baseMatcher struct {
 	name   string
 	params []string
-	check  func(result *Result, params []interface{}) (bool, string)
+	check  func(result *Result, params []any) (bool, string)
 }
 
 func (m *baseMatcher) Info() *check.CheckerInfo {
@@ -23,7 +23,7 @@ func (m *baseMatcher) Info() *check.CheckerInfo {
 	}
 }
 
-func (m *baseMatcher) Check(params []interface{}, names []string) (bool, string) {
+func (m *baseMatcher) Check(params []any, names []string) (bool, string) {
 	result, ok := params[0].(*Result)
 	if !ok {
 		return false, fmt.Sprintf("first param must be a *Result, got %T", params[0])
@@ -37,7 +37,7 @@ var ResultOk = &baseMatcher{
 	check:  checkOk,
 }
 
-func checkOk(result *Result, params []interface{}) (bool, string) {
+func checkOk(result *Result, params []any) (bool, string) {
 	if result.Error != nil || result.ExitCode != 0 {
 		return false, fmt.Sprintf("result error: %v", result)
 	}
@@ -50,7 +50,7 @@ func checkOk(result *Result, params []interface{}) (bool, string) {
 var ResultMatches = &baseMatcher{
 	name:   "ResultMatches",
 	params: []string{"result", "expected"},
-	check: func(result *Result, params []interface{}) (bool, string) {
+	check: func(result *Result, params []any) (bool, string) {
 		expected, ok := params[1].(Expected)
 		if !ok {
 			return false, fmt.Sprintf("second param must be a Expected, got %T", params[0])

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1189,15 +1189,15 @@ func (s *S) TestJobEnvsWithServiceEnvConflict(c *check.C) {
 	delete(env, tsuruEnvs.TsuruServicesEnvVar)
 	c.Assert(env, check.DeepEquals, expected)
 
-	var serviceEnvVal map[string]interface{}
+	var serviceEnvVal map[string]any
 	err := json.Unmarshal([]byte(serviceEnvsRaw.Value), &serviceEnvVal)
 	c.Assert(err, check.IsNil)
-	c.Assert(serviceEnvVal, check.DeepEquals, map[string]interface{}{
-		"my-service": []interface{}{
-			map[string]interface{}{"instance_name": "my-instance-1", "envs": map[string]interface{}{
+	c.Assert(serviceEnvVal, check.DeepEquals, map[string]any{
+		"my-service": []any{
+			map[string]any{"instance_name": "my-instance-1", "envs": map[string]any{
 				"DB_HOST": "fake.host1",
 			}},
-			map[string]interface{}{"instance_name": "my-instance-2", "envs": map[string]interface{}{
+			map[string]any{"instance_name": "my-instance-2", "envs": map[string]any{
 				"DB_HOST": "fake.host2",
 			}},
 		},

--- a/log/file_logger.go
+++ b/log/file_logger.go
@@ -39,7 +39,7 @@ func (l *fileLogger) Error(o string) {
 	l.logger.Printf(errorPrefix, o)
 }
 
-func (l *fileLogger) Errorf(format string, o ...interface{}) {
+func (l *fileLogger) Errorf(format string, o ...any) {
 	l.Error(fmt.Sprintf(format, o...))
 }
 
@@ -48,7 +48,7 @@ func (l *fileLogger) Fatal(o string) {
 	os.Exit(1)
 }
 
-func (l *fileLogger) Fatalf(format string, o ...interface{}) {
+func (l *fileLogger) Fatalf(format string, o ...any) {
 	l.Fatal(fmt.Sprintf(format, o...))
 }
 
@@ -58,7 +58,7 @@ func (l *fileLogger) Debug(o string) {
 	}
 }
 
-func (l *fileLogger) Debugf(format string, o ...interface{}) {
+func (l *fileLogger) Debugf(format string, o ...any) {
 	l.Debug(fmt.Sprintf(format, o...))
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -22,11 +22,11 @@ import (
 
 type Logger interface {
 	Error(string)
-	Errorf(string, ...interface{})
+	Errorf(string, ...any)
 	Fatal(string)
-	Fatalf(string, ...interface{})
+	Fatalf(string, ...any)
 	Debug(string)
-	Debugf(string, ...interface{})
+	Debugf(string, ...any)
 	GetStdLogger() *log.Logger
 }
 
@@ -87,7 +87,7 @@ type withStack interface {
 
 // Errorf writes the formatted string to the Target
 // logger.
-func (t *Target) Errorf(format string, v ...interface{}) {
+func (t *Target) Errorf(format string, v ...any) {
 	t.mut.RLock()
 	defer t.mut.RUnlock()
 	if t.logger != nil {
@@ -112,7 +112,7 @@ func (t *Target) Fatal(v string) {
 
 // Fatalf writes the formatted string to the Target
 // logger.
-func (t *Target) Fatalf(format string, v ...interface{}) {
+func (t *Target) Fatalf(format string, v ...any) {
 	t.mut.RLock()
 	defer t.mut.RUnlock()
 	if t.logger != nil {
@@ -132,7 +132,7 @@ func (t *Target) Debug(v string) {
 
 // Debugf writes the formatted string to the Target
 // logger.
-func (t *Target) Debugf(format string, v ...interface{}) {
+func (t *Target) Debugf(format string, v ...any) {
 	t.mut.RLock()
 	defer t.mut.RUnlock()
 	if t.logger != nil {
@@ -159,7 +159,7 @@ func Error(v error) {
 }
 
 // Errorf is a wrapper for DefaultTarget.Errorf.
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	DefaultTarget.Errorf(format, v...)
 }
 
@@ -169,7 +169,7 @@ func Fatal(v string) {
 }
 
 // Fatalf is a wrapper for DefaultTarget.Errorf.
-func Fatalf(format string, v ...interface{}) {
+func Fatalf(format string, v ...any) {
 	DefaultTarget.Fatalf(format, v...)
 }
 
@@ -179,7 +179,7 @@ func Debug(v string) {
 }
 
 // Debugf is a wrapper for DefaultTarget.Debugf.
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	DefaultTarget.Debugf(format, v...)
 }
 

--- a/log/multi_logger.go
+++ b/log/multi_logger.go
@@ -36,19 +36,19 @@ func (m *multiLogger) Fatal(message string) {
 	os.Exit(1)
 }
 
-func (m *multiLogger) Debugf(format string, v ...interface{}) {
+func (m *multiLogger) Debugf(format string, v ...any) {
 	for _, logger := range m.loggers {
 		logger.Debugf(format, v...)
 	}
 }
 
-func (m *multiLogger) Errorf(format string, v ...interface{}) {
+func (m *multiLogger) Errorf(format string, v ...any) {
 	for _, logger := range m.loggers {
 		logger.Errorf(format, v...)
 	}
 }
 
-func (m *multiLogger) Fatalf(format string, v ...interface{}) {
+func (m *multiLogger) Fatalf(format string, v ...any) {
 	for _, logger := range m.loggers {
 		logger.Errorf(format, v...)
 	}

--- a/log/syslog_logger.go
+++ b/log/syslog_logger.go
@@ -34,7 +34,7 @@ func (l *syslogLogger) Error(o string) {
 	l.w.Err(o)
 }
 
-func (l *syslogLogger) Errorf(format string, o ...interface{}) {
+func (l *syslogLogger) Errorf(format string, o ...any) {
 	l.w.Err(fmt.Sprintf(format, o...))
 }
 
@@ -43,7 +43,7 @@ func (l *syslogLogger) Fatal(o string) {
 	os.Exit(1)
 }
 
-func (l *syslogLogger) Fatalf(format string, o ...interface{}) {
+func (l *syslogLogger) Fatalf(format string, o ...any) {
 	l.Fatal(fmt.Sprintf(format, o...))
 }
 
@@ -53,7 +53,7 @@ func (l *syslogLogger) Debug(o string) {
 	}
 }
 
-func (l *syslogLogger) Debugf(format string, o ...interface{}) {
+func (l *syslogLogger) Debugf(format string, o ...any) {
 	l.Debug(fmt.Sprintf(format, o...))
 }
 

--- a/provision/dockercommon/commands_test.go
+++ b/provision/dockercommon/commands_test.go
@@ -48,7 +48,7 @@ func (s *S) SetUpTest(c *check.C) {
 	servicemock.SetMockService(&s.mockService)
 }
 
-func newVersion(c *check.C, app *appTypes.App, customData map[string]interface{}) appTypes.AppVersion {
+func newVersion(c *check.C, app *appTypes.App, customData map[string]any) appTypes.AppVersion {
 	version, err := servicemanager.AppVersion.NewAppVersion(context.TODO(), appTypes.NewVersionArgs{
 		App: app,
 	})
@@ -63,8 +63,8 @@ func newVersion(c *check.C, app *appTypes.App, customData map[string]interface{}
 }
 
 func (s *S) TestRunLeanContainersCmd(c *check.C) {
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
+	customData := map[string]any{
+		"processes": map[string]any{
 			"web": "python web.py",
 		},
 	}
@@ -80,13 +80,13 @@ func (s *S) TestRunLeanContainersCmd(c *check.C) {
 }
 
 func (s *S) TestRunLeanContainersCmdHooks(c *check.C) {
-	customData := map[string]interface{}{
-		"hooks": map[string]interface{}{
-			"restart": map[string]interface{}{
+	customData := map[string]any{
+		"hooks": map[string]any{
+			"restart": map[string]any{
 				"before": []string{"cmd1", "cmd2"},
 			},
 		},
-		"processes": map[string]interface{}{
+		"processes": map[string]any{
 			"web": "python web.py",
 		},
 	}
@@ -102,8 +102,8 @@ func (s *S) TestRunLeanContainersCmdHooks(c *check.C) {
 }
 
 func (s *S) TestRunLeanContainersImplicitProcess(c *check.C) {
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
+	customData := map[string]any{
+		"processes": map[string]any{
 			"web": "python web.py",
 		},
 	}
@@ -119,8 +119,8 @@ func (s *S) TestRunLeanContainersImplicitProcess(c *check.C) {
 }
 
 func (s *S) TestRunLeanContainersCmdNoProcessSpecified(c *check.C) {
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
+	customData := map[string]any{
+		"processes": map[string]any{
 			"web":    "python web.py",
 			"worker": "python worker.py",
 		},
@@ -139,8 +139,8 @@ func (s *S) TestRunLeanContainersCmdNoProcessSpecified(c *check.C) {
 }
 
 func (s *S) TestRunLeanContainersCmdInvalidProcess(c *check.C) {
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
+	customData := map[string]any{
+		"processes": map[string]any{
 			"web": "python web.py",
 		},
 	}
@@ -170,8 +170,8 @@ func (s *S) TestRunLeanContainersCmdNoImageMetadata(c *check.C) {
 }
 
 func (s *S) TestLeanContainerCmdsManyCmds(c *check.C) {
-	customData := map[string]interface{}{
-		"processes": map[string]interface{}{
+	customData := map[string]any{
+		"processes": map[string]any{
 			"web": []string{"python", "web.py"},
 		},
 	}

--- a/provision/kubernetes/builder_test.go
+++ b/provision/kubernetes/builder_test.go
@@ -20,7 +20,7 @@ func newEmptyVersion(c *check.C, app *appTypes.App) appTypes.AppVersion {
 	return version
 }
 
-func newVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]interface{}) appTypes.AppVersion {
+func newVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]any) appTypes.AppVersion {
 	version := newEmptyVersion(c, app)
 	err := version.CommitBuildImage()
 	c.Assert(err, check.IsNil)
@@ -38,14 +38,14 @@ func newVersion(c *check.C, app *appTypes.App, processes map[string][]string, cu
 	return version
 }
 
-func newCommittedVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]interface{}) appTypes.AppVersion {
+func newCommittedVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]any) appTypes.AppVersion {
 	version := newVersion(c, app, processes, customData...)
 	err := version.CommitBaseImage()
 	c.Assert(err, check.IsNil)
 	return version
 }
 
-func newSuccessfulVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]interface{}) appTypes.AppVersion {
+func newSuccessfulVersion(c *check.C, app *appTypes.App, processes map[string][]string, customData ...map[string]any) appTypes.AppVersion {
 	version := newCommittedVersion(c, app, processes, customData...)
 	err := version.CommitSuccessful()
 	c.Assert(err, check.IsNil)

--- a/provision/kubernetes/deploy_test.go
+++ b/provision/kubernetes/deploy_test.go
@@ -850,7 +850,7 @@ func (s *S) TestServiceManagerDeployServiceNoExposedPorts(c *check.C) {
 		map[string][]string{
 			"p1": {"cmd1"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"pod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -907,7 +907,7 @@ func (s *S) TestServiceManagerDeployServiceNoExposedPortsRemoveExistingService(c
 	version = newCommittedVersion(c, a, map[string][]string{
 		"p1": {"cmd1"},
 	},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"pod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -1215,7 +1215,7 @@ func (s *S) TestServiceManagerDeployServiceWithHC(c *check.C) {
 				"web": {"cm1"},
 				"p2":  {"cmd2"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"healthcheck": tt.hc,
 			},
 		)
@@ -1301,7 +1301,7 @@ func (s *S) TestEnsureBackendConfigIfEnabled(c *check.C) {
 			"web": {"cm1"},
 			"p2":  {"cmd2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"healthcheck": hc,
 		},
 	)
@@ -1386,7 +1386,7 @@ func (s *S) TestEnsureBackendConfigIfEnabledWithDefaults(c *check.C) {
 			"web": {"cm1"},
 			"p2":  {"cmd2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"healthcheck": hc,
 		},
 	)
@@ -1471,7 +1471,7 @@ func (s *S) TestEnsureBackendConfigWithMissingSlash(c *check.C) {
 			"web": {"cm1"},
 			"p2":  {"cmd2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"healthcheck": hc,
 		},
 	)
@@ -1539,7 +1539,7 @@ func (s *S) TestEnsureBackendConfigWithCommandHC(c *check.C) {
 			"web": {"cm1"},
 			"p2":  {"cmd2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"healthcheck": hc,
 		},
 	)
@@ -1636,7 +1636,7 @@ func (s *S) TestServiceManagerDeployServiceWithRestartHooks(c *check.C) {
 			"web": {"proc1"},
 			"p2":  {"proc2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"hooks": provTypes.TsuruYamlHooks{
 				Restart: provTypes.TsuruYamlRestartHooks{
 					Before: []string{"before cmd1", "before cmd2"},
@@ -1771,7 +1771,7 @@ func (s *S) TestServiceManagerDeployServiceWithKubernetesPorts(c *check.C) {
 			"web": {"proc1"},
 			"p2":  {"proc2"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"mypod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -1896,7 +1896,7 @@ func (s *S) TestServiceManagerDeployServiceWithKubernetesPortsDuplicatedProcess(
 		map[string][]string{
 			"web": {"proc1"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"mypod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -1939,7 +1939,7 @@ func (s *S) TestServiceManagerDeployServiceWithZeroKubernetesPorts(c *check.C) {
 		map[string][]string{
 			"web": {"proc1"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"mypod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{
@@ -3363,7 +3363,7 @@ func (s *S) TestServiceManagerDeployServiceWithVolumes(c *check.C) {
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"plugin": "nfs",
 		}},
 		Pool:      "test-default",
@@ -3604,7 +3604,7 @@ func (s *S) TestServiceManagerDeployServiceProcessHealthcheckTimeoutExceeded(c *
 		map[string][]string{
 			"p1": {"cmd1"},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"processes": []provTypes.TsuruYamlProcess{
 				{
 					Name: "p1",
@@ -4477,12 +4477,12 @@ func (s *S) TestServiceManagerDeployServiceRemovePDBFromRemovedProcess(c *check.
 
 func (s *S) TestGetImagePullSecrets(c *check.C) {
 	tests := []struct {
-		config      map[string]interface{}
+		config      map[string]any
 		images      []string
 		expectedRef []apiv1.LocalObjectReference
 	}{
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry":               "myreg1.com",
 				"docker:registry-auth:username": "user",
 				"docker:registry-auth:password": "pass",
@@ -4493,7 +4493,7 @@ func (s *S) TestGetImagePullSecrets(c *check.C) {
 			},
 		},
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry":               "myreg1.com",
 				"docker:registry-auth:username": "user",
 				"docker:registry-auth:password": "pass",
@@ -4502,7 +4502,7 @@ func (s *S) TestGetImagePullSecrets(c *check.C) {
 			expectedRef: nil,
 		},
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry":               "myreg1.com",
 				"docker:registry-auth:username": "user",
 				"docker:registry-auth:password": "pass",
@@ -4513,21 +4513,21 @@ func (s *S) TestGetImagePullSecrets(c *check.C) {
 			},
 		},
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry": "myreg1.com",
 			},
 			images:      []string{"myreg1.com/tsuru/go"},
 			expectedRef: nil,
 		},
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry": "",
 			},
 			images:      []string{"tsuru/go"},
 			expectedRef: nil,
 		},
 		{
-			config: map[string]interface{}{
+			config: map[string]any{
 				"docker:registry":               "",
 				"docker:registry-auth:username": "user",
 				"docker:registry-auth:password": "pass",

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -679,8 +679,8 @@ func changeUnits(ctx context.Context, a *appTypes.App, units int, processName st
 }
 
 func replicasPatch(replicas int) (types.PatchType, []byte, error) {
-	patch, err := json.Marshal([]interface{}{
-		map[string]interface{}{
+	patch, err := json.Marshal([]any{
+		map[string]any{
 			"op":    "replace",
 			"path":  "/spec/replicas",
 			"value": replicas,

--- a/provision/kubernetes/provisioner_test.go
+++ b/provision/kubernetes/provisioner_test.go
@@ -1304,12 +1304,12 @@ func (s *S) TestInternalAddressesNoService(c *check.C) {
 	processes := map[string][]string{
 		"web": {"run", "mycmd", "web"},
 	}
-	customData := map[string]interface{}{
-		"kubernetes": map[string]interface{}{
-			"groups": map[string]interface{}{
-				"pod1": map[string]interface{}{
-					"web": map[string]interface{}{
-						"ports": []interface{}{},
+	customData := map[string]any{
+		"kubernetes": map[string]any{
+			"groups": map[string]any{
+				"pod1": map[string]any{
+					"web": map[string]any{
+						"ports": []any{},
 					},
 				},
 			},
@@ -1339,30 +1339,30 @@ func (s *S) TestDeployWithCustomConfig(c *check.C) {
 	processes := map[string][]string{
 		"web": {"run mycmd arg1"},
 	}
-	customData := map[string]interface{}{
-		"kubernetes": map[string]interface{}{
-			"groups": map[string]interface{}{
-				"pod1": map[string]interface{}{
-					"web": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
+	customData := map[string]any{
+		"kubernetes": map[string]any{
+			"groups": map[string]any{
+				"pod1": map[string]any{
+					"web": map[string]any{
+						"ports": []any{
+							map[string]any{
 								"name": "my-port",
 								"port": 9000,
 							},
-							map[string]interface{}{
+							map[string]any{
 								"protocol":    "tcp",
 								"target_port": 8080,
 							},
 						},
 					},
 				},
-				"pod2": map[string]interface{}{
-					"proc2": map[string]interface{}{},
+				"pod2": map[string]any{
+					"proc2": map[string]any{},
 				},
-				"pod3": map[string]interface{}{
-					"proc3": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
+				"pod3": map[string]any{
+					"proc3": map[string]any{
+						"ports": []any{
+							map[string]any{
 								"protocol":    "udp",
 								"port":        9000,
 								"target_port": 9001,
@@ -2156,7 +2156,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeSameClusterAndNamespace(c *check.C
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"plugin": "emptyDir",
 		}},
 		Pool:      "test-default",
@@ -2224,7 +2224,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeSameClusterOtherNamespace(c *check
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "my-storageclass",
 		}},
 		Pool:      "test-default",
@@ -2277,7 +2277,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeOtherCluster(c *check.C) {
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "mystorage-class",
 		}},
 		Pool:      a.Pool,
@@ -2360,7 +2360,7 @@ func (s *S) TestProvisionerUpdateAppWithVolumeWithTwoBindsOtherCluster(c *check.
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "myclass",
 		}},
 		Pool:      a.Pool,
@@ -2467,7 +2467,7 @@ func (s *S) TestEnvsForAppCustomPorts(c *check.C) {
 		"proc5": {"python", "worker.py"},
 		"proc6": {"python", "proc6.py"},
 	},
-		map[string]interface{}{
+		map[string]any{
 			"kubernetes": provTypes.TsuruYamlKubernetesConfig{
 				Groups: map[string]provTypes.TsuruYamlKubernetesGroup{
 					"mypod1": map[string]provTypes.TsuruYamlKubernetesProcessConfig{

--- a/provision/kubernetes/rollbacker.go
+++ b/provision/kubernetes/rollbacker.go
@@ -162,13 +162,13 @@ func equalIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
 // previous version. If the returned error is nil the patch is valid.
 func getDeploymentPatch(podTemplate *corev1.PodTemplateSpec, annotations map[string]string) (types.PatchType, []byte, error) {
 	// Create a patch of the Deployment that replaces spec.template
-	patch, err := json.Marshal([]interface{}{
-		map[string]interface{}{
+	patch, err := json.Marshal([]any{
+		map[string]any{
 			"op":    "replace",
 			"path":  "/spec/template",
 			"value": podTemplate,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"op":    "replace",
 			"path":  "/metadata/annotations",
 			"value": annotations,

--- a/provision/kubernetes/testing/reaction.go
+++ b/provision/kubernetes/testing/reaction.go
@@ -623,7 +623,7 @@ func cleanupPods(client ClusterInterface, opts metav1.ListOptions, namespace str
 	return nil
 }
 
-func shortMD5ForObject(i interface{}) string {
+func shortMD5ForObject(i any) string {
 	b, _ := json.Marshal(i)
 	m := md5.Sum(b)
 

--- a/provision/kubernetes/volume.go
+++ b/provision/kubernetes/volume.go
@@ -134,7 +134,7 @@ func nonPersistentVolume(v *volumeTypes.Volume, opts *volumeOptions) (apiv1.Volu
 			},
 		}
 	} else {
-		data, err := json.Marshal(map[string]interface{}{
+		data, err := json.Marshal(map[string]any{
 			opts.Plugin: v.Opts,
 		})
 		if err != nil {
@@ -243,7 +243,7 @@ func createVolume(ctx context.Context, client *ClusterClient, v *volumeTypes.Vol
 	if opts.Plugin != "" {
 		pvSpec := apiv1.PersistentVolumeSpec{}
 		var data []byte
-		data, err = json.Marshal(map[string]interface{}{
+		data, err = json.Marshal(map[string]any{
 			opts.Plugin: v.Opts,
 		})
 		if err != nil {

--- a/provision/kubernetes/volume_test.go
+++ b/provision/kubernetes/volume_test.go
@@ -241,7 +241,7 @@ func (s *S) TestCreateVolumesForAppPluginNonPersistentEphemeral(_ *check.C) {
 		Opts: map[string]string{
 			"capacity": "10Gi",
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "my-storage-class",
 		}},
 		Pool:      "test-default",
@@ -515,7 +515,7 @@ func (s *S) TestDeleteVolume(_ *check.C) {
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "myown",
 		}},
 		Pool:      "test-default",
@@ -559,7 +559,7 @@ func (s *S) TestVolumeExists(_ *check.C) {
 			"capacity":     "20Gi",
 			"access-modes": string(apiv1.ReadWriteMany),
 		},
-		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]interface{}{
+		Plan: volumeTypes.VolumePlan{Name: "p1", Opts: map[string]any{
 			"storage-class": "mystorage-class",
 		}},
 		Pool:      "test-default",

--- a/provision/pool/pool_test.go
+++ b/provision/pool/pool_test.go
@@ -115,11 +115,11 @@ func (s *S) SetUpTest(c *check.C) {
 	servicemanager.Plan = s.mockPlanService
 }
 
-func asMapStringInterface(val interface{}) map[string]interface{} {
+func asMapStringInterface(val any) map[string]any {
 	if val == nil {
 		return nil
 	}
-	if mapVal, ok := val.(map[string]interface{}); ok {
+	if mapVal, ok := val.(map[string]any); ok {
 		return mapVal
 	}
 	return nil

--- a/provision/provisiontest/fake_provisioner.go
+++ b/provision/provisiontest/fake_provisioner.go
@@ -165,7 +165,7 @@ func (p *FakeProvisioner) Stops(app *appTypes.App, process string) int {
 	return p.apps[app.Name].stops[process]
 }
 
-func (p *FakeProvisioner) CustomData(app *appTypes.App) map[string]interface{} {
+func (p *FakeProvisioner) CustomData(app *appTypes.App) map[string]any {
 	p.mut.RLock()
 	defer p.mut.RUnlock()
 	return p.apps[app.Name].lastData
@@ -776,7 +776,7 @@ type provisionedApp struct {
 	starts    map[string]int
 	stops     map[string]int
 	unitLen   int
-	lastData  map[string]interface{}
+	lastData  map[string]any
 	image     string
 	mockAddrs []appTypes.RoutableAddresses
 

--- a/provision/servicecommon/actions_test.go
+++ b/provision/servicecommon/actions_test.go
@@ -159,7 +159,7 @@ func (m *recordManager) RemoveService(ctx context.Context, a *appTypes.App, proc
 	return nil
 }
 
-func newVersion(c *check.C, app *appTypes.App, customData map[string]interface{}) appTypes.AppVersion {
+func newVersion(c *check.C, app *appTypes.App, customData map[string]any) appTypes.AppVersion {
 	version, err := servicemanager.AppVersion.NewAppVersion(context.TODO(), appTypes.NewVersionArgs{
 		App: app,
 	})
@@ -175,7 +175,7 @@ func newVersion(c *check.C, app *appTypes.App, customData map[string]interface{}
 	return version
 }
 
-func newSuccessfulVersion(c *check.C, app *appTypes.App, customData map[string]interface{}) appTypes.AppVersion {
+func newSuccessfulVersion(c *check.C, app *appTypes.App, customData map[string]any) appTypes.AppVersion {
 	version := newVersion(c, app, customData)
 	err := version.CommitSuccessful()
 	c.Assert(err, check.IsNil)
@@ -185,14 +185,14 @@ func newSuccessfulVersion(c *check.C, app *appTypes.App, customData map[string]i
 func (s *S) TestRunServicePipeline(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
 	})
-	newVersion := newVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	newVersion := newVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web2",
 			"worker2": "python worker2",
 		},
@@ -229,14 +229,14 @@ func (s *S) TestRunServicePipeline(c *check.C) {
 func (s *S) TestRunServicePipelineNilSpec(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
 	})
-	newVersion := newVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	newVersion := newVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web2",
 			"worker2": "python worker2",
 		},
@@ -270,8 +270,8 @@ func (s *S) TestRunServicePipelineNilSpec(c *check.C) {
 func (s *S) TestRunServicePipelineSingleProcess(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	version := newVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	version := newVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
@@ -316,7 +316,7 @@ func (s *S) TestActionUpdateServicesForward(c *check.C) {
 		oldVersion:       oldVersion,
 		oldVersionNumber: oldVersion.Version(),
 	}
-	processes, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	processes, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.IsNil)
 	c.Assert(processes, check.DeepEquals, map[string]*labelReplicas{"web": {}})
 	newLabelsWeb, err := provision.ServiceLabels(context.TODO(), provision.ServiceLabelsOpts{
@@ -343,7 +343,7 @@ func (s *S) TestActionUpdateServicesForwardMultiple(c *check.C) {
 		oldVersion:       oldVersion,
 		oldVersionNumber: oldVersion.Version(),
 	}
-	processes, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	processes, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.IsNil)
 	c.Assert(processes, check.DeepEquals, map[string]*labelReplicas{"web": {}, "worker2": {}})
 	labelsWeb, err := provision.ServiceLabels(context.TODO(), provision.ServiceLabelsOpts{
@@ -391,7 +391,7 @@ func (s *S) TestActionUpdateServicesForwardFailureInMiddle(c *check.C) {
 		oldVersion:       oldVersion,
 		oldVersionNumber: oldVersion.Version(),
 	}
-	_, err = updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	_, err = updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.Equals, expectedError)
 	labelsWeb, err := provision.ServiceLabels(context.TODO(), provision.ServiceLabelsOpts{
 		App:     fakeApp,
@@ -429,7 +429,7 @@ func (s *S) TestActionUpdateServicesForwardFailureInMiddleNewProc(c *check.C) {
 		oldVersion:       oldVersion,
 		oldVersionNumber: oldVersion.Version(),
 	}
-	_, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	_, err := updateServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.Equals, expectedError)
 	labelsWeb, err := provision.ServiceLabels(context.TODO(), provision.ServiceLabelsOpts{
 		App:     fakeApp,
@@ -476,7 +476,7 @@ func (s *S) TestActionUpdateServicesBackward(c *check.C) {
 	}
 	updateServices.Backward(action.BWContext{
 		FWResult: result,
-		Params:   []interface{}{args},
+		Params:   []any{args},
 	})
 	sort.Slice(m.calls, func(i, j int) bool {
 		return m.calls[0].action < m.calls[1].action
@@ -494,7 +494,7 @@ func (s *S) TestUpdateImageInDBForward(c *check.C) {
 		app:        fakeApp,
 		newVersion: newVersion,
 	}
-	_, err := updateImageInDB.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	_, err := updateImageInDB.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.IsNil)
 	c.Assert(newVersion.VersionInfo().DeploySuccessful, check.Equals, true)
 }
@@ -502,8 +502,8 @@ func (s *S) TestUpdateImageInDBForward(c *check.C) {
 func (s *S) TestRemoveOldServicesForward(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
@@ -517,7 +517,7 @@ func (s *S) TestRemoveOldServicesForward(c *check.C) {
 		oldVersion:       oldVersion,
 		oldVersionNumber: oldVersion.Version(),
 	}
-	_, err := removeOldServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	_, err := removeOldServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.IsNil)
 	c.Assert(m.calls, check.DeepEquals, []managerCall{
 		{action: "remove", app: fakeApp, processName: "worker1", versionNumber: oldVersion.Version()},
@@ -556,8 +556,8 @@ func (s *S) TestRemoveOldServicesWithAutoscaleCleanup(c *check.C) {
 	c.Assert(autoscales[0].Process, check.Equals, "worker1")
 
 	m := &recordManager{}
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
@@ -572,7 +572,7 @@ func (s *S) TestRemoveOldServicesWithAutoscaleCleanup(c *check.C) {
 		oldVersionNumber: oldVersion.Version(),
 	}
 
-	_, err = removeOldServices.Forward(action.FWContext{Context: ctx, Params: []interface{}{args}})
+	_, err = removeOldServices.Forward(action.FWContext{Context: ctx, Params: []any{args}})
 	c.Assert(err, check.IsNil)
 
 	autoscales, err = autoscaleProv.GetAutoScale(ctx, fakeApp)
@@ -622,8 +622,8 @@ func (s *S) TestRemoveOldServicesWithMultipleAutoscales(c *check.C) {
 	c.Assert(autoscales, check.HasLen, 2)
 
 	m := &recordManager{}
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
@@ -639,7 +639,7 @@ func (s *S) TestRemoveOldServicesWithMultipleAutoscales(c *check.C) {
 	}
 
 	// Remove worker1 process (keep web)
-	_, err = removeOldServices.Forward(action.FWContext{Context: ctx, Params: []interface{}{args}})
+	_, err = removeOldServices.Forward(action.FWContext{Context: ctx, Params: []any{args}})
 	c.Assert(err, check.IsNil)
 
 	autoscales, err = autoscaleProv.GetAutoScale(ctx, fakeApp)
@@ -656,8 +656,8 @@ func (s *S) TestRemoveOldServicesWithMultipleAutoscales(c *check.C) {
 func (s *S) TestRemoveOldServicesWithNonAutoscaleProvisioner(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	oldVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":     "python web1",
 			"worker1": "python worker1",
 		},
@@ -673,7 +673,7 @@ func (s *S) TestRemoveOldServicesWithNonAutoscaleProvisioner(c *check.C) {
 	}
 
 	// Should not crash even though provisioner doesn't support autoscaling
-	_, err := removeOldServices.Forward(action.FWContext{Context: context.TODO(), Params: []interface{}{args}})
+	_, err := removeOldServices.Forward(action.FWContext{Context: context.TODO(), Params: []any{args}})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(m.calls, check.HasLen, 2)
@@ -684,8 +684,8 @@ func (s *S) TestRemoveOldServicesWithNonAutoscaleProvisioner(c *check.C) {
 func (s *S) TestRunServicePipelineUpdateStates(c *check.C) {
 	m := &recordManager{}
 	a := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	newVersion := newVersion(c, a, map[string]interface{}{
-		"processes": map[string]interface{}{
+	newVersion := newVersion(c, a, map[string]any{
+		"processes": map[string]any{
 			"p1": "cm1",
 		},
 	})
@@ -793,8 +793,8 @@ func (s *S) TestRunServicePipelineOldVersionNotFoundLogsDebugNotError(c *check.C
 	defer log.SetLogger(nil)
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	newVersion := newVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	newVersion := newVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web": "python web1",
 		},
 	})

--- a/provision/servicecommon/state_test.go
+++ b/provision/servicecommon/state_test.go
@@ -15,8 +15,8 @@ import (
 func (s *S) TestChangeAppState(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
-	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":    "python web1",
 			"worker": "python worker1",
 		},
@@ -62,8 +62,8 @@ func (s *S) TestChangeUnits(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
 	fakeApp.Deploys = 1
-	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web":    "python web1",
 			"worker": "python worker1",
 		},
@@ -93,8 +93,8 @@ func (s *S) TestChangeUnitsSingleProcess(c *check.C) {
 	m := &recordManager{}
 	fakeApp := provisiontest.NewFakeApp("myapp", "whitespace", 1)
 	fakeApp.Deploys = 1
-	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]interface{}{
-		"processes": map[string]interface{}{
+	latestVersion := newSuccessfulVersion(c, fakeApp, map[string]any{
+		"processes": map[string]any{
 			"web": "python web1",
 		},
 	})

--- a/router/api/router.go
+++ b/router/api/router.go
@@ -320,8 +320,8 @@ func (r *apiRouter) GetBackendStatus(ctx context.Context, app *appTypes.App) (ro
 	return rsp, nil
 }
 
-func addDefaultOpts(app *appTypes.App, opts map[string]interface{}) map[string]interface{} {
-	mergedOpts := make(map[string]interface{})
+func addDefaultOpts(app *appTypes.App, opts map[string]any) map[string]any {
+	mergedOpts := make(map[string]any)
 	for k, v := range opts {
 		mergedOpts[k] = v
 	}
@@ -367,14 +367,14 @@ func headersFromConfig(config router.ConfigGetter) (http.Header, error) {
 	headers, _ := config.Get("headers")
 	headerResult := make(http.Header)
 	if headers != nil {
-		h, ok := headers.(map[interface{}]interface{})
+		h, ok := headers.(map[any]any)
 		if !ok {
 			return nil, errors.Errorf("invalid header configuration: %v", headers)
 		}
 
 		for k, v := range h {
 			_, isStr := v.(string)
-			_, isSlice := v.([]interface{})
+			_, isSlice := v.([]any)
 			if !isStr && !isSlice {
 				return nil, errors.Errorf("invalid header configuration at key: %s. Expected string or array of strings got %v", k, v)
 			}

--- a/router/api/router_test.go
+++ b/router/api/router_test.go
@@ -142,7 +142,7 @@ func (s *S) TestEnsureBackend(c *check.C) {
 	routerV2 := s.testRouter
 	app := appTypes.App{Name: "myapp", Pool: "mypool", Teams: []string{"team01", "team02"}, TeamOwner: "team03"}
 	err := routerV2.EnsureBackend(context.TODO(), &app, router.EnsureBackendOpts{
-		Opts: map[string]interface{}{
+		Opts: map[string]any{
 			"myinfo.io/test": "test",
 		},
 		Tags: []string{"tag1", "tag2"},
@@ -167,11 +167,11 @@ func (s *S) TestEnsureBackend(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(s.apiRouter.backends["myapp"].tags, check.DeepEquals, []string{"tag1", "tag2"})
-	c.Assert(s.apiRouter.backends["myapp"].opts, check.DeepEquals, map[string]interface{}{
+	c.Assert(s.apiRouter.backends["myapp"].opts, check.DeepEquals, map[string]any{
 		"myinfo.io/test":         "test",
 		"tsuru.io/app-pool":      "mypool",
 		"tsuru.io/app-teamowner": "team03",
-		"tsuru.io/app-teams":     []interface{}{"team01", "team02"},
+		"tsuru.io/app-teams":     []any{"team01", "team02"},
 	})
 	c.Assert(s.apiRouter.backends["myapp"].prefixAddrs, check.DeepEquals, map[string]routesReq{
 		"": {
@@ -232,7 +232,7 @@ func (s *S) TestCreateCustomHeaders(c *check.C) {
 		}
 	})
 	os.Setenv("ROUTER_ENV_HEADER_OPT", "XYZ")
-	config.Set("routers:apirouter:headers", map[interface{}]interface{}{"X-CUSTOM": "HI", "X-CUSTOM-ENV": "$ROUTER_ENV_HEADER_OPT"})
+	config.Set("routers:apirouter:headers", map[any]any{"X-CUSTOM": "HI", "X-CUSTOM-ENV": "$ROUTER_ENV_HEADER_OPT"})
 	defer config.Unset("router:apirouter:headers")
 	defer os.Unsetenv("ROUTER_ENV_HEADER_OPT")
 	r, err := createRouter("apirouter", router.ConfigGetterFromPrefix("routers:apirouter"))
@@ -254,8 +254,8 @@ func (s *S) TestCreateDuplicatedCustomHeaders(c *check.C) {
 		}
 	})
 	os.Setenv("ROUTER_ENV_HEADER_OPT", "XYZ")
-	config.Set("routers:apirouter:headers", map[interface{}]interface{}{
-		"X-CUSTOM-ENV": []interface{}{
+	config.Set("routers:apirouter:headers", map[any]any{
+		"X-CUSTOM-ENV": []any{
 			"$ROUTER_ENV_HEADER_OPT",
 			"ABC",
 		},
@@ -314,7 +314,7 @@ type backend struct {
 	swapWith    string
 	cnameOnly   bool
 	healthcheck routerTypes.HealthcheckData
-	opts        map[string]interface{}
+	opts        map[string]any
 	prefixAddrs map[string]routesReq
 }
 
@@ -364,7 +364,7 @@ func (f *fakeRouterAPI) addBackend(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusConflict)
 		return
 	}
-	var req map[string]interface{}
+	var req map[string]any
 	json.NewDecoder(r.Body).Decode(&req)
 	f.backends[name] = &backend{opts: req, addr: name + ".apirouter.com"}
 }
@@ -414,7 +414,7 @@ func (f *fakeRouterAPI) updateBackend(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	var req map[string]interface{}
+	var req map[string]any
 	json.NewDecoder(r.Body).Decode(&req)
 	backend.opts = req
 }

--- a/router/config.go
+++ b/router/config.go
@@ -15,7 +15,7 @@ type ConfigGetter interface {
 	GetInt(string) (int, error)
 	GetFloat(string) (float64, error)
 	GetBool(string) (bool, error)
-	Get(string) (interface{}, error)
+	Get(string) (any, error)
 	Hash() (string, error)
 }
 
@@ -35,9 +35,9 @@ func (g *delegateConfigGetter) Hash() (string, error) {
 
 var ConfigGetterFromData = configGetterFromData
 
-func configGetterFromData(data map[string]interface{}) ConfigGetter {
+func configGetterFromData(data map[string]any) ConfigGetter {
 	cfg := config.Configuration{}
-	unconverted, _ := internalConfig.UnconvertEntries(data).(map[interface{}]interface{})
+	unconverted, _ := internalConfig.UnconvertEntries(data).(map[any]any)
 	cfg.Store(unconverted)
 	return &delegateConfigGetter{Configuration: &cfg}
 }
@@ -45,7 +45,7 @@ func configGetterFromData(data map[string]interface{}) ConfigGetter {
 func ConfigGetterFromPrefix(prefix string) ConfigGetter {
 	data, _ := config.Get(prefix)
 	cfg := config.Configuration{}
-	unconverted, _ := data.(map[interface{}]interface{})
+	unconverted, _ := data.(map[any]any)
 	cfg.Store(unconverted)
 	return &delegateConfigGetter{Configuration: &cfg}
 }

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -28,16 +28,16 @@ func TestDynamicSuites(t *testing.T) {
 	prefixGetter := ConfigGetterFromPrefix("mine")
 	check.Suite(&ConfigSuite{getter: prefixGetter})
 
-	routerConfig := map[string]interface{}{
+	routerConfig := map[string]any{
 		"str":       "str",
 		"str-int":   "1",
 		"str-float": "1.1",
 		"int":       1,
 		"float":     1.1,
 		"bool":      true,
-		"complex": map[string]interface{}{
+		"complex": map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": 1,
 			},
 		},
@@ -102,9 +102,9 @@ func (s *ConfigSuite) TestGetBool(c *check.C) {
 func (s *ConfigSuite) TestGet(c *check.C) {
 	v, err := s.getter.Get("complex")
 	c.Assert(err, check.IsNil)
-	c.Check(v, check.DeepEquals, map[interface{}]interface{}{
+	c.Check(v, check.DeepEquals, map[any]any{
 		"a": "b",
-		"c": map[interface{}]interface{}{
+		"c": map[any]any{
 			"d": 1,
 		},
 	})
@@ -115,7 +115,7 @@ func (s *ConfigSuite) TestGet(c *check.C) {
 
 	v, err = s.getter.Get("complex:c")
 	c.Assert(err, check.IsNil)
-	c.Check(v, check.DeepEquals, map[interface{}]interface{}{
+	c.Check(v, check.DeepEquals, map[any]any{
 		"d": 1,
 	})
 

--- a/router/dynamic_test.go
+++ b/router/dynamic_test.go
@@ -59,7 +59,7 @@ func (s *S) TestDynamicRouterServiceUpdate(c *check.C) {
 	err = svc.Create(ctx, router.DynamicRouter{
 		Name: "mine",
 		Type: "myrouter",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
 			"c": "d",
 			"e": "f",
@@ -68,7 +68,7 @@ func (s *S) TestDynamicRouterServiceUpdate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = svc.Update(ctx, router.DynamicRouter{
 		Name: "mine",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": nil,
 			"c": "999",
 			"z": "x",
@@ -80,7 +80,7 @@ func (s *S) TestDynamicRouterServiceUpdate(c *check.C) {
 	c.Assert(dbDR, check.DeepEquals, &router.DynamicRouter{
 		Name: "mine",
 		Type: "myrouter",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"c": "999",
 			"z": "x",
 			"e": "f",

--- a/router/rebuild/rebuild.go
+++ b/router/rebuild/rebuild.go
@@ -84,7 +84,7 @@ func RebuildRoutesInRouter(ctx context.Context, appRouter appTypes.AppRouter, o 
 		return errHc
 	}
 	opts := router.EnsureBackendOpts{
-		Opts:        map[string]interface{}{},
+		Opts:        map[string]any{},
 		Prefixes:    []router.BackendPrefix{},
 		Team:        o.App.TeamOwner,
 		CertIssuers: o.App.CertIssuers,

--- a/router/rebuild/rebuild_test.go
+++ b/router/rebuild/rebuild_test.go
@@ -64,8 +64,8 @@ func (s *S) TestRebuildRoutesSetsHealthcheck(c *check.C) {
 		App: &a,
 	})
 	c.Assert(err, check.IsNil)
-	customData := map[string]interface{}{
-		"healthcheck": map[string]interface{}{
+	customData := map[string]any{
+		"healthcheck": map[string]any{
 			"path":          "/healthcheck",
 			"status":        http.StatusFound,
 			"use_in_router": true,

--- a/router/router.go
+++ b/router/router.go
@@ -147,7 +147,7 @@ type BackendPrefix struct {
 }
 
 type EnsureBackendOpts struct {
-	Opts        map[string]interface{} `json:"opts"`
+	Opts        map[string]any         `json:"opts"`
 	CNames      []string               `json:"cnames"`
 	Team        string                 `json:"team,omitempty"`
 	Tags        []string               `json:"tags,omitempty"`
@@ -236,9 +236,9 @@ func List(ctx context.Context) ([]router.PlanRouter, error) {
 
 func listConfigRouters() ([]router.PlanRouter, error) {
 	routerConfig, err := config.Get("routers")
-	var routers map[interface{}]interface{}
+	var routers map[any]any
 	if err == nil {
-		routers, _ = routerConfig.(map[interface{}]interface{})
+		routers, _ = routerConfig.(map[any]any)
 	}
 	routersList := make([]router.PlanRouter, 0, len(routers))
 	var keys []string
@@ -255,18 +255,18 @@ func listConfigRouters() ([]router.PlanRouter, error) {
 
 func legacyConfigToPlanRouter(name string) router.PlanRouter {
 	routerConfig, err := config.Get("routers")
-	var routers map[interface{}]interface{}
+	var routers map[any]any
 	if err == nil {
-		routers, _ = routerConfig.(map[interface{}]interface{})
+		routers, _ = routerConfig.(map[any]any)
 	}
 	var routerType string
 	var defaultFlag bool
 	var readinessGates []string
-	routerProperties, _ := routers[name].(map[interface{}]interface{})
+	routerProperties, _ := routers[name].(map[any]any)
 	if routerProperties != nil {
 		routerType, _ = routerProperties["type"].(string)
 		defaultFlag, _ = routerProperties["default"].(bool)
-		readinessGatesRaw, ok := routerProperties["readinessGates"].([]interface{})
+		readinessGatesRaw, ok := routerProperties["readinessGates"].([]any)
 		if ok {
 			for _, readinessGate := range readinessGatesRaw {
 				readinessGates = append(readinessGates, fmt.Sprint(readinessGate))
@@ -276,10 +276,10 @@ func legacyConfigToPlanRouter(name string) router.PlanRouter {
 	if routerType == "" {
 		routerType = name
 	}
-	var config map[string]interface{}
+	var config map[string]any
 	if routerProperties != nil {
 		configRaw := internalConfig.ConvertEntries(routerProperties)
-		config, _ = configRaw.(map[string]interface{})
+		config, _ = configRaw.(map[string]any)
 		delete(config, "type")
 		delete(config, "default")
 		delete(config, "readinessGates")

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -132,7 +132,7 @@ func (s *S) TestGetDynamicRouter(c *check.C) {
 	err := servicemanager.DynamicRouter.Create(context.TODO(), router.DynamicRouter{
 		Name: "inst2",
 		Type: "myrouter",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"cfg1": "v2",
 		},
 	})
@@ -143,14 +143,14 @@ func (s *S) TestGetDynamicRouter(c *check.C) {
 	c.Assert(planRouter1, check.DeepEquals, router.PlanRouter{
 		Name:   "inst1",
 		Type:   "myrouter",
-		Config: map[string]interface{}{"cfg1": "v1"},
+		Config: map[string]any{"cfg1": "v1"},
 	})
 	_, planRouter2, err := GetWithPlanRouter(context.TODO(), "inst2")
 	c.Assert(err, check.IsNil)
 	c.Assert(planRouter2, check.DeepEquals, router.PlanRouter{
 		Name:    "inst2",
 		Type:    "myrouter",
-		Config:  map[string]interface{}{"cfg1": "v2"},
+		Config:  map[string]any{"cfg1": "v2"},
 		Dynamic: true,
 	})
 
@@ -226,16 +226,16 @@ func (s *S) TestListIncludesDynamic(c *check.C) {
 	err := servicemanager.DynamicRouter.Create(context.TODO(), router.DynamicRouter{
 		Name: "router-dyn",
 		Type: "myrouter",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"mycfg": "zzz",
 		},
 	})
 	c.Assert(err, check.IsNil)
 
 	expected := []router.PlanRouter{
-		{Name: "router-dyn", Type: "myrouter", Dynamic: true, Config: map[string]interface{}{"mycfg": "zzz"}},
+		{Name: "router-dyn", Type: "myrouter", Dynamic: true, Config: map[string]any{"mycfg": "zzz"}},
 		{Name: "router1", Type: "foo"},
-		{Name: "router2", Type: "bar", Config: map[string]interface{}{"cfg1": "aaa"}},
+		{Name: "router2", Type: "bar", Config: map[string]any{"cfg1": "aaa"}},
 	}
 	routers, err := List(context.TODO())
 	c.Assert(err, check.IsNil)

--- a/service/actions_test.go
+++ b/service/actions_test.go
@@ -44,7 +44,7 @@ func (s *S) TestNotifyCreateServiceInstanceForward(c *check.C) {
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{srv, &instance, evt, ""},
+		Params: []any{srv, &instance, evt, ""},
 	}
 	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -66,16 +66,16 @@ func (s *S) TestNotifyCreateServiceInstanceForwardInvalidParams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = servicesCollection.InsertOne(context.TODO(), &srv)
 	c.Assert(err, check.IsNil)
-	ctx := action.FWContext{Params: []interface{}{"", "", ""}}
+	ctx := action.FWContext{Params: []any{"", "", ""}}
 	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be a Service.")
-	ctx = action.FWContext{Params: []interface{}{srv, "", ""}}
+	ctx = action.FWContext{Params: []any{srv, "", ""}}
 	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a *ServiceInstance.")
 	instance := ServiceInstance{Name: "mysql"}
-	ctx = action.FWContext{Params: []interface{}{srv, &instance, 1}}
+	ctx = action.FWContext{Params: []any{srv, &instance, 1}}
 	_, err = notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Third parameter must be an event.")
@@ -95,7 +95,7 @@ func (s *S) TestNotifyCreateServiceInstanceBackward(c *check.C) {
 	c.Assert(err, check.IsNil)
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
-	ctx := action.BWContext{Params: []interface{}{srv, &instance, evt, "test"}}
+	ctx := action.BWContext{Params: []any{srv, &instance, evt, "test"}}
 	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(1))
 }
@@ -112,10 +112,10 @@ func (s *S) TestNotifyCreateServiceInstanceBackwardParams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = servicesCollection.InsertOne(context.TODO(), &srv)
 	c.Assert(err, check.IsNil)
-	ctx := action.BWContext{Params: []interface{}{srv, ""}}
+	ctx := action.BWContext{Params: []any{srv, ""}}
 	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(0))
-	ctx = action.BWContext{Params: []interface{}{"", ""}}
+	ctx = action.BWContext{Params: []any{"", ""}}
 	notifyCreateServiceInstance.Backward(ctx)
 	c.Assert(atomic.LoadInt32(&requests), check.Equals, int32(0))
 }
@@ -132,7 +132,7 @@ func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 	srv := Service{Name: "mongodb"}
 	instance := ServiceInstance{Name: "mysql"}
 	ctx := action.FWContext{
-		Params: []interface{}{srv, &instance},
+		Params: []any{srv, &instance},
 	}
 	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -145,7 +145,7 @@ func (s *S) TestCreateServiceInstanceForward(c *check.C) {
 }
 
 func (s *S) TestCreateServiceInstanceForwardParams(c *check.C) {
-	ctx := action.FWContext{Params: []interface{}{"", ""}}
+	ctx := action.FWContext{Params: []any{"", ""}}
 	_, err := createServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a *ServiceInstance.")
@@ -159,7 +159,7 @@ func (s *S) TestCreateServiceInstanceBackward(c *check.C) {
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &instance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
-		Params: []interface{}{srv, &instance},
+		Params: []any{srv, &instance},
 	}
 	createServiceInstance.Backward(ctx)
 	err = serviceInstancesCollection.FindOne(context.TODO(), mongoBSON.M{"name": instance.Name}).Decode(&instance)
@@ -173,7 +173,7 @@ func (s *S) TestCreateServiceInstanceBackwardParams(c *check.C) {
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &instance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
-		Params: []interface{}{"", ""},
+		Params: []any{"", ""},
 	}
 	createServiceInstance.Backward(ctx)
 	err = serviceInstancesCollection.FindOne(context.TODO(), mongoBSON.M{"name": instance.Name}).Decode(&instance)
@@ -197,7 +197,7 @@ func (s *S) TestUpdateServiceInstanceForward(c *check.C) {
 	c.Assert(err, check.IsNil)
 	updatedInstance := ServiceInstance{Description: "new description", Tags: []string{"tag-a", "tag-b"}, TeamOwner: "new-owner"}
 	ctx := action.FWContext{
-		Params: []interface{}{srv, instance, updatedInstance},
+		Params: []any{srv, instance, updatedInstance},
 	}
 	_, err = updateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -211,11 +211,11 @@ func (s *S) TestUpdateServiceInstanceForward(c *check.C) {
 }
 
 func (s *S) TestUpdateServiceInstanceForwardParams(c *check.C) {
-	ctx := action.FWContext{Params: []interface{}{"", ""}}
+	ctx := action.FWContext{Params: []any{"", ""}}
 	_, err := updateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
-	ctx = action.FWContext{Params: []interface{}{"", ServiceInstance{}, ""}}
+	ctx = action.FWContext{Params: []any{"", ServiceInstance{}, ""}}
 	_, err = updateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Third parameter must be a ServiceInstance.")
@@ -230,7 +230,7 @@ func (s *S) TestUpdateServiceInstanceBackward(c *check.C) {
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &updatedInstance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
-		Params: []interface{}{srv, instance, updatedInstance},
+		Params: []any{srv, instance, updatedInstance},
 	}
 	updateServiceInstance.Backward(ctx)
 	var si ServiceInstance
@@ -248,7 +248,7 @@ func (s *S) TestUpdateServiceInstanceBackwardParams(c *check.C) {
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &updatedInstance)
 	c.Assert(err, check.IsNil)
 	ctx := action.BWContext{
-		Params: []interface{}{"", "", ""},
+		Params: []any{"", "", ""},
 	}
 	updateServiceInstance.Backward(ctx)
 	var si ServiceInstance
@@ -280,7 +280,7 @@ func (s *S) TestNotifyUpdateServiceInstanceForward(c *check.C) {
 	instance := ServiceInstance{Name: "mysql"}
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{srv, &instance, evt, ""},
+		Params: []any{srv, &instance, evt, ""},
 	}
 	r, err := notifyCreateServiceInstance.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -300,20 +300,20 @@ func (s *S) TestNotifyUpdateServiceInstanceForwardParams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	_, err = servicesCollection.InsertOne(context.TODO(), &srv)
 	c.Assert(err, check.IsNil)
-	ctx := action.FWContext{Params: []interface{}{""}}
+	ctx := action.FWContext{Params: []any{""}}
 	_, err = notifyUpdateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "First parameter must be a Service.")
-	ctx = action.FWContext{Params: []interface{}{srv, "", ""}}
+	ctx = action.FWContext{Params: []any{srv, "", ""}}
 	_, err = notifyUpdateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Second parameter must be a ServiceInstance.")
-	ctx = action.FWContext{Params: []interface{}{srv, ServiceInstance{}, "", nil}}
+	ctx = action.FWContext{Params: []any{srv, ServiceInstance{}, "", nil}}
 	_, err = notifyUpdateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "Third parameter must be an event.")
 	evt := createEvt(c)
-	ctx = action.FWContext{Params: []interface{}{srv, ServiceInstance{}, "", evt, nil}}
+	ctx = action.FWContext{Params: []any{srv, ServiceInstance{}, "", evt, nil}}
 	_, err = notifyUpdateServiceInstance.Forward(ctx)
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, "RequestID should be a string.")
@@ -328,7 +328,7 @@ func (s *S) TestBindAppDBActionForward(c *check.C) {
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params: []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 	}
 	_, err = bindAppDBAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -344,7 +344,7 @@ func (s *S) TestBindAppDBActionForwardInvalidParam(c *check.C) {
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &si)
 	c.Assert(err, check.IsNil)
 	ctx := action.FWContext{
-		Params: []interface{}{"wrong parameter"},
+		Params: []any{"wrong parameter"},
 	}
 	_, err = bindAppDBAction.Forward(ctx)
 	c.Assert(err, check.Not(check.IsNil))
@@ -360,7 +360,7 @@ func (s *S) TestBindAppDBActionForwardTwice(c *check.C) {
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params: []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 	}
 	_, err = bindAppDBAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -377,7 +377,7 @@ func (s *S) TestBindAppDBActionBackwardRemovesAppFromServiceInstance(c *check.C)
 	c.Assert(err, check.IsNil)
 	evt := createEvt(c)
 	ctx := action.BWContext{
-		Params: []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params: []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 	}
 	bindAppDBAction.Backward(ctx)
 	c.Assert(err, check.IsNil)
@@ -406,7 +406,7 @@ func (s *S) TestBindAppEndpointActionForwardReturnsEnvVars(c *check.C) {
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params: []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 	}
 	envs, err := bindAppEndpointAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -438,7 +438,7 @@ func (s *S) TestBindAppEndpointActionBackward(c *check.C) {
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
 	evt := createEvt(c)
 	bwCtx := action.BWContext{
-		Params:   []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 		FWResult: nil,
 	}
 	bindAppEndpointAction.Backward(bwCtx)
@@ -454,7 +454,7 @@ func (s *S) TestSetBoundEnvsActionForward(c *check.C) {
 	a := provisiontest.NewFakeApp("myapp", "static", 1)
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params:   []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 		Previous: map[string]string{"DATABASE_NAME": "mydb", "DATABASE_USER": "root"},
 	}
 	result, err := setBoundEnvsAction.Forward(ctx)
@@ -471,7 +471,7 @@ func (s *S) TestSetBoundEnvsActionForward(c *check.C) {
 }
 
 func (s *S) TestSetBoundEnvsActionForwardWrongParameter(c *check.C) {
-	ctx := action.FWContext{Params: []interface{}{"something"}}
+	ctx := action.FWContext{Params: []any{"something"}}
 	_, err := setBoundEnvsAction.Forward(ctx)
 	c.Assert(err.Error(), check.Equals, "invalid arguments for pipeline, expected *bindAppPipelineArgs.")
 }
@@ -489,7 +489,7 @@ func (s *S) TestSetBoundEnvsActionBackward(c *check.C) {
 	c.Assert(err, check.IsNil)
 	evt := createEvt(c)
 	ctx := action.BWContext{
-		Params:   []interface{}{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindAppPipelineArgs{app: a, serviceInstance: &si, event: evt}},
 		FWResult: nil,
 	}
 	setBoundEnvsAction.Backward(ctx)
@@ -517,7 +517,7 @@ func (s *S) TestUnbindAppDBForward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindAppDB.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	siDB, err := GetServiceInstance(context.TODO(), si.ServiceName, si.Name)
@@ -545,7 +545,7 @@ func (s *S) TestUnbindAppDBBackward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.BWContext{Params: []interface{}{&args}}
+	ctx := action.BWContext{Params: []any{&args}}
 	unbindAppDB.Backward(ctx)
 	siDB, err := GetServiceInstance(context.TODO(), si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
@@ -578,7 +578,7 @@ func (s *S) TestUnbindAppEndpointForward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindAppEndpoint.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(reqs, check.HasLen, 1)
@@ -612,7 +612,7 @@ func (s *S) TestUnbindAppEndpointForwardNotFound(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindAppEndpoint.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(reqs, check.HasLen, 1)
@@ -646,7 +646,7 @@ func (s *S) TestUnbindAppEndpointBackward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.BWContext{Params: []interface{}{&args}}
+	ctx := action.BWContext{Params: []any{&args}}
 	unbindAppEndpoint.Backward(ctx)
 	c.Assert(reqs, check.HasLen, 1)
 	c.Assert(reqs[0].Method, check.Equals, "POST")
@@ -681,7 +681,7 @@ func (s *S) TestRemoveBoundEnvsForward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = removeBoundEnvs.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	envs := a.ServiceEnvs
@@ -699,7 +699,7 @@ func (s *S) TestBindJobDBActionForwardInvalidParam(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	ctx := action.FWContext{
-		Params: []interface{}{"wrong parameter"},
+		Params: []any{"wrong parameter"},
 	}
 	_, err = bindJobDBAction.Forward(ctx)
 	c.Assert(err, check.Not(check.IsNil))
@@ -718,7 +718,7 @@ func (s *S) TestBindJobDBActionJobAlreadyBound(c *check.C) {
 	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params: []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 	}
 	_, err = bindJobDBAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -739,7 +739,7 @@ func (s *S) TestBindJobDBActionBackwardRemovesAppFromServiceInstance(c *check.C)
 
 	evt := createEvt(c)
 	ctx := action.BWContext{
-		Params: []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params: []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 	}
 	bindJobDBAction.Backward(ctx)
 
@@ -776,7 +776,7 @@ func (s *S) TestBindJobEndpointActionForwardReturnsEnvVars(c *check.C) {
 	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params: []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params: []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 	}
 	envs, err := bindJobEndpointAction.Forward(ctx)
 	c.Assert(err, check.IsNil)
@@ -816,7 +816,7 @@ func (s *S) TestBindJobEndpointActionBackward(c *check.C) {
 	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
 	evt := createEvt(c)
 	bwCtx := action.BWContext{
-		Params:   []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 		FWResult: nil,
 	}
 	bindJobEndpointAction.Backward(bwCtx)
@@ -831,7 +831,7 @@ func (s *S) TestSetJobBoundEnvsActionForward(c *check.C) {
 	job := provisiontest.NewFakeJob("test-job", "test-pool", "test-team-owner")
 	evt := createEvt(c)
 	ctx := action.FWContext{
-		Params:   []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 		Previous: map[string]string{"DATABASE_NAME": "mydb", "DATABASE_USER": "root"},
 	}
 	result, err := setJobBoundEnvsAction.Forward(ctx)
@@ -847,7 +847,7 @@ func (s *S) TestSetJobBoundEnvsActionForward(c *check.C) {
 }
 
 func (s *S) TestSetJobBoundEnvsActionForwardWrongParameter(c *check.C) {
-	ctx := action.FWContext{Params: []interface{}{"something"}}
+	ctx := action.FWContext{Params: []any{"something"}}
 	_, err := setJobBoundEnvsAction.Forward(ctx)
 	c.Assert(err.Error(), check.Equals, "invalid arguments for pipeline, expected *bindJobPipelineArgs.")
 }
@@ -872,7 +872,7 @@ func (s *S) TestSetJobBoundEnvsActionBackward(c *check.C) {
 
 	evt := createEvt(c)
 	ctx := action.BWContext{
-		Params:   []interface{}{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
+		Params:   []any{&bindJobPipelineArgs{job: job, serviceInstance: &si, event: evt}},
 		FWResult: nil,
 	}
 	setJobBoundEnvsAction.Backward(ctx)
@@ -909,7 +909,7 @@ func (s *S) TestUnbindJobDBForward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindJobDB.Forward(ctx)
 	c.Assert(err, check.IsNil)
 
@@ -946,7 +946,7 @@ func (s *S) TestUnbindJobDBBackward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.BWContext{Params: []interface{}{&args}}
+	ctx := action.BWContext{Params: []any{&args}}
 	unbindJobDB.Backward(ctx)
 	siDB, err := GetServiceInstance(context.TODO(), si.ServiceName, si.Name)
 	c.Assert(err, check.IsNil)
@@ -986,7 +986,7 @@ func (s *S) TestUnbindJobEndpointForward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindJobEndpoint.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(reqs, check.HasLen, 1)
@@ -1031,7 +1031,7 @@ func (s *S) TestUnbindJobEndpointForwardNotFound(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = unbindJobEndpoint.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(reqs, check.HasLen, 1)
@@ -1076,7 +1076,7 @@ func (s *S) TestUnbindJobEndpointBackward(c *check.C) {
 		serviceInstance: &si,
 		writer:          buf,
 	}
-	ctx := action.BWContext{Params: []interface{}{&args}}
+	ctx := action.BWContext{Params: []any{&args}}
 	unbindJobEndpoint.Backward(ctx)
 	c.Assert(reqs, check.HasLen, 1)
 	c.Assert(reqs[0].Method, check.Equals, "PUT")
@@ -1120,7 +1120,7 @@ func (s *S) TestRemoveJobBoundEnvsForward(c *check.C) {
 		job:             job,
 		serviceInstance: &si,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = removeJobBoundEnvs.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(rmCalled, check.Equals, true)
@@ -1152,7 +1152,7 @@ func (s *S) TestReloadJobProvisionerForwardForCronJob(c *check.C) {
 		job:             job,
 		serviceInstance: &si,
 	}
-	ctx := action.FWContext{Params: []interface{}{&args}}
+	ctx := action.FWContext{Params: []any{&args}}
 	_, err = reloadJobProvisioner.Forward(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(reloadCalled, check.Equals, true)

--- a/service/endpoint.go
+++ b/service/endpoint.go
@@ -513,7 +513,7 @@ func (c *endpointClient) issueRequest(ctx context.Context, path, method string, 
 	return resp, err
 }
 
-func (c *endpointClient) jsonFromResponse(resp *http.Response, v interface{}) error {
+func (c *endpointClient) jsonFromResponse(resp *http.Response, v any) error {
 	err := json.NewDecoder(resp.Body).Decode(v)
 	if err != nil {
 		log.Errorf("Got error while parsing service json: %s", err)

--- a/service/endpoint_test.go
+++ b/service/endpoint_test.go
@@ -115,9 +115,9 @@ func (s *S) TestEndpointCreate(c *check.C) {
 		TeamOwner:   "theteam",
 		Description: "xyz",
 		Tags:        []string{"tag 1", "tag 2"},
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"p1": "v1",
-			"p2": map[string]interface{}{
+			"p2": map[string]any{
 				"complex1": "complexvalue1",
 			},
 		},
@@ -160,9 +160,9 @@ func (s *S) TestEndpointCreateJSON(c *check.C) {
 		TeamOwner:   "theteam",
 		Description: "xyz",
 		Tags:        []string{"tag 1", "tag 2"},
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"p1": "v1",
-			"p2": map[string]interface{}{
+			"p2": map[string]any{
 				"complex1": "complexvalue1",
 			},
 		},
@@ -203,7 +203,7 @@ func (s *S) TestEndpointUpdateJSON(c *check.C) {
 		Description: "my service",
 		Tags:        []string{"tag1", "tag2"},
 		PlanName:    "small",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"p1": "v1",
 		},
 	}
@@ -269,7 +269,7 @@ func (s *S) TestEndpointBindAppJSON(c *check.C) {
 	a := provisiontest.NewFakeAppWithPool("her-app", "python", "her-pool", 1)
 	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde", encoding: ServiceEncodingJSON}
 	evt := createEvt(c)
-	bindParams := map[string]interface{}{"p1": "v1"}
+	bindParams := map[string]any{"p1": "v1"}
 	_, err := client.BindApp(context.TODO(), &instance, a, bindParams, evt, "")
 	h.Lock()
 	defer h.Unlock()
@@ -498,9 +498,9 @@ func (s *S) TestUpdateShouldSendAPutRequestToTheResourceURL(c *check.C) {
 		Description: "my service",
 		Tags:        []string{"tag1", "tag2"},
 		PlanName:    "small",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"p1": "v1",
-			"p2": map[string]interface{}{
+			"p2": map[string]any{
 				"complex1": "complexvalue1",
 			},
 		},
@@ -698,9 +698,9 @@ func (s *S) TestBindAppWithParams(c *check.C) {
 	}
 	client := &endpointClient{endpoint: ts.URL, username: "user", password: "abcde"}
 	evt := createEvt(c)
-	bindParams := map[string]interface{}{
+	bindParams := map[string]any{
 		"p1": "v1",
-		"p2": map[string]interface{}{
+		"p2": map[string]any{
 			"complex1": "complexvalue1",
 		},
 	}

--- a/service/payloads.go
+++ b/service/payloads.go
@@ -116,7 +116,7 @@ func (r *unbindAppPayload) Form() url.Values {
 	return params
 }
 
-func addParameters(dst url.Values, params map[string]interface{}) {
+func addParameters(dst url.Values, params map[string]any) {
 	if params == nil || dst == nil {
 		return
 	}

--- a/service/service_instance.go
+++ b/service/service_instance.go
@@ -49,16 +49,16 @@ var (
 )
 
 type ServiceInstance struct {
-	Name        string                 `json:"name"`
-	ServiceName string                 `bson:"service_name" json:"service_name"`
-	PlanName    string                 `bson:"plan_name" json:"plan_name"`
-	Apps        []string               `json:"apps"`
-	Jobs        []string               `json:"jobs"`
-	Teams       []string               `json:"teams"`
-	TeamOwner   string                 `json:"team_owner"`
-	Description string                 `json:"description"`
-	Tags        []string               `json:"tags"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
+	Name        string         `json:"name"`
+	ServiceName string         `bson:"service_name" json:"service_name"`
+	PlanName    string         `bson:"plan_name" json:"plan_name"`
+	Apps        []string       `json:"apps"`
+	Jobs        []string       `json:"jobs"`
+	Teams       []string       `json:"teams"`
+	TeamOwner   string         `json:"team_owner"`
+	Description string         `json:"description"`
+	Tags        []string       `json:"tags"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
 	// Pool is the pool name which the Service Instance should run into.
 	// This field is mandatory iff the parent Service is running in
 	// multi-cluster mode (see Service.IsMultiCluster field)
@@ -332,7 +332,7 @@ func (si *ServiceInstance) Revoke(ctx context.Context, teamName string) error {
 	return si.updateData(ctx, mongoBSON.M{"$pull": mongoBSON.M{"teams": team.Name}})
 }
 
-func genericServiceInstancesFilter(services interface{}, teams []string) mongoBSON.M {
+func genericServiceInstancesFilter(services any, teams []string) mongoBSON.M {
 	query := mongoBSON.M{}
 	if len(teams) != 0 {
 		query["teams"] = mongoBSON.M{"$in": teams}

--- a/service/service_instance_test.go
+++ b/service/service_instance_test.go
@@ -202,7 +202,7 @@ func (s *InstanceSuite) TestBindApp(c *check.C) {
 		setBoundEnvsAction = oldSetBoundEnvsAction
 	}()
 	var calls []string
-	var params []interface{}
+	var params []any
 	bindAppDBAction = &action.Action{
 		Forward: func(ctx action.FWContext) (action.Result, error) {
 			calls = append(calls, "bindAppDBAction")
@@ -232,7 +232,7 @@ func (s *InstanceSuite) TestBindApp(c *check.C) {
 		"bindAppDBAction", "bindAppEndpointAction",
 		"setBoundEnvsAction",
 	}
-	expectedParams := []interface{}{&bindAppPipelineArgs{
+	expectedParams := []any{&bindAppPipelineArgs{
 		app:             a,
 		serviceInstance: &si,
 		writer:          &buf,
@@ -259,7 +259,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToApp(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Apps:        []string{"app1", "app2"},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -272,7 +272,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToApp(c *check.C) {
 		Apps:        []string{"app1"},
 		Jobs:        []string{},
 		Teams:       []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
@@ -300,7 +300,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToJob(c *check.C) {
 		Teams:       []string{s.team.Name},
 		Jobs:        []string{"job1", "job2"},
 		Apps:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -313,7 +313,7 @@ func (s *InstanceSuite) TestGetServiceInstancesBoundToJob(c *check.C) {
 		Jobs:        []string{"job1"},
 		Apps:        []string{},
 		Teams:       []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	_, err = serviceInstancesCollection.InsertOne(context.TODO(), &sInstance2)
 	c.Assert(err, check.IsNil)
@@ -335,7 +335,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesNoFilters(c *chec
 		Tags:        []string{"tag1"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	sInstance2 := ServiceInstance{
 		Name:        "s9sql",
@@ -344,7 +344,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesNoFilters(c *chec
 		Tags:        []string{"tag2"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
@@ -370,7 +370,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTeams(
 		Tags:        []string{},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	sInstance2 := ServiceInstance{
 		Name:        "s9sql",
@@ -379,7 +379,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTeams(
 		Tags:        []string{},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -403,7 +403,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByNames(
 		Tags:        []string{},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	sInstance2 := ServiceInstance{
 		Name:        "s9sql",
@@ -412,7 +412,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByNames(
 		Tags:        []string{},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -436,7 +436,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTags(c
 		Teams:       []string{"team1"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	sInstance2 := ServiceInstance{
 		Name:        "s9sql",
@@ -445,7 +445,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByTags(c
 		Teams:       []string{"team1"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -469,7 +469,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByMultip
 		Tags:        []string{"tag1"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	sInstance2 := ServiceInstance{
 		Name:        "s9sql",
@@ -478,7 +478,7 @@ func (s *InstanceSuite) TestGetServicesInstancesByTeamsAndNamesFilteringByMultip
 		Tags:        []string{"tag1", "tag3"},
 		Apps:        []string{},
 		Jobs:        []string{},
-		Parameters:  map[string]interface{}{},
+		Parameters:  map[string]any{},
 	}
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
@@ -644,17 +644,17 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSON(c *check.C) {
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(info)
 	c.Assert(err, check.IsNil)
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,
 		"Apps":        nil,
 		"Jobs":        nil,
 		"ServiceName": "mysql",
-		"Info":        map[string]interface{}{"key": "value"},
+		"Info":        map[string]any{"key": "value"},
 		"TeamOwner":   "",
 		"Pool":        "",
 	}
@@ -672,10 +672,10 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSONWithoutInfo(c *check.C
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(info)
 	c.Assert(err, check.IsNil)
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,
@@ -700,10 +700,10 @@ func (s *InstanceSuite) TestServiceInstanceInfoMarshalJSONWithoutEndpoint(c *che
 	c.Assert(err, check.IsNil)
 	data, err := json.Marshal(info)
 	c.Assert(err, check.IsNil)
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"Name":        "ql",
 		"PlanName":    "",
 		"Teams":       nil,
@@ -1328,7 +1328,7 @@ func (s *InstanceSuite) TestGetServiceInstance(c *check.C) {
 	serviceInstanceCollection, err := storagev2.ServiceInstancesCollection()
 	c.Assert(err, check.IsNil)
 
-	serviceInstanceCollection.InsertMany(context.TODO(), []interface{}{
+	serviceInstanceCollection.InsertMany(context.TODO(), []any{
 		ServiceInstance{Name: "mongo-1", ServiceName: "mongodb", Teams: []string{s.team.Name}},
 		ServiceInstance{Name: "mongo-2", ServiceName: "mongodb", Teams: []string{s.team.Name}},
 		ServiceInstance{Name: "mongo-3", ServiceName: "mongodb", Teams: []string{s.team.Name}},
@@ -1827,9 +1827,9 @@ func (s *InstanceSuite) TestUnbindAppMultipleApps(c *check.C) {
 
 func (s *S) TestRenameServiceInstanceTeam(c *check.C) {
 	sInstances := []any{
-		ServiceInstance{Name: "si1", ServiceName: "mysql", Teams: []string{"team1", "team2", "team3"}, TeamOwner: "team1", Parameters: map[string]interface{}{}},
-		ServiceInstance{Name: "si2", ServiceName: "mysql", Teams: []string{"team1", "team3"}, TeamOwner: "team2", Parameters: map[string]interface{}{}},
-		ServiceInstance{Name: "si3", ServiceName: "mysql", Teams: []string{"team2", "team3"}, TeamOwner: "team3", Parameters: map[string]interface{}{}},
+		ServiceInstance{Name: "si1", ServiceName: "mysql", Teams: []string{"team1", "team2", "team3"}, TeamOwner: "team1", Parameters: map[string]any{}},
+		ServiceInstance{Name: "si2", ServiceName: "mysql", Teams: []string{"team1", "team3"}, TeamOwner: "team2", Parameters: map[string]any{}},
+		ServiceInstance{Name: "si3", ServiceName: "mysql", Teams: []string{"team2", "team3"}, TeamOwner: "team3", Parameters: map[string]any{}},
 	}
 
 	serviceInstancesCollection, err := storagev2.ServiceInstancesCollection()
@@ -1852,9 +1852,9 @@ func (s *S) TestRenameServiceInstanceTeam(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(dbInstances, check.DeepEquals, []ServiceInstance{
-		{Name: "si1", ServiceName: "mysql", Teams: []string{"team1", "team3", "team9000"}, TeamOwner: "team1", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]interface{}{}},
-		{Name: "si2", ServiceName: "mysql", Teams: []string{"team1", "team3"}, TeamOwner: "team9000", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]interface{}{}},
-		{Name: "si3", ServiceName: "mysql", Teams: []string{"team3", "team9000"}, TeamOwner: "team3", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]interface{}{}},
+		{Name: "si1", ServiceName: "mysql", Teams: []string{"team1", "team3", "team9000"}, TeamOwner: "team1", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]any{}},
+		{Name: "si2", ServiceName: "mysql", Teams: []string{"team1", "team3"}, TeamOwner: "team9000", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]any{}},
+		{Name: "si3", ServiceName: "mysql", Teams: []string{"team3", "team9000"}, TeamOwner: "team3", Apps: []string{}, Jobs: []string{}, Tags: []string{}, Parameters: map[string]any{}},
 	})
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -502,39 +502,39 @@ func (s *S) TestServiceModelMarshalJSON(c *check.C) {
 				Teams:       []string{"t1", "t2"},
 				Apps:        []string{"app1", "app2"},
 				Jobs:        []string{"job1"},
-				Parameters:  map[string]interface{}{"parameter": "val"},
+				Parameters:  map[string]any{"parameter": "val"},
 			},
 		}},
 	}
 	data, err := json.Marshal(&sm)
 	c.Assert(err, check.IsNil)
-	expected := make([]map[string]interface{}, 2)
-	expected[0] = map[string]interface{}{
+	expected := make([]map[string]any, 2)
+	expected[0] = map[string]any{
 		"service":           "mysql",
 		"instances":         nil,
 		"plans":             nil,
 		"service_instances": nil,
 	}
-	expected[1] = map[string]interface{}{
+	expected[1] = map[string]any{
 		"service":   "mongo",
 		"instances": nil,
 		"plans":     nil,
-		"service_instances": []interface{}{map[string]interface{}{
+		"service_instances": []any{map[string]any{
 			"name":         "my instance",
-			"tags":         []interface{}{"my tag"},
+			"tags":         []any{"my tag"},
 			"team_owner":   "t1",
-			"teams":        []interface{}{"t1", "t2"},
-			"apps":         []interface{}{"app1", "app2"},
-			"jobs":         []interface{}{"job1"},
+			"teams":        []any{"t1", "t2"},
+			"apps":         []any{"app1", "app2"},
+			"jobs":         []any{"job1"},
 			"plan_name":    "",
 			"service_name": "mysql",
 			"description":  "",
-			"parameters": map[string]interface{}{
+			"parameters": map[string]any{
 				"parameter": "val",
 			},
 		}},
 	}
-	result := make([]map[string]interface{}, 2)
+	result := make([]map[string]any, 2)
 	err = json.Unmarshal(data, &result)
 	c.Assert(err, check.IsNil)
 	c.Assert(result, check.DeepEquals, expected)

--- a/service/suite_test.go
+++ b/service/suite_test.go
@@ -40,7 +40,7 @@ func (c *hasAccessToChecker) Info() *check.CheckerInfo {
 	return &check.CheckerInfo{Name: "HasAccessTo", Params: []string{"team", "service"}}
 }
 
-func (c *hasAccessToChecker) Check(params []interface{}, names []string) (bool, string) {
+func (c *hasAccessToChecker) Check(params []any, names []string) (bool, string) {
 	if len(params) != 2 {
 		return false, "you must provide two parameters"
 	}

--- a/set/set.go
+++ b/set/set.go
@@ -85,7 +85,7 @@ func FromSlice(l []string) Set {
 	return s
 }
 
-func FromMap(m interface{}) Set {
+func FromMap(m any) Set {
 	s := Set{}
 	v := reflect.ValueOf(m)
 	if v.Kind() != reflect.Map {

--- a/storage/mongodb/dynamic_router.go
+++ b/storage/mongodb/dynamic_router.go
@@ -17,8 +17,8 @@ import (
 type dynamicRouter struct {
 	Name           string `bson:"_id"`
 	Type           string
-	ReadinessGates []string               `bson:",omitempty"`
-	Config         map[string]interface{} `bson:",omitempty"`
+	ReadinessGates []string       `bson:",omitempty"`
+	Config         map[string]any `bson:",omitempty"`
 }
 
 type dynamicRouterStorage struct{}

--- a/storage/mongodb/otel.go
+++ b/storage/mongodb/otel.go
@@ -62,16 +62,16 @@ func (s *mongoDBSpan) Finish() {
 }
 
 // LogKV is a compatibility method for old logging API
-func (s *mongoDBSpan) LogKV(keyvals ...interface{}) {
+func (s *mongoDBSpan) LogKV(keyvals ...any) {
 	// OpenTelemetry doesn't have direct equivalent, ignoring
 }
 
-func (s *mongoDBSpan) SetQueryStatement(query interface{}) {
+func (s *mongoDBSpan) SetQueryStatement(query any) {
 	value, _ := json.Marshal(query)
 	s.SetAttributes(attribute.String("db.statement", string(value)))
 }
 
-func (s *mongoDBSpan) SetMongoID(id interface{}) {
+func (s *mongoDBSpan) SetMongoID(id any) {
 	s.SetQueryStatement(mongoBSON.M{"_id": id})
 }
 

--- a/storage/storagetest/app_version_suite.go
+++ b/storage/storagetest/app_version_suite.go
@@ -116,8 +116,8 @@ func (s *AppVersionSuite) TestAppVersionStorage_AppVersions(c *check.C) {
 	c.Assert(versions.AppName, check.Equals, "myapp")
 	c.Assert(versions.Count, check.Equals, 2)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		1: {Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -165,14 +165,14 @@ func (s *AppVersionSuite) TestAppVersionStorage_AllAppVersions(c *check.C) {
 	c.Assert(allVersions[0].Count, check.Equals, 1)
 	c.Assert(allVersions[0].UpdatedAt.Unix() <= time.Now().UTC().Unix(), check.Equals, true)
 	c.Assert(allVersions[0].Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		1: {Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 
 	c.Assert(allVersions[1].AppName, check.Equals, "myapp2")
 	c.Assert(allVersions[1].Count, check.Equals, 1)
 	c.Assert(allVersions[1].UpdatedAt.Unix() <= time.Now().UTC().Unix(), check.Equals, true)
 	c.Assert(allVersions[1].Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		1: {Version: 1, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		1: {Version: 1, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 
@@ -206,7 +206,7 @@ func (s *AppVersionSuite) TestAppVersionStorage_DeleteVersionIDs(c *check.C) {
 	c.Assert(versions.LastSuccessfulVersion, check.DeepEquals, 0)
 	c.Assert(versions.UpdatedAt.IsZero(), check.Equals, false)
 	c.Assert(versions.Versions, check.DeepEquals, map[int]appTypes.AppVersionInfo{
-		2: {Version: 2, CustomData: map[string]interface{}{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
+		2: {Version: 2, CustomData: map[string]any{}, Processes: map[string][]string{}, ExposedPorts: []string{}, PastUnits: map[string]int{}},
 	})
 }
 

--- a/storage/storagetest/dynamic_router_suite.go
+++ b/storage/storagetest/dynamic_router_suite.go
@@ -20,9 +20,9 @@ func (s *DynamicRouterSuite) TestSave(c *check.C) {
 	dr := router.DynamicRouter{
 		Name: "my-router",
 		Type: "my-type",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": "e",
 			},
 		},
@@ -47,9 +47,9 @@ func (s *DynamicRouterSuite) TestList(c *check.C) {
 	dr1 := router.DynamicRouter{
 		Name: "my-router1",
 		Type: "my-type",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": "e",
 			},
 		},
@@ -57,9 +57,9 @@ func (s *DynamicRouterSuite) TestList(c *check.C) {
 	dr2 := router.DynamicRouter{
 		Name: "my-router2",
 		Type: "my-type",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": "e",
 			},
 		},
@@ -77,9 +77,9 @@ func (s *DynamicRouterSuite) TestR(c *check.C) {
 	dr1 := router.DynamicRouter{
 		Name: "my-router1",
 		Type: "my-type",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": "e",
 			},
 		},
@@ -87,9 +87,9 @@ func (s *DynamicRouterSuite) TestR(c *check.C) {
 	dr2 := router.DynamicRouter{
 		Name: "my-router2",
 		Type: "my-type",
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"a": "b",
-			"c": map[string]interface{}{
+			"c": map[string]any{
 				"d": "e",
 			},
 		},

--- a/storage/storagetest/pool_suite.go
+++ b/storage/storagetest/pool_suite.go
@@ -24,7 +24,7 @@ func (s *PoolSuite) TestFindAll(c *check.C) {
 	collection, err := storagev2.PoolCollection()
 	c.Assert(err, check.IsNil)
 
-	_, err = collection.InsertMany(context.TODO(), []interface{}{
+	_, err = collection.InsertMany(context.TODO(), []any{
 		mongoBSON.M{"_id": "pool-A", "provisioner": "docker", "default": true},
 		mongoBSON.M{"_id": "pool-B", "provisioner": "kubernetes"},
 	},
@@ -41,7 +41,7 @@ func (s *PoolSuite) TestFindAll(c *check.C) {
 func (s *PoolSuite) TestFindByName(c *check.C) {
 	collection, err := storagev2.PoolCollection()
 	c.Assert(err, check.IsNil)
-	_, err = collection.InsertMany(context.TODO(), []interface{}{
+	_, err = collection.InsertMany(context.TODO(), []any{
 		mongoBSON.M{"_id": "pool-A", "provisioner": "docker", "default": true},
 		mongoBSON.M{"_id": "pool-B", "provisioner": "kubernetes"},
 	})

--- a/storage/storagetest/volume_suite.go
+++ b/storage/storagetest/volume_suite.go
@@ -26,7 +26,7 @@ func (s *VolumeSuite) Test_SaveGetDelete(c *check.C) {
 		},
 		Plan: volume.VolumePlan{
 			Name: "plan1",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"opt1": "value1",
 			},
 		},
@@ -55,7 +55,7 @@ func (s *VolumeSuite) Test_ListByFilter(c *check.C) {
 			},
 			Plan: volume.VolumePlan{
 				Name: "plan1",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"opt1": "value1",
 				},
 			},
@@ -69,7 +69,7 @@ func (s *VolumeSuite) Test_ListByFilter(c *check.C) {
 			},
 			Plan: volume.VolumePlan{
 				Name: "plan1",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"opt1": "value1",
 				},
 			},
@@ -84,7 +84,7 @@ func (s *VolumeSuite) Test_ListByFilter(c *check.C) {
 			},
 			Plan: volume.VolumePlan{
 				Name: "plan1",
-				Opts: map[string]interface{}{
+				Opts: map[string]any{
 					"opt1": "value1",
 				},
 			},
@@ -195,7 +195,7 @@ func (s *VolumeSuite) Test_RenameTeam(c *check.C) {
 		},
 		Plan: volume.VolumePlan{
 			Name: "plan1",
-			Opts: map[string]interface{}{
+			Opts: map[string]any{
 				"opt1": "value1",
 			},
 		},

--- a/streamfmt/streamfmt.go
+++ b/streamfmt/streamfmt.go
@@ -34,49 +34,49 @@ func Error(text string) string {
 
 // Formatted versions
 
-func Sectionf(format string, a ...interface{}) string {
+func Sectionf(format string, a ...any) string {
 	return SectionPrefix + fmt.Sprintf(format, a...) + SectionSuffix
 }
 
-func Actionf(format string, a ...interface{}) string {
+func Actionf(format string, a ...any) string {
 	return ActionPrefix + fmt.Sprintf(format, a...)
 }
 
-func Errorf(format string, a ...interface{}) string {
+func Errorf(format string, a ...any) string {
 	return ErrorPrefix + strings.ToUpper(fmt.Sprintf(format, a...)) + ErrorSuffix
 }
 
 // io.Writer versions
 
-func FprintSectionf(w io.Writer, format string, a ...interface{}) {
+func FprintSectionf(w io.Writer, format string, a ...any) {
 	fmt.Fprint(w, Sectionf(format, a...))
 }
 
-func FprintActionf(w io.Writer, format string, a ...interface{}) {
+func FprintActionf(w io.Writer, format string, a ...any) {
 	fmt.Fprint(w, Actionf(format, a...))
 }
 
-func FprintErrorf(w io.Writer, format string, a ...interface{}) {
+func FprintErrorf(w io.Writer, format string, a ...any) {
 	fmt.Fprint(w, Errorf(format, a...))
 }
 
 // io.Writer versions with newline
 
-func FprintlnSectionf(w io.Writer, format string, a ...interface{}) {
+func FprintlnSectionf(w io.Writer, format string, a ...any) {
 	if w == nil {
 		return
 	}
 	fmt.Fprintln(w, Sectionf(format, a...))
 }
 
-func FprintlnActionf(w io.Writer, format string, a ...interface{}) {
+func FprintlnActionf(w io.Writer, format string, a ...any) {
 	if w == nil {
 		return
 	}
 	fmt.Fprintln(w, Actionf(format, a...))
 }
 
-func FprintlnErrorf(w io.Writer, format string, a ...interface{}) {
+func FprintlnErrorf(w io.Writer, format string, a ...any) {
 	if w == nil {
 		return
 	}

--- a/streamfmt/streamfmt_test.go
+++ b/streamfmt/streamfmt_test.go
@@ -64,13 +64,13 @@ func TestSectionf(t *testing.T) {
 	tests := []struct {
 		name     string
 		format   string
-		args     []interface{}
+		args     []any
 		expected string
 	}{
 		{
 			name:     "with args",
 			format:   "Deploying app %s to pool %s",
-			args:     []interface{}{"myapp", "prod"},
+			args:     []any{"myapp", "prod"},
 			expected: "---- Deploying app myapp to pool prod ----",
 		},
 		{
@@ -82,7 +82,7 @@ func TestSectionf(t *testing.T) {
 		{
 			name:     "with number",
 			format:   "Version %d",
-			args:     []interface{}{42},
+			args:     []any{42},
 			expected: "---- Version 42 ----",
 		},
 	}
@@ -97,13 +97,13 @@ func TestActionf(t *testing.T) {
 	tests := []struct {
 		name     string
 		format   string
-		args     []interface{}
+		args     []any
 		expected string
 	}{
 		{
 			name:     "with args",
 			format:   "Step %d of %d",
-			args:     []interface{}{1, 5},
+			args:     []any{1, 5},
 			expected: " ---> Step 1 of 5",
 		},
 		{
@@ -124,13 +124,13 @@ func TestErrorf(t *testing.T) {
 	tests := []struct {
 		name     string
 		format   string
-		args     []interface{}
+		args     []any
 		expected string
 	}{
 		{
 			name:     "with args",
 			format:   "failed to deploy %s: %s",
-			args:     []interface{}{"myapp", "timeout"},
+			args:     []any{"myapp", "timeout"},
 			expected: "**** FAILED TO DEPLOY MYAPP: TIMEOUT ****",
 		},
 		{

--- a/test/checkers.go
+++ b/test/checkers.go
@@ -15,7 +15,7 @@ func (*jsonEquals) Info() *check.CheckerInfo {
 
 }
 
-func (*jsonEquals) Check(params []interface{}, names []string) (result bool, error string) {
+func (*jsonEquals) Check(params []any, names []string) (result bool, error string) {
 	data0, err := json.Marshal(params[0])
 	if err != nil {
 		return false, err.Error()

--- a/types/app/version.go
+++ b/types/app/version.go
@@ -70,22 +70,22 @@ type AppVersions struct {
 }
 
 type AppVersionInfo struct {
-	Version          int                    `json:"version"`
-	Description      string                 `json:"description"`
-	BuildImage       string                 `json:"buildImage"`
-	DeployImage      string                 `json:"deployImage"`
-	CustomBuildTag   string                 `json:"customBuildTag"`
-	CustomData       map[string]interface{} `json:"customData"`
-	Processes        map[string][]string    `json:"processes"`
-	ExposedPorts     []string               `json:"exposedPorts"`
-	EventID          string                 `json:"eventID"`
-	CreatedAt        time.Time              `json:"createdAt"`
-	UpdatedAt        time.Time              `json:"updatedAt"`
-	DisabledReason   string                 `json:"disabledReason"`
-	Disabled         bool                   `json:"disabled"`
-	DeploySuccessful bool                   `json:"deploySuccessful"`
-	MarkedToRemoval  bool                   `json:"markedToRemoval"`
-	PastUnits        map[string]int         `json:"pastUnits"`
+	Version          int                 `json:"version"`
+	Description      string              `json:"description"`
+	BuildImage       string              `json:"buildImage"`
+	DeployImage      string              `json:"deployImage"`
+	CustomBuildTag   string              `json:"customBuildTag"`
+	CustomData       map[string]any      `json:"customData"`
+	Processes        map[string][]string `json:"processes"`
+	ExposedPorts     []string            `json:"exposedPorts"`
+	EventID          string              `json:"eventID"`
+	CreatedAt        time.Time           `json:"createdAt"`
+	UpdatedAt        time.Time           `json:"updatedAt"`
+	DisabledReason   string              `json:"disabledReason"`
+	Disabled         bool                `json:"disabled"`
+	DeploySuccessful bool                `json:"deploySuccessful"`
+	MarkedToRemoval  bool                `json:"markedToRemoval"`
+	PastUnits        map[string]int      `json:"pastUnits"`
 }
 
 type NewVersionArgs struct {

--- a/types/router/router.go
+++ b/types/router/router.go
@@ -17,17 +17,17 @@ type DynamicRouter struct {
 	Name           string
 	Type           string
 	ReadinessGates []string
-	Config         map[string]interface{}
+	Config         map[string]any
 }
 
 type PlanRouter struct {
-	Name           string                 `json:"name"`
-	Type           string                 `json:"type"`
-	Info           map[string]string      `json:"info"`
-	Config         map[string]interface{} `json:"config"`
-	ReadinessGates []string               `json:"readinessGates"`
-	Dynamic        bool                   `json:"dynamic"`
-	Default        bool                   `json:"default"`
+	Name           string            `json:"name"`
+	Type           string            `json:"type"`
+	Info           map[string]string `json:"info"`
+	Config         map[string]any    `json:"config"`
+	ReadinessGates []string          `json:"readinessGates"`
+	Dynamic        bool              `json:"dynamic"`
+	Default        bool              `json:"default"`
 }
 
 func (r *DynamicRouter) ToPlanRouter() PlanRouter {

--- a/types/volume/volume.go
+++ b/types/volume/volume.go
@@ -22,7 +22,7 @@ var (
 
 type VolumePlan struct {
 	Name string
-	Opts map[string]interface{}
+	Opts map[string]any
 }
 
 type VolumeBindID struct {
@@ -46,7 +46,7 @@ type Volume struct {
 	Opts      map[string]string `bson:",omitempty"`
 }
 
-func (v *Volume) UnmarshalPlan(result interface{}) error {
+func (v *Volume) UnmarshalPlan(result any) error {
 	jsonData, err := json.Marshal(v.Plan.Opts)
 	if err != nil {
 		return errors.WithStack(err)

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -278,7 +278,7 @@ func (s *volumeService) validate(ctx context.Context, v *volumeTypes.Volume) err
 		return errors.WithStack(err)
 	}
 
-	planOpts, ok := internalConfig.ConvertEntries(data).(map[string]interface{})
+	planOpts, ok := internalConfig.ConvertEntries(data).(map[string]any)
 	if !ok {
 		return errors.Errorf("invalid type for plan opts %T", planOpts)
 	}
@@ -324,11 +324,11 @@ func isProvisioned(ctx context.Context, v *volumeTypes.Volume) (bool, error) {
 	return isProv, nil
 }
 
-func asMapStringInterface(val interface{}) map[string]interface{} {
+func asMapStringInterface(val any) map[string]any {
 	if val == nil {
 		return nil
 	}
-	if mapVal, ok := val.(map[string]interface{}); ok {
+	if mapVal, ok := val.(map[string]any); ok {
 		return mapVal
 	}
 	return nil


### PR DESCRIPTION
Go 1.26 ships the [modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) analyzers as a first-class toolchain command, and `go.mod` is already on 1.26. This applies one of them — `any` — across the tree.

Generated with `go fix -any ./...`, no hand edits.

### Why this is safe to review quickly

`any` is a [type alias for `interface{}`](https://go.dev/ref/spec#Type_declarations) declared in `builtin`, so the two are indistinguishable to the type checker. The diff is a 1:1 token swap; the only other changes are `gofmt` re-aligning struct field columns that got narrower.

That claim is mechanically checkable — every one of the 102 files is byte-identical to piping the original through `sed 's/interface{}/any/g' | gofmt`:

```
$ for f in $(git diff --name-only HEAD~1); do
    git show HEAD~1:"$f" | sed 's/interface{}/any/g' | gofmt | diff -q - "$f"
  done
$   # no output
```

### Verified

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — 0 files
- `golangci-lint run ./...` — clean
- full unit suite (64 packages, excluding `./integration`) — pass

No generated code is touched: `provision/kubernetes/pkg`, `*.pb.go` and `permission/permitems.go` are all untouched, so `hack/verify-codegen.sh` is unaffected.
