### PR TITLE
fix(lint): move new-from-merge-base into .golangci.yml so make lint matches CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,16 +83,12 @@ jobs:
         go-version: "1.26.6"
     - uses: actions/checkout@v4
       with:
-        # modernize is gated with --new-from-merge-base below, which needs the
-        # merge base to be present in the local clone.
-        fetch-depth: 0
+        fetch-depth: 0 # new-from-merge-base in .golangci.yml needs the history
     - run: make yamllint
     - uses: golangci/golangci-lint-action@v8
       with:
         version: v2.11.4
-        # Existing code is grandfathered: only lines touched by the PR are
-        # reported. Drop --new-from-merge-base once the tree is clean.
-        args: --timeout=10m --new-from-merge-base=origin/main
+        args: --timeout=10m
       env:
         GOROOT: ""
   govulncheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,9 @@ version: "2"
 run:
   tests: true
 
+issues:
+  new-from-merge-base: origin/main
+
 linters:
   enable:
   - misspell


### PR DESCRIPTION
#2905 enabled `modernize` in `.golangci.yml` but only CI passes `--new-from-merge-base`, so `make lint` fails on a clean checkout of `main`:

```
$ git clone https://github.com/tsuru/tsuru && cd tsuru && make lint
40 issues:
* modernize: 40
make: *** [Makefile:43: metalint] Error 1
```

Move the flag into `.golangci.yml` so the Makefile and CI run the same thing. Verified on a fresh clone: `make lint` exits 0 on `main`, and a new old-style loop is still reported.
