### PR TITLE
modernize: adopt strings.Cut, SplitSeq, Builder and fmt.Appendf

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1254,7 +1254,7 @@ func Run(ctx context.Context, app *appTypes.App, cmd string, w io.Writer, args p
 	logWriter := LogWriter{AppName: app.Name, Source: "app-run"}
 	logWriter.Async()
 	defer logWriter.Close()
-	logWriter.Write([]byte(fmt.Sprintf("running '%s'", cmd)))
+	logWriter.Write(fmt.Appendf(nil, "running '%s'", cmd))
 	return run(ctx, app, cmd, io.MultiWriter(w, &logWriter), args)
 }
 

--- a/auth/authtest/smtp_test.go
+++ b/auth/authtest/smtp_test.go
@@ -109,8 +109,8 @@ func (m fakeMailAddress) Email() string {
 
 func (m fakeMailAddress) Hostname() string {
 	s := string(m)
-	if p := strings.Index(s, "@"); p > -1 {
-		return s[p+1:]
+	if _, after, ok := strings.Cut(s, "@"); ok {
+		return after
 	}
 	return ""
 }

--- a/auth/oidc/oidc.go
+++ b/auth/oidc/oidc.go
@@ -64,8 +64,8 @@ type oidcScheme struct {
 
 func personalTeamName(email string) string {
 	name := email
-	if idx := strings.Index(email, "@"); idx >= 0 {
-		name = email[:idx]
+	if before, _, ok := strings.Cut(email, "@"); ok {
+		name = before
 	}
 	return auth.NormalizeTeamName(name)
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -475,25 +475,25 @@ func maxLabelSize(labels []string) int {
 
 func (m *Manager) dumpCommands(commands []string) string {
 	sort.Strings(commands)
-	var output string
+	var output strings.Builder
 	maxCmdSize := maxLabelSize(commands)
 	for _, command := range commands {
-		output += formatDescriptionLine(command, m.Commands[command].Info().Desc, maxCmdSize)
+		output.WriteString(formatDescriptionLine(command, m.Commands[command].Info().Desc, maxCmdSize))
 	}
-	output += fmt.Sprintf("\nUse %s help <commandname> to get more information about a command.\n", m.name)
-	return output
+	output.WriteString(fmt.Sprintf("\nUse %s help <commandname> to get more information about a command.\n", m.name))
+	return output.String()
 }
 
 func (m *Manager) dumpTopics() string {
 	topics := m.discoverTopics()
 	sort.Strings(topics)
 	maxTopicSize := maxLabelSize(topics)
-	var output string
+	var output strings.Builder
 	for _, topic := range topics {
-		output += formatDescriptionLine(topic, m.topics[topic], maxTopicSize)
+		output.WriteString(formatDescriptionLine(topic, m.topics[topic], maxTopicSize))
 	}
-	output += fmt.Sprintf("\nUse %s help <topicname> to get more information about a topic.\n", m.name)
-	return output
+	output.WriteString(fmt.Sprintf("\nUse %s help <topicname> to get more information about a topic.\n", m.name))
+	return output.String()
 }
 
 func (m *Manager) normalizeCommandArgs(args []string) []string {
@@ -522,9 +522,9 @@ func (m *Manager) discoverTopics() []string {
 		if _, isDeprecated := cmd.(*DeprecatedCommand); isDeprecated {
 			continue
 		}
-		idx := strings.Index(cmdName, "-")
-		if idx != -1 {
-			freq[cmdName[:idx]] += 1
+		before, _, ok := strings.Cut(cmdName, "-")
+		if ok {
+			freq[before] += 1
 		}
 	}
 	for topic := range m.topics {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -88,11 +88,12 @@ func (m *MultiError) Error() string {
 	if m.Len() == 1 {
 		return fmt.Sprintf("%+v", m.errors[0])
 	}
-	msg := fmt.Sprintf("multiple errors reported (%d):\n", len(m.errors))
+	var msg strings.Builder
+	msg.WriteString(fmt.Sprintf("multiple errors reported (%d):\n", len(m.errors)))
 	for i, err := range m.errors {
-		msg += fmt.Sprintf("error #%d: %+v\n", i, err)
+		msg.WriteString(fmt.Sprintf("error #%d: %+v\n", i, err))
 	}
-	return msg
+	return msg.String()
 }
 
 func (m *MultiError) Format(s fmt.State, verb rune) {

--- a/integration/cmd.go
+++ b/integration/cmd.go
@@ -120,15 +120,17 @@ func (e *Environment) Clone() *Environment {
 func (e *Environment) String() string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	ret := fmt.Sprintln("Env vars:")
+	var ret strings.Builder
+	ret.WriteString(fmt.Sprintln("Env vars:"))
 	for k, v := range e.data {
-		ret += fmt.Sprintf("  %s: %#v\n", k, v)
+		ret.WriteString(fmt.Sprintf("  %s: %#v\n", k, v))
 	}
-	ret += fmt.Sprintln("Local vars:")
+	ret.WriteString(fmt.Sprintln("Local vars:"))
 	for k, v := range e.local {
-		ret += fmt.Sprintf("  %s: %#v\n", k, v)
+		ret.WriteString(fmt.Sprintf("  %s: %#v\n", k, v))
 	}
-	return ret[:len(ret)-1]
+	s := ret.String()
+	return s[:len(s)-1]
 }
 
 func (e *Environment) flatData() map[string]string {

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -376,8 +376,8 @@ func appVersions() ExecFlow {
 				// Check that all pods are running and not being deleted
 				res := K("get", "pods", "-l", fmt.Sprintf("tsuru.io/app-name=%s", appName), "-o", `"jsonpath={range .items[*]}{.status.phase},{.metadata.deletionTimestamp}{'\\n'}{end}"`).Run(env)
 				c.Assert(res, ResultOk)
-				podStatuses := strings.Split(strings.TrimSpace(res.Stdout.String()), "\n")
-				for _, status := range podStatuses {
+				podStatuses := strings.SplitSeq(strings.TrimSpace(res.Stdout.String()), "\n")
+				for status := range podStatuses {
 					if status == "" {
 						continue
 					}

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -66,8 +66,8 @@ type resultTable struct {
 }
 
 func (r *resultTable) parse() {
-	lines := strings.Split(r.raw, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(r.raw, "\n")
+	for line := range lines {
 		if len(line) == 0 || line[0] != '|' {
 			continue
 		}

--- a/io/stream_writer_test.go
+++ b/io/stream_writer_test.go
@@ -248,20 +248,20 @@ func (s *S) TestSimpleJsonMessageFormatterWithTS(c *check.C) {
 	buf := bytes.Buffer{}
 	ts := time.Unix(0, 0).Format(time.RFC3339)
 	streamWriter := NewStreamWriter(&buf, nil)
-	streamWriter.Write([]byte(fmt.Sprintf(`{"message": "my\nmsg\n", "timestamp": "%s"}`, ts)))
-	streamWriter.Write([]byte(fmt.Sprintf(`{"message": "other", "timestamp": "%s"}`, ts)))
-	streamWriter.Write([]byte(fmt.Sprintf(`{"message": " msg\n", "timestamp": "%s"}`, ts)))
-	streamWriter.Write([]byte(fmt.Sprintf(`{"message": "more", "timestamp": "%s"}`, ts)))
-	streamWriter.Write([]byte(fmt.Sprintf(`{"message": "\nmsgs", "timestamp": "%s"}`, ts)))
+	streamWriter.Write(fmt.Appendf(nil, `{"message": "my\nmsg\n", "timestamp": "%s"}`, ts))
+	streamWriter.Write(fmt.Appendf(nil, `{"message": "other", "timestamp": "%s"}`, ts))
+	streamWriter.Write(fmt.Appendf(nil, `{"message": " msg\n", "timestamp": "%s"}`, ts))
+	streamWriter.Write(fmt.Appendf(nil, `{"message": "more", "timestamp": "%s"}`, ts))
+	streamWriter.Write(fmt.Appendf(nil, `{"message": "\nmsgs", "timestamp": "%s"}`, ts))
 	c.Assert(buf.String(), check.Matches, ".+: my\n.+: msg\n.+: other msg\n.+: more\n.+: msgs")
 
 	buf = bytes.Buffer{}
 	streamWriterNoTs := NewStreamWriter(&buf, &SimpleJsonMessageFormatter{NoTimestamp: true})
-	streamWriterNoTs.Write([]byte(fmt.Sprintf(`{"message": "my\nmsg\n", "timestamp": "%s"}`, ts)))
-	streamWriterNoTs.Write([]byte(fmt.Sprintf(`{"message": "other", "timestamp": "%s"}`, ts)))
-	streamWriterNoTs.Write([]byte(fmt.Sprintf(`{"message": " msg\n", "timestamp": "%s"}`, ts)))
-	streamWriterNoTs.Write([]byte(fmt.Sprintf(`{"message": "more", "timestamp": "%s"}`, ts)))
-	streamWriterNoTs.Write([]byte(fmt.Sprintf(`{"message": "\nmsgs", "timestamp": "%s"}`, ts)))
+	streamWriterNoTs.Write(fmt.Appendf(nil, `{"message": "my\nmsg\n", "timestamp": "%s"}`, ts))
+	streamWriterNoTs.Write(fmt.Appendf(nil, `{"message": "other", "timestamp": "%s"}`, ts))
+	streamWriterNoTs.Write(fmt.Appendf(nil, `{"message": " msg\n", "timestamp": "%s"}`, ts))
+	streamWriterNoTs.Write(fmt.Appendf(nil, `{"message": "more", "timestamp": "%s"}`, ts))
+	streamWriterNoTs.Write(fmt.Appendf(nil, `{"message": "\nmsgs", "timestamp": "%s"}`, ts))
 	c.Assert(buf.String(), check.Matches, "my\nmsg\nother msg\nmore\nmsgs")
 }
 
@@ -305,7 +305,7 @@ func (s *S) TestSimpleJsonMessageFormatterJsonInJson(c *check.C) {
 	buf := bytes.Buffer{}
 	encoder := json.NewEncoder(&buf)
 	writer := SimpleJsonMessageEncoderWriter{Encoder: encoder}
-	for _, l := range bytes.Split([]byte(mockPullOutput), []byte("\n")) {
+	for l := range bytes.SplitSeq([]byte(mockPullOutput), []byte("\n")) {
 		writer.Write(l)
 	}
 	parts := bytes.Split(buf.Bytes(), []byte("\n"))
@@ -353,7 +353,7 @@ func (s *S) TestSimpleJsonMessageFormatterJsonInJsonInTerminal(c *check.C) {
 	writer := SimpleJsonMessageEncoderWriter{Encoder: encoder, now: func() time.Time {
 		return time.Time{}
 	}}
-	for _, l := range bytes.Split([]byte(mockPullOutput), []byte("\n")) {
+	for l := range bytes.SplitSeq([]byte(mockPullOutput), []byte("\n")) {
 		writer.Write(l)
 	}
 	parts := bytes.Split(buf.Bytes(), []byte("\n"))

--- a/provision/kubernetes/cluster.go
+++ b/provision/kubernetes/cluster.go
@@ -461,8 +461,8 @@ func (c *ClusterClient) namespaceLabels(ns string) (map[string]string, error) {
 	if nsLabelsConf == "" {
 		return labels, nil
 	}
-	labelsRaw := strings.Split(nsLabelsConf, ",")
-	for _, l := range labelsRaw {
+	labelsRaw := strings.SplitSeq(nsLabelsConf, ",")
+	for l := range labelsRaw {
 		parts := strings.Split(l, "=")
 		if len(parts) != 2 {
 			continue

--- a/provision/kubernetes/provisioner.go
+++ b/provision/kubernetes/provisioner.go
@@ -1308,11 +1308,11 @@ func (p *kubernetesProvisioner) StartupMessage() (string, error) {
 		}
 		return "", err
 	}
-	var out string
+	var out strings.Builder
 	for _, c := range clusters {
-		out += fmt.Sprintf("Kubernetes provisioner on cluster %q - %s\n", c.Name, c.restConfig.Host)
+		out.WriteString(fmt.Sprintf("Kubernetes provisioner on cluster %q - %s\n", c.Name, c.restConfig.Host))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (p *kubernetesProvisioner) DeleteVolume(ctx context.Context, volumeName, pool string) error {

--- a/provision/kubernetes/volume.go
+++ b/provision/kubernetes/volume.go
@@ -111,7 +111,7 @@ func nonPersistentVolume(v *volumeTypes.Volume, opts *volumeOptions) (apiv1.Volu
 			Team:   v.TeamOwner,
 		})
 		var accessModes []apiv1.PersistentVolumeAccessMode
-		for _, am := range strings.Split(opts.AccessModes, ",") {
+		for am := range strings.SplitSeq(opts.AccessModes, ",") {
 			accessModes = append(accessModes, apiv1.PersistentVolumeAccessMode(am))
 		}
 		volumeSrc = apiv1.VolumeSource{
@@ -235,7 +235,7 @@ func createVolume(ctx context.Context, client *ClusterClient, v *volumeTypes.Vol
 		apiv1.ResourceStorage: opts.Capacity,
 	}
 	var accessModes []apiv1.PersistentVolumeAccessMode
-	for _, am := range strings.Split(opts.AccessModes, ",") {
+	for am := range strings.SplitSeq(opts.AccessModes, ",") {
 		accessModes = append(accessModes, apiv1.PersistentVolumeAccessMode(am))
 	}
 	var volName string

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -353,7 +353,7 @@ func parseScopes(s []string) scopes {
 			return nil
 		}
 		// The scopeStr may have strings that contain multiple scopes separated by a space.
-		for _, scope := range strings.Split(scopeStr, " ") {
+		for scope := range strings.SplitSeq(scopeStr, " ") {
 			parts := strings.SplitN(scope, ":", 3)
 			names := []string{parts[0]}
 			if len(parts) > 1 {

--- a/types/permission/permission.go
+++ b/types/permission/permission.go
@@ -88,26 +88,26 @@ func (s *PermissionScheme) IsParent(other *PermissionScheme) bool {
 
 func (s *PermissionScheme) Identifier() string {
 	parts := s.nameParts()
-	var str string
+	var str strings.Builder
 	for i := len(parts) - 1; i >= 0; i-- {
-		str += strings.Replace(cases.Title(language.English).String(parts[i]), "-", "", -1)
+		str.WriteString(strings.Replace(cases.Title(language.English).String(parts[i]), "-", "", -1))
 	}
-	if str == "" {
+	if str.Len() == 0 {
 		return "All"
 	}
-	return str
+	return str.String()
 }
 
 func (s *PermissionScheme) FullName() string {
 	parts := s.nameParts()
-	var str string
+	var str strings.Builder
 	for i := len(parts) - 1; i >= 0; i-- {
-		str += parts[i]
+		str.WriteString(parts[i])
 		if i != 0 {
-			str += "."
+			str.WriteString(".")
 		}
 	}
-	return str
+	return str.String()
 }
 
 func (s *PermissionScheme) AllowedContexts() []ContextType {


### PR DESCRIPTION
Third slice of the Go 1.26 modernizer sweep, after #2904 and #2905. This one covers the `strings` fixers: `stringscut`, `stringsseq`, `stringsbuilder` and `fmtappendf`.

Generated with `go fix -<fixer> ./...`, one fixer at a time, plus two hand cleanups noted below.

### What changed

| Rewrite | Count | Example |
|---|---:|---|
| `strings.Cut` | 4 | `strings.Index` + manual slicing |
| `strings.SplitSeq` / `bytes.SplitSeq` | 8 | `range strings.Split(…)` — avoids allocating the slice |
| `fmt.Appendf(nil, …)` | 7 | `[]byte(fmt.Sprintf(…))` |
| `strings.Builder` | 6 | `+=` accumulation in a loop |

Note three of the touched files are under `integration/`, which `make test` skips; `go vet ./integration/...` is clean.

### Two hand cleanups on top of the generated output

`stringsbuilder` replaces the accumulator variable with `.String()` at every use site, which is correct but produces two calls on one line where the original read the variable twice:

```go
// integration/cmd.go, as generated
return ret.String()[:len(ret.String())-1]

// types/permission/permission.go, as generated
if str.String() == "" {
```

Both work — `Builder.String()` is cheap — but neither is what you'd write by hand, so this branch hoists the local in the first case and uses `str.Len() == 0` in the second:

```go
s := ret.String()
return s[:len(s)-1]
```

Flagging it because it means this slice is *not* purely mechanical, unlike #2904.

### Verified

- `go build ./...`, `go vet ./...`, `go vet ./integration/...`, `gofmt -l .` — clean
- `golangci-lint run ./...` (v2.11.4) — 0 issues
- full unit suite, 64 packages — pass
- `tsurud api --dry` — pass

No generated code is touched.
