### PR TITLE
Fix/cluster storage breaking kubeconfig (#2911)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
       uses: medyagh/setup-minikube@master
       with:
         kubernetes-version: "v${{ matrix.k8s_version }}"
+        container-runtime: docker
+        insecure-registry: "10.96.0.0/12"
+        minikube-version: 1.38.1
     - uses: azure/setup-helm@v1
       with:
         version: v3.14.3

--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,11 @@ run-tsurud-token: $(TSR_BIN)
 validate-api-spec: install-swagger
 	$(SWAGGER) validate ./docs/reference/api.yaml
 
-test-ci-integration:
+test-ci-integration: clone_platforms
 	if [ -z "$$INTEGRATION_KUBECONFIG" ]; then \
 		echo "INTEGRATION_KUBECONFIG is not set"; \
 		exit 1; \
 	fi
-	git clone https://github.com/tsuru/platforms /tmp/platforms
 	TSURU_INTEGRATION_examplesdir="/tmp/platforms/examples" \
 	TSURU_INTEGRATION_enabled=1 TSURU_INTEGRATION_verbose=2 TSURU_INTEGRATION_maxconcurrency=4 \
 	TSURU_INTEGRATION_platforms="python,go" \
@@ -138,7 +137,6 @@ local.test-ci-integration: clone_platforms
 		echo "INTEGRATION_KUBECONFIG is not set"; \
 		exit 1; \
 	fi
-	#git clone https://github.com/tsuru/platforms /tmp/platforms
 	TSURU_INTEGRATION_examplesdir="/tmp/platforms/examples" \
 	TSURU_INTEGRATION_enabled=1 TSURU_INTEGRATION_verbose=2 TSURU_INTEGRATION_maxconcurrency=1 \
 	TSURU_INTEGRATION_platforms="python,go" \
@@ -168,6 +166,10 @@ generate-test-certs:
 # Docker binary. If you are using podman, you can change this to podman when
 # running make commands. Example: make local DOCKER=podman
 DOCKER ?= docker
+
+# Docker Compose command. Prefer the standalone binary when it is installed,
+# otherwise use the Compose plugin provided by the Docker binary.
+DOCKER_COMPOSE ?= $(shell command -v docker-compose >/dev/null 2>&1 && echo docker-compose || echo "$(DOCKER) compose")
 
 # Kubernetes version used with minikube
 K8S_VERSION = v1.32.0
@@ -230,7 +232,7 @@ endif
 local.setup: local.cluster
 	@echo "Setting up local tsuru development environment..."
 	@$(LOCAL_DEV) render-templates $(TSURU_HOST_IP) $(TSURU_HOST_PORT)
-	@$(DOCKER) compose --profile tsurud-api up -d
+	@$(DOCKER_COMPOSE) --profile tsurud-api up -d
 	@$(LOCAL_DEV) setup-tsuru-user $(TSURU_ROOT_USER) $(TSURU_ROOT_PASS)
 	@$(LOCAL_DEV) setup-tsuru-target $(TSURU_HOST_IP) $(TSURU_HOST_PORT)
 	@$(LOCAL_DEV) setup-tsuru-cluster $(TSURU_HOST_IP)
@@ -250,7 +252,7 @@ local.prerun:
 # Start the local development environment for tsuru.
 local.run: local.prerun local.cluster
 	@echo "Starting local tsuru development environment..."
-	$(DOCKER) compose up -d
+	$(DOCKER_COMPOSE) up -d
 	go build -o $(TSR_BIN) $(TSR_SRC)
 	$(TSR_BIN) api -c "./etc/tsurud.conf"
 
@@ -258,7 +260,7 @@ local.run: local.prerun local.cluster
 # Stop the local development environment for tsuru.
 local.stop:
 	@echo "Stopping local tsuru development environment..."
-	@$(DOCKER) compose --profile tsurud-api down
+	@$(DOCKER_COMPOSE) --profile tsurud-api down
 	@minikube stop
 	@$(LOCAL_DEV) cleanup-loopback $(TSURU_HOST_IP)
 
@@ -266,7 +268,7 @@ local.stop:
 # Clear the local development environment for tsuru.
 local.cleanup: local.stop
 	@echo "Clearing local tsuru development environment..."
-	@$(DOCKER) compose down --volumes --rmi all
+	@$(DOCKER_COMPOSE) down --volumes --rmi all
 	@minikube delete
 	@find ./etc ! -name '*.template' ! -name 'tsuru.conf' -mindepth 1 | \
 		xargs -I{} echo rm {}
@@ -293,4 +295,4 @@ generate-grpc:
 		types/tag/service.proto
 
 connect-db:
-	@$(DOCKER) compose exec mongo bash -c 'mongosh "mongodb://mongo:27017'
+	@$(DOCKER_COMPOSE) exec mongo bash -c 'mongosh "mongodb://mongo:27017'

--- a/db/storagev2/collections.go
+++ b/db/storagev2/collections.go
@@ -6,6 +6,7 @@ package storagev2
 
 import (
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func AppsCollection() (*mongo.Collection, error) {
@@ -93,7 +94,14 @@ func DynamicRoutersCollection() (*mongo.Collection, error) {
 }
 
 func ProvisionerClustersCollection() (*mongo.Collection, error) {
-	return Collection("provisioner_clusters")
+	db, err := database()
+	if err != nil {
+		return nil, err
+	}
+
+	return db.Collection("provisioner_clusters", options.Collection().SetBSONOptions(&options.BSONOptions{
+		NilSliceAsEmpty: false,
+	})), nil
 }
 
 func AuthGroupsCollection() (*mongo.Collection, error) {

--- a/scripts/localkube-integration.sh
+++ b/scripts/localkube-integration.sh
@@ -26,6 +26,19 @@ function onerror() {
   ${KUBECTL} logs -n ${NAMESPACE} deploy/tsuru-api || true
   echo
   ${KUBECTL} get pods -A -o wide
+  while read -r pod_namespace pod_name pod_phase pod_ready; do
+    if [[ "${pod_phase}" == "Succeeded" ]] ||
+      [[ "${pod_phase}" == "Running" && "${pod_ready}" == "True" ]]; then
+      continue
+    fi
+
+    echo
+    echo "POD DESCRIPTION: ${pod_namespace}/${pod_name}"
+    ${KUBECTL} describe pod -n "${pod_namespace}" "${pod_name}" || true
+  done < <(
+    ${KUBECTL} get pods -A --no-headers \
+      -o 'custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,READY:.status.conditions[?(@.type=="Ready")].status'
+  )
   echo
   ${KUBECTL} get services -A -o wide
   [[ -n ${tsuru_api_port_forward_pid} ]] && kill ${tsuru_api_port_forward_pid}

--- a/storage/mongodb/cluster_test.go
+++ b/storage/mongodb/cluster_test.go
@@ -5,11 +5,58 @@
 package mongodb
 
 import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tsuru/config"
+	"github.com/tsuru/tsuru/db/storagev2"
 	"github.com/tsuru/tsuru/storage/storagetest"
+	"github.com/tsuru/tsuru/types/provision"
 	check "gopkg.in/check.v1"
+	authexec "k8s.io/client-go/plugin/pkg/client/auth/exec"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 var _ = check.Suite(&storagetest.ClusterSuite{
 	ClusterStorage: &clusterStorage{},
 	SuiteHooks:     &mongodbBaseTest{},
 })
+
+func TestUpsertClusterWithExecConfigPreservesValidPluginPolicy(t *testing.T) {
+	config.Set("database:url", "127.0.0.1:27017?maxPoolSize=150")
+	config.Set("database:name", "tsuru_storage_mongodb_test_cluster_internal")
+	storagev2.Reset()
+	require.NoError(t, storagev2.ClearAllCollections(nil))
+	t.Cleanup(func() {
+		err := storagev2.ClearAllCollections(nil)
+		storagev2.Reset()
+		require.NoError(t, err)
+	})
+
+	storage := &clusterStorage{}
+	cluster := provision.Cluster{
+		Name: "clustername",
+		KubeConfig: &provision.KubeConfig{
+			AuthInfo: clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:         "gke-gcloud-auth-plugin",
+					APIVersion:      "client.authentication.k8s.io/v1beta1",
+					InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+				},
+			},
+		},
+	}
+
+	err := storage.Upsert(context.Background(), cluster)
+	require.NoError(t, err)
+
+	storedCluster, err := storage.FindByName(context.Background(), cluster.Name)
+	require.NoError(t, err)
+	require.NotNil(t, storedCluster.KubeConfig)
+	require.NotNil(t, storedCluster.KubeConfig.AuthInfo.Exec)
+
+	err = authexec.ValidatePluginPolicy(storedCluster.KubeConfig.AuthInfo.Exec.PluginPolicy)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR merges the commit that fixes the cluster config persistence and integration testing

* chore: check which docker compose tool is available on user setup

* test: cluster config write operations should preserve valid kube-config

* fix: provisioner cluster collection should not convert nil slices/maps to empty on storage writes

* test: extend retry time for job completion check on integration

* test: describe broken pods after failed integration testing

* fix: nil map should be read as empty for provisioner cluster

* chore: setup minikube and debug registry-insecure reads

* chore: pin minikube version

* test: use testify require on regression test