### PR TITLE
fix(storagev2): stop sharing index options across concurrent callers

### DIFF
--- a/db/storagev2/indexes.go
+++ b/db/storagev2/indexes.go
@@ -244,11 +244,30 @@ func EnsureIndexesCreated(db *mongo.Database) error {
 
 		collection := db.Collection(collectionName)
 
-		_, err := collection.Indexes().CreateMany(context.TODO(), index.Indexes)
+		_, err := collection.Indexes().CreateMany(context.TODO(), copyIndexModels(index.Indexes))
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// copyIndexModels returns a copy of models whose IndexOptions are safe for the
+// driver to mutate.
+//
+// CreateMany fills in a generated index name on any IndexModel that does not
+// carry one, writing it back into the IndexOptions it was given. Those options
+// come from the package-level EnsureIndexes, so two goroutines calling
+// EnsureIndexesCreated concurrently race on that shared state.
+func copyIndexModels(models []mongo.IndexModel) []mongo.IndexModel {
+	out := make([]mongo.IndexModel, len(models))
+	for i, model := range models {
+		if model.Options != nil {
+			opts := *model.Options
+			model.Options = &opts
+		}
+		out[i] = model
+	}
+	return out
 }

--- a/db/storagev2/indexes_test.go
+++ b/db/storagev2/indexes_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package storagev2
+
+import (
+	"sync"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestCopyIndexModelsClonesOptions(t *testing.T) {
+	original := []mongo.IndexModel{
+		{Options: options.Index().SetUnique(true)},
+		{Options: nil},
+	}
+
+	got := copyIndexModels(original)
+
+	if len(got) != len(original) {
+		t.Fatalf("got %d models, want %d", len(got), len(original))
+	}
+	if got[0].Options == original[0].Options {
+		t.Error("options pointer was shared with the original, driver writes would escape")
+	}
+	if got[0].Options.Unique == nil || !*got[0].Options.Unique {
+		t.Error("copy lost the Unique option")
+	}
+	if got[1].Options != nil {
+		t.Error("nil options should stay nil")
+	}
+}
+
+// TestCopyIndexModelsIsolatesWriters covers the race that CreateMany triggers:
+// it names any index that lacks a name, writing back into the IndexOptions it
+// was handed. Run under -race this fails if the copy shares state.
+func TestCopyIndexModelsIsolatesWriters(t *testing.T) {
+	shared := []mongo.IndexModel{{Options: options.Index()}}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			models := copyIndexModels(shared)
+			models[0].Options.SetName("generated")
+			_ = models[0].Options.Name
+		}()
+	}
+	wg.Wait()
+
+	if shared[0].Options.Name != nil {
+		t.Errorf("writes leaked into the shared options: name = %q", *shared[0].Options.Name)
+	}
+}


### PR DESCRIPTION
`make race` intermittently fails in CI with a data race inside the mongo-driver, reached through `EnsureIndexesCreated`. It just took down the `test` job on #2905, which changes nothing in `db/storagev2`.

```
Read at 0x00c00019f2d0 by goroutine 136996:
  mongo.getOrGenerateIndexName()        index_view.go:465
  mongo.IndexView.CreateMany()          index_view.go:199
  db/storagev2.EnsureIndexesCreated()   indexes.go:247

Previous write at 0x00c00019f2d0 by goroutine 149:
  options.(*IndexOptions).SetName()     indexoptions.go:314
  mongo.IndexView.CreateMany()          index_view.go:213
  db/storagev2.EnsureIndexesCreated()   indexes.go:247
```

### Cause

`EnsureIndexes` is a package-level var whose entries carry `*options.IndexOptions` pointers:

```go
var EnsureIndexes = []EnsureIndex{
	{
		Collection: "apps",
		Indexes: []mongo.IndexModel{
			{Keys: ..., Options: options.Index().SetUnique(true)},
		},
	},
	...
}
```

`CreateMany` generates a name for any index that lacks one and writes it back into the `IndexOptions` it was handed — mutating that shared package-level state. Two goroutines calling `EnsureIndexesCreated` concurrently, which happens when test suites connect in parallel, then race on it.

The race is fairly benign in practice: it scribbles a field the driver was about to overwrite anyway. But it is a real race, and it fails `make race`.

### Fix

Hand the driver a copy it is free to mutate. The copy is shallow — `Options` is the only field written.

`EnsureIndexes` keeps its current shape; nothing outside this file reads it, but changing the exported var seemed like unnecessary churn for the fix.

### Test

This package had no test file; this adds one. `TestCopyIndexModelsIsolatesWriters` reproduces the mutation pattern `CreateMany` performs, across 8 goroutines. It needs no MongoDB connection and is deterministic.

I checked that it actually catches the bug rather than just passing — with the copy removed it reports both the race and the leak:

```
--- FAIL: TestCopyIndexModelsIsolatesWriters
    indexes_test.go:56: writes leaked into the shared options: name = "generated"
    testing.go:1712: race detected during execution of test
```

### Verified

- `make race` — pass
- `golangci-lint run ./db/...` — 0 issues
